### PR TITLE
Handle string collisions in tinygettext properly

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -123,7 +123,7 @@ static void add_to_dictionary_path(void *data, const char *origdir, const char *
     if(statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY)
     {
         log_debug << "Adding \"" << full_path << "\" to dictionary search path" << std::endl;
-        g_dictionary_manager->add_directory(full_path);
+        g_dictionary_manager->add_directory(full_path, /* override_old = */ true);
     }
 }
 


### PR DESCRIPTION
Depends on SuperTux/tinygettext#4