### PR TITLE
InvisibleWall: inherit from MovingObject, remove unnecessary code

### DIFF
--- a/src/object/invisible_wall.cpp
+++ b/src/object/invisible_wall.cpp
@@ -20,13 +20,13 @@
 #include "util/reader_mapping.hpp"
 
 InvisibleWall::InvisibleWall(const ReaderMapping& lisp) :
-  MovingSprite(lisp, "images/objects/invisible/invisible.sprite", LAYER_TILES, COLGROUP_STATIC),
-  physic(),
-  width(),
-  height()
+  MovingSprite(lisp, "images/objects/invisible/invisible.sprite", LAYER_TILES, COLGROUP_STATIC)
 {
+  float width, height;
+
   if (!lisp.get("width", width)) width = 32;
   if (!lisp.get("height", height)) height = 32;
+
   bbox.set_size(width, height);
 }
 

--- a/src/object/invisible_wall.cpp
+++ b/src/object/invisible_wall.cpp
@@ -19,8 +19,7 @@
 #include "supertux/object_factory.hpp"
 #include "util/reader_mapping.hpp"
 
-InvisibleWall::InvisibleWall(const ReaderMapping& lisp) :
-  MovingSprite(lisp, "images/objects/invisible/invisible.sprite", LAYER_TILES, COLGROUP_STATIC)
+InvisibleWall::InvisibleWall(const ReaderMapping& lisp)
 {
   float width, height;
 
@@ -34,6 +33,16 @@ HitResponse
 InvisibleWall::collision(GameObject& , const CollisionHit& )
 {
   return FORCE_MOVE;
+}
+
+void
+InvisibleWall::draw(DrawingContext& )
+{
+}
+
+void
+InvisibleWall::update(float )
+{
 }
 
 /* EOF */

--- a/src/object/invisible_wall.hpp
+++ b/src/object/invisible_wall.hpp
@@ -18,7 +18,6 @@
 #define HEADER_SUPERTUX_OBJECT_INVISIBLE_WALL_HPP
 
 #include "object/moving_sprite.hpp"
-#include "supertux/physic.hpp"
 
 /** A tile that starts falling down if tux stands to long on it */
 class InvisibleWall : public MovingSprite
@@ -27,10 +26,6 @@ public:
   InvisibleWall(const ReaderMapping& lisp);
 
   HitResponse collision(GameObject& other, const CollisionHit& hit);
-
-private:
-  Physic physic;
-  float width, height;
 };
 
 #endif

--- a/src/object/invisible_wall.hpp
+++ b/src/object/invisible_wall.hpp
@@ -17,15 +17,19 @@
 #ifndef HEADER_SUPERTUX_OBJECT_INVISIBLE_WALL_HPP
 #define HEADER_SUPERTUX_OBJECT_INVISIBLE_WALL_HPP
 
-#include "object/moving_sprite.hpp"
+#include "supertux/moving_object.hpp"
+#include "util/reader_fwd.hpp"
 
 /** A tile that starts falling down if tux stands to long on it */
-class InvisibleWall : public MovingSprite
+class InvisibleWall : public MovingObject
 {
 public:
   InvisibleWall(const ReaderMapping& lisp);
 
   HitResponse collision(GameObject& other, const CollisionHit& hit);
+
+  void draw(DrawingContext& context);
+  void update(float elapsed_time);
 };
 
 #endif


### PR DESCRIPTION
As per @Hume2's suggestion.