### PR TITLE
Remove recommendation of proprietary drivers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ causes problems on some setups, so just run `supertux2 --window` and
 you should be set.
 
 The game uses OpenGL to render the graphics. You will either need a
-CPU with about 1 GHz or an accelerated video card with the vendor's
-drivers. (On Linux, the team recommends using cards from NVidia with
-the proprietary drivers, but ATI or another vendor should do.)
+CPU with about 1 GHz or an accelerated video card with recent
+graphics drivers.
 
 
 ## Playing the game


### PR DESCRIPTION
Friends don't let friends recommend proprietary software. :)

(I'm pretty sure the free drivers are good enough for playing SuperTux in 2015. This isn't 2005 anymore.)