### PR TITLE
CMakeLists: don't ship Incubator Island in Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,7 +722,8 @@ IF(CMAKE_BUILD_TYPE MATCHES Release)
   INSTALL(DIRECTORY ${CMAKE_BINARY_DIR}/data/levels
                     DESTINATION ${INSTALL_SUBDIR_SHARE}
                     PATTERN "data/levels/test" EXCLUDE
-                    PATTERN "data/levels/test_old" EXCLUDE)
+                    PATTERN "data/levels/test_old" EXCLUDE
+                    PATTERN "data/levels/incubator" EXCLUDE)
 ELSE()
   INSTALL(DIRECTORY ${CMAKE_BINARY_DIR}/data/levels
                     DESTINATION ${INSTALL_SUBDIR_SHARE})


### PR DESCRIPTION
Incubator Island doesn't have a story - which we might want to avoid in the official release. The levels should be either incorporated into a worldmap with an actual story or archived (maybe in a separate worldmap available as unofficial addon).