### PR TITLE
SSpiky: be invincible to flaming while asleep

### DIFF
--- a/src/badguy/sspiky.cpp
+++ b/src/badguy/sspiky.cpp
@@ -110,7 +110,11 @@ SSpiky::is_freezable() const
 bool
 SSpiky::is_flammable() const
 {
-  return true;
+  if (state == SSPIKY_SLEEPING) {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 /* EOF */


### PR DESCRIPTION
This has no effect on frozen SSpikys, since freezing them wakes them up.

Fixes #315