### PR TITLE
CMakeLists: exclude test levels from Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,13 +498,22 @@ INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/supertux2.appdata.xml DESTINATION "sha
 
 INSTALL(DIRECTORY data/images
                   data/fonts
-                  data/levels
                   data/music
                   data/scripts
                   data/speech
                   data/sounds
                   data/locale
                   DESTINATION ${INSTALL_SUBDIR_SHARE})
+
+IF(CMAKE_BUILD_TYPE MATCHES Release)
+  INSTALL(DIRECTORY data/levels
+                    DESTINATION ${INSTALL_SUBDIR_SHARE}
+                    PATTERN "data/levels/test" EXCLUDE
+                    PATTERN "data/levels/test_old" EXCLUDE)
+ELSE()
+  INSTALL(DIRECTORY data/levels
+                    DESTINATION ${INSTALL_SUBDIR_SHARE})
+ENDIF()
 
 ## Create config.h now that INSTALL_SUBDIR_* have been set.
 


### PR DESCRIPTION
As being mentioned in #108, exclude `test` and `test_old` level directories when built with `CMAKE_BUILD_TYPE=Release`.