### PR TITLE
Fix tiles with images larger than 32x32px not being visible

### DIFF
--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -244,6 +244,57 @@ TileMap::draw(DrawingContext& context)
     } /* for (pos y) */
   } /* for (pos x) */
 
+  /* Make sure that tiles with images larger than 32x32 that overlap
+   * the draw rect will be drawn, even if their tile position does
+   * not fall within the draw rect. */
+  static const int EXTENDING_TILES = 32;
+  int ex_left = std::max(0, t_draw_rect.left-EXTENDING_TILES);
+  int ex_top = std::max(0, t_draw_rect.top-EXTENDING_TILES);
+  Vector ex_start = get_tile_position(ex_left, ex_top);
+
+  for (pos.x = start.x, tx = t_draw_rect.left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
+    for (pos.y = ex_start.y, ty = ex_top; ty < t_draw_rect.top; pos.y += 32, ++ty) {
+      int index = ty*width + tx;
+      assert (index >= 0);
+      assert (index < (width * height));
+
+      if (tiles[index] == 0) continue;
+      const Tile* tile = tileset->get(tiles[index]);
+      assert(tile != 0);
+
+      SurfacePtr image = tile->get_current_image();
+      if (image) {
+        int h = image->get_height();
+        if (h <= 32) continue;
+
+        if (pos.y + h > start.y)
+          tile->draw(context, pos, z_pos, current_tint);
+      }
+    }
+  }
+
+  for (pos.x = ex_start.x, tx = ex_left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
+    for(pos.y = ex_start.y, ty = ex_top; ty < t_draw_rect.bottom; pos.y += 32, ++ty) {
+      int index = ty*width + tx;
+      assert (index >= 0);
+      assert (index < (width * height));
+
+      if (tiles[index] == 0) continue;
+      const Tile* tile = tileset->get(tiles[index]);
+      assert(tile != 0);
+
+      SurfacePtr image = tile->get_current_image();
+      if (image) {
+        int w = image->get_width();
+        int h = image->get_height();
+        if (w <= 32 && h <= 32) continue;
+
+        if (pos.x + w > start.x && pos.y + h > start.y)
+          tile->draw(context, pos, z_pos, current_tint);
+      }
+    }
+  }
+
   if(draw_target != DrawingContext::NORMAL) {
     context.pop_target();
   }

--- a/src/supertux/tile.cpp
+++ b/src/supertux/tile.cpp
@@ -110,25 +110,34 @@ Tile::load_images()
   }
 }
 
-void
-Tile::draw(DrawingContext& context, const Vector& pos, int z_pos, Color color) const
+SurfacePtr
+Tile::get_current_image() const
 {
-  if(draw_editor_images) {
-    if(editor_images.size() > 1) {
+  if (draw_editor_images) {
+    if (editor_images.size() > 1) {
       size_t frame = size_t(game_time * fps) % editor_images.size();
-      context.draw_surface(editor_images[frame], pos, 0, color, Blend(), z_pos);
-      return;
+      return editor_images[frame];
     } else if (editor_images.size() == 1) {
-      context.draw_surface(editor_images[0], pos, 0, color, Blend(), z_pos);
-      return;
+      return editor_images[0];
     }
   }
 
-  if(images.size() > 1) {
+  if (images.size() > 1) {
     size_t frame = size_t(game_time * fps) % images.size();
-    context.draw_surface(images[frame], pos, 0, color, Blend(), z_pos);
+    return images[frame];
   } else if (images.size() == 1) {
-    context.draw_surface(images[0], pos, 0, color, Blend(), z_pos);
+    return images[0];
+  } else {
+    return nullptr;
+  }
+}
+
+void
+Tile::draw(DrawingContext& context, const Vector& pos, int z_pos, Color color) const
+{
+  SurfacePtr surface = get_current_image();
+  if (surface) {
+    context.draw_surface(surface, pos, 0, color, Blend(), z_pos);
   }
 }
 

--- a/src/supertux/tile.hpp
+++ b/src/supertux/tile.hpp
@@ -129,6 +129,8 @@ public:
   /** load Surfaces, if not already loaded */
   void load_images();
 
+  SurfacePtr get_current_image() const;
+
   /** Draw a tile on the screen */
   void draw(DrawingContext& context, const Vector& pos, int z_pos, Color color = Color(1, 1, 1)) const;
 


### PR DESCRIPTION
Fixes #317.

This checks tiles surrounding the draw rect from top and left (as far as defined by EXTENDING_TILES) to see if their image overlaps with the draw rect.