### PR TITLE
getting a null string exception when the data dir is unable to be set

### DIFF
--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -160,7 +160,7 @@ public:
     {
       // check if we run from source dir
       char* basepath_c = SDL_GetBasePath();
-      std::string basepath = basepath_c;
+      std::string basepath = basepath_c ? basepath_c : "./";
       SDL_free(basepath_c);
 
       // If we are on windows, the data directory is one directory above the binary


### PR DESCRIPTION
tested under OpenBSD, launched supertux executable from the compiled directory, data dir is null as SDL_GetBasePath returns NULL. Small proposition is to set data dir to the current directory in this case.