### PR TITLE
Add addons with precedence to the tinygettext search path.

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -123,7 +123,8 @@ static void add_to_dictionary_path(void *data, const char *origdir, const char *
     if(statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY)
     {
         log_debug << "Adding \"" << full_path << "\" to dictionary search path" << std::endl;
-        g_dictionary_manager->add_directory(full_path);
+        // We want translations from addons to have precedence
+        g_dictionary_manager->add_directory(full_path, true);
     }
 }
 


### PR DESCRIPTION
Fixes #309, #486.

Depends on SuperTux/tinygettext#5