### PR TITLE
Bombs can now be thrown

### DIFF
--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -63,6 +63,7 @@ GoldBomb::collision_solid(const CollisionHit& hit)
       physic.set_velocity_x(-physic.get_velocity_x());
     else if (hit.top)
       physic.set_velocity_y(0);
+    update_on_ground_flag(hit);
     return;
   }
   WalkingBadguy::collision_solid(hit);
@@ -128,6 +129,7 @@ void
 GoldBomb::active_update(float elapsed_time)
 {
   if(tstate == STATE_TICKING) {
+    if (on_ground()) physic.set_velocity_x(0);
     ticking->set_position(get_pos());
     if(sprite->animation_done()) {
       kill_fall();


### PR DESCRIPTION
I just copied the gold bomb code over, as gold bombs could already be thrown. Currently the goldbomb and mrbomb are not connected in any way, therefore the code I could have reused was instead copied. It just feels wrong that the gold bomb doesn't inherit the code of the bomb... any thoughts? See supertux/supertux#143