### PR TITLE
Fix a case of grown Tux having smaller height than he appears

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1531,7 +1531,6 @@ Player::kill(bool completely)
       set_bonus(GROWUP_BONUS, true);
     } else if(player_status->bonus == GROWUP_BONUS) {
       safe_timer.start(TUX_SAFE_TIME /* + GROWING_TIME */);
-      adjust_height(SMALL_TUX_HEIGHT);
       duck = false;
       backflipping = false;
       sprite->set_angle(0.0f);

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1537,10 +1537,6 @@ Player::kill(bool completely)
       powersprite->set_angle(0.0f);
       lightsprite->set_angle(0.0f);
       set_bonus(NO_BONUS, true);
-    } else if(player_status->bonus == NO_BONUS) {
-      safe_timer.start(TUX_SAFE_TIME);
-      adjust_height(SMALL_TUX_HEIGHT);
-      duck = false;
     }
   } else {
     SoundManager::current()->play("sounds/kill.wav");


### PR DESCRIPTION
If you place Tux inside a wall (e.g. via ghost mode) while he is 'grown', he gets hit but retains his 'grown' state (not 100% reproducible, sometimes he just dies immediately), while his height (the value) is lowered to that of small/'nobonus' Tux. This results in behavior seen in #303.

I've found that in this case adjust_height() is called twice for some reason:
* in kill(), before calling set_state(): https://github.com/SuperTux/supertux/blob/c3edde698049d00dad851e62ae67b7108d0976fd/src/object/player.cpp#L1534
* in set_state(): https://github.com/SuperTux/supertux/blob/c3edde698049d00dad851e62ae67b7108d0976fd/src/object/player.cpp#L1138

The first call is superfluous, because set_state() already performs height adjustment via adjust_height(). Now, if adjust_height() finds out that Tux's height would increase AND the new height would cause Tux to be stuck inside a wall, it fails (returns false) without changing his height. If adjust_height() fails in set_state(), Tux's state won't be changed, either.

What happens is that kill() sets Tux's height from big to small, and then set_state() attempts to set Tux's height from small to small. This does not seem like a problem. However, due to float precision issues (arising from RectF not being defined by its height -- the height needs to be calculated), the second call of adjust_height() thinks that Tux's height is to be increased (in my case from 30.7999878 to 30.8), therefore performs stuck check and fails (because obviously I'm in a wall). Therefore, Tux remains in 'grown' state, but his height is small.

I'm not sure whether or how this is related to #303, but there is a possibility this PR could fix it. Also, this PR removes some code that is never executed.