### PR TITLE
Fix build failure on big-endian archs

### DIFF
--- a/src/audio/wav_sound_file.cpp
+++ b/src/audio/wav_sound_file.cpp
@@ -159,7 +159,7 @@ WavSoundFile::read(void* buffer, size_t buffer_size)
     tmp[2*i+1] = c;
   }
 
-  *buffer = tmp;
+  *(char *)buffer = *tmp;
 #endif
 
   return readsize;


### PR DESCRIPTION
Cast (void *)buffer pointer to (char *) and dereference (char *)tmp
pointer.

This should fix https://github.com/SuperTux/supertux/issues/80