### PR TITLE
LevelDot: add a NULL check for Editor::current()->get_world()

### DIFF
--- a/src/editor/worldmap_objects.cpp
+++ b/src/editor/worldmap_objects.cpp
@@ -85,7 +85,8 @@ LevelDot::LevelDot (const ReaderMapping& lisp) :
     title_color = Color(vColor);
   }
 
-  level = FileSystem::join(Editor::current()->get_world()->get_basedir(), name);
+  level = Editor::current()->get_world() ?
+    FileSystem::join(Editor::current()->get_world()->get_basedir(), name) : name;
 }
 
 LevelDot::~LevelDot() { }


### PR DESCRIPTION
This is an attempt to fix a crash when opening a worldmap using the
`--edit-level` option. It was caused by the editor attempting to load the level
paths using the world's base directory which doesn't exist when using the
`--edit-level` option.

Resolves SuperTux/data#41.