### PR TITLE
Submodule build improvements; add support for out-of-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,11 +211,27 @@ INCLUDE(ConfigureChecks)
 
 ## Also execute instructions in external/squirrel/CMakeLists.txt
 
+IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/squirrel/CMakeLists.txt)
+  message(FATAL_ERROR "squirrel submodule is not checked out or ${CMAKE_CURRENT_SOURCE_DIR}/external/squirrel/CMakeLists.txt is missing")
+ENDIF()
+
 ADD_SUBDIRECTORY(${CMAKE_CURRENT_SOURCE_DIR}/external/squirrel)
 
 ## Add squirrel lib dir to search path
 
 LINK_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/external/squirrel)
+
+## Also execute instructions in external/squirrel/CMakeLists.txt
+
+IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/tinygettext/CMakeLists.txt)
+  message(FATAL_ERROR "tinygettext submodule is not checked out or ${CMAKE_CURRENT_SOURCE_DIR}/external/tinygettext/CMakeLists.txt is missing")
+ENDIF()
+
+ADD_SUBDIRECTORY(${CMAKE_CURRENT_SOURCE_DIR}/external/tinygettext)
+
+## Add tinygettext lib dir to search path
+
+LINK_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/external/tinygettext)
 
 ## Some additional include paths
 
@@ -408,7 +424,7 @@ SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 ## Add target for supertux binary
 
 ADD_LIBRARY(supertux2_c OBJECT ${SUPERTUX_SOURCES_C})
-ADD_EXECUTABLE(supertux2 ${CMAKE_BINARY_DIR}/version.h ${SUPERTUX_SOURCES_CXX} ${TINYGETTEXT_SOURCES_CXX} ${SUPERTUX_RESOURCES} $<TARGET_OBJECTS:supertux2_c>)
+ADD_EXECUTABLE(supertux2 ${CMAKE_BINARY_DIR}/version.h ${SUPERTUX_SOURCES_CXX} ${SUPERTUX_RESOURCES} $<TARGET_OBJECTS:supertux2_c>)
 SET_TARGET_PROPERTIES(supertux2 PROPERTIES COMPILE_FLAGS "${SUPERTUX2_EXTRA_WARNING_FLAGS}")
 
 IF(WIN32)
@@ -431,6 +447,7 @@ TARGET_LINK_LIBRARIES(supertux2 ${SDL2_LIBRARIES})
 TARGET_LINK_LIBRARIES(supertux2 ${SDL2IMAGE_LIBRARIES})
 
 TARGET_LINK_LIBRARIES(supertux2 squirrel)
+TARGET_LINK_LIBRARIES(supertux2 tinygettext)
 TARGET_LINK_LIBRARIES(supertux2 ${OPENAL_LIBRARY})
 TARGET_LINK_LIBRARIES(supertux2 ${OGGVORBIS_LIBRARIES})
 TARGET_LINK_LIBRARIES(supertux2 ${PHYSFS_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ IF(COMMAND cmake_policy)
 ENDIF(COMMAND cmake_policy)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/mk/cmake)
+INCLUDE(ConfigureFiles)
 
 ## For autopackage
 SET(APPDATADIR "${CMAKE_INSTALL_PREFIX}/share/games/supertux2")
@@ -176,12 +177,13 @@ IF(GIT_EXECUTABLE AND EXISTS ${GIT_CFG_DIR})
                     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef VERSION_H" > "${CMAKE_BINARY_DIR}/version.h.tmp"
                     COMMAND ${CMAKE_COMMAND} -E echo "#define VERSION_H" >> "${CMAKE_BINARY_DIR}/version.h.tmp"
                     COMMAND ${CMAKE_COMMAND} >> "${CMAKE_BINARY_DIR}/version.h.tmp" -E echo_append "#define PACKAGE_VERSION \"${SUPERTUX_VERSION} commit "
+                    
                     COMMAND ${GIT_EXECUTABLE} rev-parse --sq HEAD >> "${CMAKE_BINARY_DIR}/version.h.tmp"
                     COMMAND ${CMAKE_COMMAND} >>  "${CMAKE_BINARY_DIR}/version.h.tmp" -E echo "\""
                     COMMAND ${CMAKE_COMMAND} -E echo "#endif" >>  "${CMAKE_BINARY_DIR}/version.h.tmp"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/version.h.tmp" "${CMAKE_BINARY_DIR}/version.h"
                     COMMAND ${CMAKE_COMMAND} -E remove "${CMAKE_BINARY_DIR}/version.h.tmp"
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                     COMMENT "Updating ${CMAKE_BINARY_DIR}/version.h..."
                     VERBATIM)
 ELSE(GIT_EXECUTABLE AND EXISTS ${GIT_CFG_DIR})
