### PR TITLE
Display localized name instead of English translation

### DIFF
--- a/src/supertux/menu/language_menu.cpp
+++ b/src/supertux/menu/language_menu.cpp
@@ -45,7 +45,7 @@ LanguageMenu::LanguageMenu()
   std::set<tinygettext::Language> languages = g_dictionary_manager->get_languages();
   for (std::set<tinygettext::Language>::iterator i = languages.begin(); i != languages.end(); ++i)
   {
-    add_entry(mnid++, i->get_name());
+    add_entry(mnid++, i->get_localized_name());
   }
 
   add_hl();


### PR DESCRIPTION
SuperTux changes. Commit hash of tinygettext submodule will update periodically as more translations get added.

Unfortunately, I couldn't test it due to tinygettext refusing to build.

Depends on supertux/tinygettext#3
Fixes #291

