### PR TITLE
Fixed the typo. (1 GHz instead of 10 GHz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ causes problems on some setups, so just run `supertux2 --window` and
 you should be set.
 
 The game uses OpenGL to render the graphics. You will either need a
-CPU with about 10 GHz or an accelerated video card with the vendor's
+CPU with about 1 GHz or an accelerated video card with the vendor's
 drivers. (On Linux, the team recommends using cards from NVidia with
 the proprietary drivers, but ATI or another vendor should do.)
 


### PR DESCRIPTION
In the README.md file, it was written that the game required 10GHz CPU, which is clearly a typo. So, fixed that to 1 GHz CPU, so as to keep the README as error-free and clear as possible,