### PR TITLE
src: remove calls to std::move to make clang happy

### DIFF
--- a/src/gui/menu_script.cpp
+++ b/src/gui/menu_script.cpp
@@ -62,7 +62,7 @@ ScriptMenu::~ScriptMenu()
 void
 ScriptMenu::push_string(std::string new_line)
 {
-  script_strings.push_back( move(std::unique_ptr<std::string>(new std::string(new_line))) );
+  script_strings.push_back( std::unique_ptr<std::string>(new std::string(new_line)) );
   add_script_line( (script_strings.end()-1)->get() );
 }
 

--- a/src/supertux/menu/editor_levelset_select_menu.cpp
+++ b/src/supertux/menu/editor_levelset_select_menu.cpp
@@ -152,7 +152,7 @@ EditorLevelsetSelectMenu::menu_action(MenuItem* item)
   if (item->id >= 0)
   {
     std::unique_ptr<Menu> menu = std::unique_ptr<Menu>(new EditorLevelSelectMenu(
-                                 std::move(World::load(m_contrib_worlds[item->id]))));
+                                 World::load(m_contrib_worlds[item->id])));
     MenuManager::instance().push_menu(std::move(menu));
   }
 }


### PR DESCRIPTION
I haven't tested whether this has any effect on runtime. Should be investigated though before the release so we can have a warning-free clang build too.