### PR TITLE
Configs now per profile

### DIFF
--- a/src/lisp/writer.cpp
+++ b/src/lisp/writer.cpp
@@ -219,28 +219,28 @@ Writer::paste_raw(const Lisp* lsp)
       //This isn't a list, just write
       case Lisp::LispType::TYPE_STRING:
         {
-          std::string strval;
+          std::string strval = "";
           val_lisp->get(strval);
           write(name, strval);
         }
         break;
       case Lisp::LispType::TYPE_BOOLEAN:
         {
-          bool boolval;
+          bool boolval = false;
           val_lisp->get(boolval);
           write(name, boolval);
         }
         break;
       case Lisp::LispType::TYPE_INTEGER:
         {
-          int intval;
+          int intval = 0;
           val_lisp->get(intval);
           write(name, intval);
         }
         break;
       case Lisp::LispType::TYPE_REAL:
         {
-          float realval;
+          float realval = 0;
           val_lisp->get(realval);
           write(name, realval);
         }

--- a/src/lisp/writer.hpp
+++ b/src/lisp/writer.hpp
@@ -22,6 +22,8 @@
 
 namespace lisp {
 
+class Lisp;
+  
 class Writer
 {
 public:
@@ -46,11 +48,23 @@ public:
   void write(const std::string& name, const std::vector<std::string>& value);
   // add more write-functions when needed...
 
+  /**
+   * Paste in a Lisp tree 'lsp' gotten using 'parse' or
+   * 'get_lisp' with the name 'container_name'.
+   */
+  void paste(const Lisp* lsp, const std::string& container_name="");
+
   void end_list(const std::string& listname);
 
 private:
   void write_escaped_string(const std::string& str);
   void indent();
+  /**
+   * @brief Pastes lisp tree into file. 
+   * @param lsp
+   * Must have a name (TYPE_SYMBOL) as first thing.
+   */
+  void paste_raw(const Lisp* lsp);
 
 private:
   std::ostream* out;

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -17,6 +17,7 @@
 #include "supertux/gameconfig.hpp"
 
 #include <stdexcept>
+#include <iostream>
 
 #include "addon/addon_manager.hpp"
 #include "control/input_manager.hpp"
@@ -129,10 +130,18 @@ Config::load()
     }
   }
 
+  //If addons is found in config file then it's a pre-0.4.0 file.
   const lisp::Lisp* config_addons_lisp = config_lisp->get_lisp("addons");
   if (config_addons_lisp)
   {
-    lisp::ListIterator iter(config_addons_lisp);
+    std::cout << "Old addons file found." << std::endl;
+    Writer addons_writer("addon-list");
+    addons_writer.paste(config_addons_lisp, "addons");
+  }
+  
+  const lisp::Lisp* addons_lisp = parser.parse("addon-list")->get_lisp("addons");
+  if (addons_lisp) {
+    lisp::ListIterator iter(addons_lisp);
     while(iter.next())
     {
       const std::string& token = iter.item();
@@ -207,17 +216,20 @@ Config::save()
   }
   writer.end_list("control");
 
-  writer.start_list("addons");
+  writer.end_list("supertux-config");
+
+  //Addons written in seperate file
+  Writer addon_writer("addon-list");
+  
+  addon_writer.start_list("addons");
   for(auto addon : addons)
   {
-    writer.start_list("addon");
-    writer.write("id", addon.id);
-    writer.write("enabled", addon.enabled);
-    writer.end_list("addon");
+    addon_writer.start_list("addon");
+    addon_writer.write("id", addon.id);
+    addon_writer.write("enabled", addon.enabled);
+    addon_writer.end_list("addon");
   }
-  writer.end_list("addons");
-
-  writer.end_list("supertux-config");
+  addon_writer.end_list("addons");
 }
 
 /* EOF */

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -25,6 +25,10 @@
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
+namespace lisp {
+  class Lisp;
+}
+
 class Config
 {
 public:
@@ -32,6 +36,8 @@ public:
   ~Config();
 
   void load();
+  void load_addons(const lisp::Lisp* lsp);
+  bool load_from(const lisp::Lisp* lsp);
   void save();
 
   int profile;

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -34,11 +34,16 @@ class Config
 public:
   Config();
   ~Config();
-
-  void load();
+  
+  // If no profile_num specified, will use current-profile file
+  void load(int profile_num = -1);
   void load_addons(const lisp::Lisp* lsp);
+  /**Try to load old 0.3.6 config file.*/
+  bool load_legacy();
   bool load_from(const lisp::Lisp* lsp);
   void save();
+  /**Save to current-profile file the number profile_num*/
+  void save_current_profile();
 
   int profile;
 

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -50,6 +50,7 @@ ProfileMenu::ProfileMenu()
 void
 ProfileMenu::menu_action(MenuItem* item)
 {
+  g_config->save();
   g_config->profile = item->id;
   MenuManager::instance().clear_menu_stack();
 }

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -24,6 +24,7 @@
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "util/gettext.hpp"
+#include "physfs.h"
 
 ProfileMenu::ProfileMenu()
 {
@@ -52,6 +53,20 @@ ProfileMenu::menu_action(MenuItem* item)
 {
   g_config->save();
   g_config->profile = item->id;
+  //Ensure profile folder exists, if not, create it
+  std::ostringstream dirname;
+  dirname << "profile" << g_config->profile;
+  if(!PHYSFS_exists(dirname.str().c_str()))
+  {
+    if(!PHYSFS_mkdir(dirname.str().c_str()))
+    {
+      std::ostringstream msg;
+      msg << "Couldn't create directory for new profile - "
+          << dirname << "': " <<PHYSFS_getLastError();
+      throw std::runtime_error(msg.str());
+    }
+  }
+  g_config->load(g_config->profile);
   MenuManager::instance().clear_menu_stack();
 }
 


### PR DESCRIPTION
Fixes #184
Please quickly have a look at the code for any formatting mistakes.
And this needs very thorough checking, as this change is quite big, I guess.
old 'config' file has been moved into profile1/config and will update from old config automatically. It will keep the old one to use as a fix if anything goes wrong or a new profile is created. You should not lose any data. addon-list now holds the addons, because they are not per-profile.