### PR TITLE
Fixed console command 'functions(...)'

### DIFF
--- a/data/scripts/console.nut
+++ b/data/scripts/console.nut
@@ -80,17 +80,14 @@ function lifeup()
 function functions(...)
 {
 	local obj = this;
-	if(vargc == 1)
+	if(vargv.len() == 1)
 		obj = vargv[0];
 	if(::type(obj) == "instance")
 		obj = obj.getclass()
 
-	while(obj != null) {
-		foreach(key, val in obj) {
-			if(::type(val) == "function")
-				println(key);
-		}
-		obj = obj.parent;
+	foreach(key, val in obj) {
+		if(::type(val) == "function")
+			println(key);
 	}
 }
 


### PR DESCRIPTION
vargc should be vargv.len() in Squirrel 3.0 and obj.parent isn't supported anymore.