@@ -419,7 +421,9 @@ ENDIF(WIN32)
 
 ## Generate supertux executable in the right place
 
-SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+#SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+CONFIGURE_FILES(${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_BINARY_DIR}/data)
 
 ## Add target for supertux binary
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,14 +84,16 @@ SuperTux uses CMake to generate a set of Makefiles for the build
 process. To generate these Makefiles and build SuperTux, perform the
 following steps:
 
- 1. `cd` to the directory where you unpacked the SuperTux source
-    archive, i.e. to the directory containing `src` and `data`.
+1. `cd` to the directory where you unpacked the SuperTux source
+   archive, i.e. to the directory containing `src` and `data`.
  
-2. If you git cloned this Supertux repo from Github run 'git submodule update --init --recursive' to fetch/update tinygettext, but
-if you got this version of Supertux from a tarball (.tar) its unnecessary to do so, since tinygettext is already in the .tar.
+2. If you cloned this Supertux repo using git run `git submodule
+   update --init --recursive` to fetch/update squirrel and tinygettext.
+   (If you got this version of Supertux from a tarball (.tar), squirrel
+   and tinygettext are already in the tarball.)
  
- 3. Create and change to a new, empty build directory by running `mkdir
-    build`, `cd build`.
+3. Create and change to a new, empty build directory by running `mkdir
+   build`, `cd build`.
 
 4. Run `cmake ..` to create the Makefiles needed to build SuperTux
    with standard options. If you are missing any libraries needed to

--- a/mk/cmake/ConfigureFiles.cmake
+++ b/mk/cmake/ConfigureFiles.cmake
@@ -1,0 +1,9 @@
+# Copy files from source directory to destination directory, substituting any
+# variables.  Create destination directory if it does not exist.
+
+macro(configure_files srcDir destDir)
+    message(STATUS "Configuring directory ${destDir}")
+    make_directory(${destDir})
+
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${srcDir} ${destDir})
+endmacro(configure_files)

--- a/mk/cmake/FindICONV.cmake
+++ b/mk/cmake/FindICONV.cmake
@@ -1,18 +1,18 @@
 #
-#  Copyright (c) 2006, Peter KÃ¼mmel, 
+#  Copyright (c) 2006, Peter Kümmel, <syntheticpp@gmx.net>
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions
 #  are met:
-#  
+#
 #  1. Redistributions of source code must retain the copyright
 #     notice, this list of conditions and the following disclaimer.
 #  2. Redistributions in binary form must reproduce the copyright
 #     notice, this list of conditions and the following disclaimer in the
 #     documentation and/or other materials provided with the distribution.
-#  3. The name of the author may not be used to endorse or promote products 
+#  3. The name of the author may not be used to endorse or promote products
 #     derived from this software without specific prior written permission.
-#  
+#
 #  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
 #  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
 #  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -23,72 +23,78 @@
 #  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 #  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  
+#
+
+set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 
 if (ICONV_INCLUDE_DIR)
   # Already in cache, be silent
   set(ICONV_FIND_QUIETLY TRUE)
-endif (ICONV_INCLUDE_DIR)
+endif()
 
-FIND_PATH(ICONV_INCLUDE_DIR iconv.h
+find_path(ICONV_INCLUDE_DIR iconv.h
  /usr/include
- /usr/local/include
-)
+ /usr/local/include)
 
 set(POTENTIAL_ICONV_LIBS iconv libiconv libiconv2)
-FIND_LIBRARY(ICONV_LIBRARY NAMES ${POTENTIAL_ICONV_LIBS}
-PATHS
- /usr/lib
- /usr/local/lib
-)
+
+find_library(ICONV_LIBRARY NAMES ${POTENTIAL_ICONV_LIBS}
+	PATHS /usr/lib /usr/local/lib)
 
 if(WIN32)
 	set(ICONV_DLL_NAMES iconv.dll  libiconv.dll libiconv2.dll)
