### PR TITLE
Update desktop menu entry file to conform to XDG specs

### DIFF
--- a/supertux2.desktop
+++ b/supertux2.desktop
@@ -1,7 +1,6 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Encoding=UTF-8
 Name=SuperTux 2
 Name[en]=SuperTux 2
 GenericName=Platform Game
@@ -41,3 +40,4 @@ Exec=supertux2
 Terminal=false
 StartupNotify=false
 Categories=Game;ArcadeGame;
+Keywords=game;arcade;platform;


### PR DESCRIPTION
Remove deprecated Encoding key, and add Keywords entry (with arbitrary keywords, feel free to modify) to comply with [latest XDG specs](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html). Thanks for considering!