### PR TITLE
Fix assertion failures introduced by PR #346

### DIFF
--- a/src/math/rect.hpp
+++ b/src/math/rect.hpp
@@ -51,6 +51,7 @@ public:
 
   int get_width()  const { return right - left; }
   int get_height() const { return bottom - top; }
+  bool is_valid() const { return right > left && bottom > top; }
 };
 
 #endif

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -226,23 +226,79 @@ TileMap::draw(DrawingContext& context)
   Rectf draw_rect = Rectf(context.get_translation(),
         context.get_translation() + Vector(SCREEN_WIDTH, SCREEN_HEIGHT));
   Rect t_draw_rect = get_tiles_overlapping(draw_rect);
-  Vector start = get_tile_position(t_draw_rect.left, t_draw_rect.top);
 
-  Vector pos;
-  int tx, ty;
+  // Make sure the tilemap is within draw view
+  if (t_draw_rect.is_valid()) {
+    Vector start = get_tile_position(t_draw_rect.left, t_draw_rect.top);
 
-  for(pos.x = start.x, tx = t_draw_rect.left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
-    for(pos.y = start.y, ty = t_draw_rect.top; ty < t_draw_rect.bottom; pos.y += 32, ++ty) {
-      int index = ty*width + tx;
-      assert (index >= 0);
-      assert (index < (width * height));
+    Vector pos;
+    int tx, ty;
 
-      if (tiles[index] == 0) continue;
-      const Tile* tile = tileset->get(tiles[index]);
-      assert(tile != 0);
-      tile->draw(context, pos, z_pos, current_tint);
-    } /* for (pos y) */
-  } /* for (pos x) */
+    for(pos.x = start.x, tx = t_draw_rect.left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
+      for(pos.y = start.y, ty = t_draw_rect.top; ty < t_draw_rect.bottom; pos.y += 32, ++ty) {
+        int index = ty*width + tx;
+        assert (index >= 0);
+        assert (index < (width * height));
+
+        if (tiles[index] == 0) continue;
+        const Tile* tile = tileset->get(tiles[index]);
+        assert(tile != 0);
+
+        tile->draw(context, pos, z_pos, current_tint);
+      } /* for (pos y) */
+    } /* for (pos x) */
+
+    /* Make sure that tiles with images larger than 32x32 that overlap
+     * the draw rect will be drawn, even if their tile position does
+     * not fall within the draw rect. */
+    static const int EXTENDING_TILES = 32;
+    int ex_left = std::max(0, t_draw_rect.left-EXTENDING_TILES);
+    int ex_top = std::max(0, t_draw_rect.top-EXTENDING_TILES);
+    Vector ex_start = get_tile_position(ex_left, ex_top);
+
+    for (pos.x = start.x, tx = t_draw_rect.left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
+      for (pos.y = ex_start.y, ty = ex_top; ty < t_draw_rect.top; pos.y += 32, ++ty) {
+        int index = ty*width + tx;
+        assert (index >= 0);
+        assert (index < (width * height));
+
+        if (tiles[index] == 0) continue;
+        const Tile* tile = tileset->get(tiles[index]);
+        assert(tile != 0);
+
+        SurfacePtr image = tile->get_current_image();
+        if (image) {
+          int h = image->get_height();
+          if (h <= 32) continue;
+
+          if (pos.y + h > start.y)
+            tile->draw(context, pos, z_pos, current_tint);
+        }
+      }
+    }
+
+    for (pos.x = ex_start.x, tx = ex_left; tx < t_draw_rect.right; pos.x += 32, ++tx) {
+      for(pos.y = ex_start.y, ty = ex_top; ty < t_draw_rect.bottom; pos.y += 32, ++ty) {
+        int index = ty*width + tx;
+        assert (index >= 0);
+        assert (index < (width * height));
+
+        if (tiles[index] == 0) continue;
+        const Tile* tile = tileset->get(tiles[index]);
+        assert(tile != 0);
+
+        SurfacePtr image = tile->get_current_image();
+        if (image) {
+          int w = image->get_width();
+          int h = image->get_height();
+          if (w <= 32 && h <= 32) continue;
+
+          if (pos.x + w > start.x && pos.y + h > start.y)
+            tile->draw(context, pos, z_pos, current_tint);
+        }
+      }
+    }
+  }
 
   if(draw_target != DrawingContext::NORMAL) {
     context.pop_target();

--- a/src/supertux/tile.cpp
+++ b/src/supertux/tile.cpp
@@ -110,25 +110,34 @@ Tile::load_images()
   }
 }
 
-void
-Tile::draw(DrawingContext& context, const Vector& pos, int z_pos, Color color) const
+SurfacePtr
+Tile::get_current_image() const
 {
-  if(draw_editor_images) {
-    if(editor_images.size() > 1) {
+  if (draw_editor_images) {
+    if (editor_images.size() > 1) {
       size_t frame = size_t(game_time * fps) % editor_images.size();
-      context.draw_surface(editor_images[frame], pos, 0, color, Blend(), z_pos);
-      return;
+      return editor_images[frame];
     } else if (editor_images.size() == 1) {
-      context.draw_surface(editor_images[0], pos, 0, color, Blend(), z_pos);
-      return;
+      return editor_images[0];
     }
   }
 
-  if(images.size() > 1) {
+  if (images.size() > 1) {
     size_t frame = size_t(game_time * fps) % images.size();
-    context.draw_surface(images[frame], pos, 0, color, Blend(), z_pos);
+    return images[frame];
   } else if (images.size() == 1) {
-    context.draw_surface(images[0], pos, 0, color, Blend(), z_pos);
+    return images[0];
+  } else {
+    return nullptr;
+  }
+}
+
+void
+Tile::draw(DrawingContext& context, const Vector& pos, int z_pos, Color color) const
+{
+  SurfacePtr surface = get_current_image();
+  if (surface) {
+    context.draw_surface(surface, pos, 0, color, Blend(), z_pos);
   }
 }
 

--- a/src/supertux/tile.hpp
+++ b/src/supertux/tile.hpp
@@ -129,6 +129,8 @@ public:
   /** load Surfaces, if not already loaded */
   void load_images();
 
+  SurfacePtr get_current_image() const;
+
   /** Draw a tile on the screen */
   void draw(DrawingContext& context, const Vector& pos, int z_pos, Color color = Color(1, 1, 1)) const;
 


### PR DESCRIPTION
Fixes the fix for #317. :-)

Quoting @tobbi:
> I'm sorry, but I needed to backout the fix. I'm getting this:
> 
> Assertion failed: (index < (width * height)), function draw, file /Users/tobiasmarkus/workspace/supertux/src/object/tilemap.cpp, line 259.
> 
> I did try it with the level "shaft racing" from Yeti's Revenge add-on. Once you kick the ice block into the wooden blocks on the right, it always crashes with the above assertion.

The problem is that _TileMap::get_tiles_overlapping_ returns a deformed rectangle (one whose top > bottom or left > right) when a tilemap is out of view. My code relies on the draw rectangle being valid. It didn't cause crashes previously, because the original 2 nested for loops ruled out these deformities. I've added a check, which should have been there before.

Anyway, in this particular case, the assertion failed when the cart (which is a tilemap with a defined path) got out of view.