-	FIND_FILE(ICONV_DLL   
+	find_file(ICONV_DLL
 					NAMES ${ICONV_DLL_NAMES}
 					PATHS ENV PATH
 					NO_DEFAULT_PATH)
-	FIND_FILE(ICONV_DLL_HELP   
+	find_file(ICONV_DLL_HELP
 					NAMES ${ICONV_DLL_NAMES}
 					PATHS ENV PATH
 					${ICONV_INCLUDE_DIR}/../bin)
-	IF(ICONV_FIND_REQUIRED)
-		IF(NOT ICONV_DLL AND NOT ICONV_DLL_HELP)
-			MESSAGE(FATAL_ERROR "Could not find iconv.dll, please add correct your PATH environment variable")
-		ENDIF(NOT ICONV_DLL AND NOT ICONV_DLL_HELP)
-		IF(NOT ICONV_DLL AND ICONV_DLL_HELP)
-			GET_FILENAME_COMPONENT(ICONV_DLL_HELP ${ICONV_DLL_HELP} PATH)
-			MESSAGE(STATUS)
-			MESSAGE(STATUS "Could not find iconv.dll in standard search path, please add ")
-			MESSAGE(STATUS "${ICONV_DLL_HELP}")
-			MESSAGE(STATUS "to your PATH environment variable.")
-			MESSAGE(STATUS)
-			MESSAGE(FATAL_ERROR "exit cmake")
-		ENDIF(NOT ICONV_DLL AND ICONV_DLL_HELP)
-	ENDIF(ICONV_FIND_REQUIRED)
-ELSE(WIN32)
-	set(ICONV_DLL TRUE)
-endif(WIN32)
+	if(ICONV_FIND_REQUIRED)
+		if(NOT ICONV_DLL AND NOT ICONV_DLL_HELP)
+			message(FATAL_ERROR "Could not find iconv.dll, please add correct your PATH environment variable")
+		endif()
+		if(NOT ICONV_DLL AND ICONV_DLL_HELP)
+			get_filename_component(ICONV_DLL_HELP ${ICONV_DLL_HELP} PATH)
+			message(STATUS)
+			message(STATUS "Could not find iconv.dll in standard search path, please add ")
+			message(STATUS "${ICONV_DLL_HELP}")
+			message(STATUS "to your PATH environment variable.")
+			message(STATUS)
+			message(FATAL_ERROR "exit cmake")
+		endif()
+	endif()
+	if(ICONV_INCLUDE_DIR AND ICONV_LIBRARY AND ICONV_DLL)
+   		set(ICONV_FOUND TRUE)
+	endif()
+else()
+	include(CheckFunctionExists)
+	check_function_exists(iconv HAVE_ICONV_IN_LIBC)
+	if(ICONV_INCLUDE_DIR AND HAVE_ICONV_IN_LIBC)
+   		set(ICONV_FOUND TRUE)
+		set(ICONV_LIBRARY  CACHE TYPE STRING FORCE)
+	endif()
+	if(ICONV_INCLUDE_DIR AND ICONV_LIBRARY)
+   		set(ICONV_FOUND TRUE)
+	endif()
+endif()
 
 
-IF (ICONV_INCLUDE_DIR AND ICONV_LIBRARY AND ICONV_DLL)
-   SET(ICONV_FOUND TRUE)
-ENDIF (ICONV_INCLUDE_DIR AND ICONV_LIBRARY AND ICONV_DLL)
 
-IF (ICONV_FOUND)
-   IF (NOT ICONV_FIND_QUIETLY)
-      MESSAGE(STATUS "Found iconv library: ${ICONV_LIBRARY}")
-      #MESSAGE(STATUS "Found iconv   dll  : ${ICONV_DLL}")
-   ENDIF (NOT ICONV_FIND_QUIETLY)
-ELSE (ICONV_FOUND)
-   IF (ICONV_FIND_REQUIRED)
-      MESSAGE(STATUS "Looked for iconv library named ${POTENTIAL_ICONV_LIBS}.")
-      MESSAGE(STATUS "Found no acceptable iconv library. This is fatal.")
-      MESSAGE(STATUS "iconv header: ${ICONV_INCLUDE_DIR}")
-      MESSAGE(STATUS "iconv lib   : ${ICONV_LIBRARY}")
-      MESSAGE(FATAL_ERROR "Could NOT find iconv library")
-   ENDIF (ICONV_FIND_REQUIRED)
-ENDIF (ICONV_FOUND)
+if(ICONV_FOUND)
+   if(NOT ICONV_FIND_QUIETLY)
+      message(STATUS "Found iconv library: ${ICONV_LIBRARY}")
+      #message(STATUS "Found iconv   dll  : ${ICONV_DLL}")
+   endif()
+else()
+   if(ICONV_FIND_REQUIRED)
+      message(STATUS "Looked for iconv library named ${POTENTIAL_ICONV_LIBS}.")
+      message(STATUS "Found no acceptable iconv library. This is fatal.")
+      message(STATUS "iconv header: ${ICONV_INCLUDE_DIR}")
+      message(STATUS "iconv lib   : ${ICONV_LIBRARY}")
+      message(FATAL_ERROR "Could NOT find iconv library")
+   endif()
+endif()
 
-MARK_AS_ADVANCED(ICONV_LIBRARY ICONV_INCLUDE_DIR)
-
+mark_as_advanced(ICONV_LIBRARY ICONV_INCLUDE_DIR)


### PR DESCRIPTION
This pull request improves the build error messages if a submodule is not checked out, and builds tinygettext and squirrel separately, and then links them in to the SuperTux build.  It also fixes the directories used to properly support out-of-tree builds (which should never touch the source directory).