### PR TITLE
Store script variables

### DIFF
--- a/src/scripting/functions.hpp
+++ b/src/scripting/functions.hpp
@@ -20,6 +20,7 @@
 #ifndef SCRIPTING_API
 #include <squirrel.h>
 #include <string>
+#include "util/sqarrayser.hpp"
 
 #define __suspend
 #define __custom(x)
@@ -228,6 +229,11 @@ void record_demo(const std::string& filename);
  */
 void play_demo(const std::string& filename);
 
+/**
+ * Declare function for storing variables
+ */
+ SQInteger store(HSQUIRRELVM vm) __custom("t..");
+ SQInteger load(HSQUIRRELVM vm) __custom("ts");
 } // namespace scripting
 
 #endif

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -5168,6 +5168,16 @@ static SQInteger play_demo_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger store_wrapper(HSQUIRRELVM vm)
+{
+  return scripting::store(vm);
+}
+
+static SQInteger load_wrapper(HSQUIRRELVM vm)
+{
+  return scripting::load(vm);
+}
+
 static SQInteger Level_finish_wrapper(HSQUIRRELVM vm)
 {
   SQBool arg0;
@@ -6085,6 +6095,20 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'play_demo'");
+  }
+
+  sq_pushstring(v, "store", -1);
+  sq_newclosure(v, &store_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "t..");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'store'");
+  }
+
+  sq_pushstring(v, "load", -1);
+  sq_newclosure(v, &load_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'load'");
   }
 
   sq_pushstring(v, "Level_finish", -1);

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -72,11 +72,24 @@ GameManager::start_worldmap(std::unique_ptr<World> world)
                                            last_worldmap : m_world->get_worldmap_filename(),
                                            *m_savegame);
     ScreenManager::current()->push_screen(std::unique_ptr<Screen>(worldmap));
+    
   }
   catch(std::exception& e)
   {
     log_fatal << "Couldn't start world: " << e.what() << std::endl;
   }
+}
+
+dictionary*
+GameManager::get_dictionary() const
+{
+  return m_world->get_dictionary();
+}
+
+const std::string
+GameManager::get_current_worldname() const
+{
+  return m_world->get_title();
 }
 
 std::string

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 #include "util/currenton.hpp"
-
+#include "util/dictionary.hpp"
 class Savegame;
 class World;
 
@@ -34,10 +34,12 @@ public:
   GameManager();
   ~GameManager();
 
+  dictionary* get_dictionary() const;
   void start_worldmap(std::unique_ptr<World> world);
   void start_level(std::unique_ptr<World> world, const std::string& level_filename);
 
   std::string get_level_name(const std::string& levelfile) const;
+  const std::string get_current_worldname() const;
 
 private:
   GameManager(const GameManager&) = delete;

--- a/src/supertux/savegame.cpp
+++ b/src/supertux/savegame.cpp
@@ -30,6 +30,9 @@
 #include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
 #include "worldmap/worldmap.hpp"
+#include "supertux/game_manager.hpp"
+#include "supertux/game_session.hpp"
+#include "util/dictionary.hpp"
 
 namespace {
 using scripting::get_table_entry;
@@ -250,6 +253,10 @@ Savegame::save()
       msg << "Savegame path '" << dirname << "' is not a directory";
       throw std::runtime_error(msg.str());
     }
+    
+    auto dict = GameManager::current()->get_dictionary();
+
+    dict->save();
   }
 
   HSQUIRRELVM vm = scripting::global_vm;

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -33,6 +33,8 @@
 #include "util/reader_mapping.hpp"
 #include "util/string_util.hpp"
 #include "worldmap/worldmap.hpp"
+#include "supertux/world.hpp"
+
 
 std::unique_ptr<World>
 World::load(const std::string& directory)
@@ -48,6 +50,13 @@ World::load(const std::string& directory)
     world->m_savegame_filename = stream.str();
   }
 
+  { // generate dictionary filename
+    std::string worlddirname = FileSystem::basename(directory);
+    std::ostringstream stream;
+    stream << "profile" << g_config->profile << "/" << worlddirname << ".sss"; // sss = serialized storage store (cool extensionname)
+    world->m_dictionary_filename = stream.str();
+  }
+  world->get_dictionary()->setFilename(world->get_dictionary_filename());
   return world;
 }
 
@@ -87,6 +96,13 @@ World::create(const std::string& title, const std::string& desc)
     world->m_savegame_filename = stream.str();
   }
 
+  { // generate dictionary filename
+    std::string worlddirname = FileSystem::basename(dirname);
+    std::ostringstream stream;
+    stream << "profile" << g_config->profile << "/" << worlddirname << ".sss"; // sss = serialized storage store (cool extensionname)
+    world->m_dictionary_filename = stream.str();
+  }
+  world->m_dictionary->setFilename(world->m_dictionary_filename);
   return world;
 }
 
@@ -94,6 +110,8 @@ World::World() :
   m_basedir(),
   m_worldmap_filename(),
   m_savegame_filename(),
+  m_dictionary_filename(),
+  m_dictionary(new dictionary()),
   m_title(),
   m_description(),
   m_hide_from_contribs(false),
@@ -162,7 +180,11 @@ World::get_basedir() const
 {
   return m_basedir;
 }
-
+dictionary*
+World::get_dictionary()
+{
+  return  m_dictionary.get();
+}
 std::string
 World::get_title() const
 {

--- a/src/supertux/world.hpp
+++ b/src/supertux/world.hpp
@@ -21,6 +21,7 @@
 #include <squirrel.h>
 #include <string>
 #include <vector>
+#include "util/dictionary.hpp"
 
 class World
 {
@@ -33,7 +34,6 @@ private:
 public:
   /**
       Load a World
-
       @param directory  Directory containing the info file, e.g. "levels/world1"
   */
   static std::unique_ptr<World> load(const std::string& directory);
@@ -44,7 +44,7 @@ public:
 
   std::string get_basedir() const;
   std::string get_title() const;
-
+  dictionary* get_dictionary();
   bool hide_from_contribs() const { return m_hide_from_contribs; }
 
   bool is_levelset() const { return m_is_levelset; }
@@ -52,7 +52,7 @@ public:
 
   std::string get_worldmap_filename() const { return m_worldmap_filename; }
   std::string get_savegame_filename() const { return m_savegame_filename; }
-
+  std::string get_dictionary_filename() const { return m_dictionary_filename;}
   void save(bool retry = false);
   void set_default_values();
 
@@ -60,6 +60,8 @@ private:
   std::string m_basedir;
   std::string m_worldmap_filename;
   std::string m_savegame_filename;
+  std::string m_dictionary_filename;
+  std::unique_ptr<dictionary>  m_dictionary;
 
 public:
   std::string m_title;

--- a/src/util/dictionary.cpp
+++ b/src/util/dictionary.cpp
@@ -1,0 +1,301 @@
+//  SuperTux
+//  Copyright (C) 2016 Christian Hagemeier <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include "util/dictionary.hpp"
+#include <iostream>
+
+using std::vector;
+using std::cout;
+using namespace boost;
+using std::auto_ptr;
+
+dictionary::dictionary(const std::string& filename):
+    m_table(),
+    m_filename(filename),
+    m_writer() {
+    this->load();
+}
+
+dictionary::dictionary(void):
+    m_table(),
+    m_filename(),
+    m_writer() {
+}
+
+dictionaryTypes dictionary::str2type(const std::string& type) {
+    if(type == "int")
+        return DICT_INT;
+    if(type == "arr")
+        return DICT_ARR;
+    if(type == "bool")
+        return DICT_BOOL;
+    if(type == "float")
+        return DICT_FLOAT;
+    if(type == "table")
+        return DICT_TABLE;
+    if(type == "str")
+        return DICT_STRING;
+    throw new std::runtime_error("No valid type string provided! (Invalid supertux storage file)");
+}
+
+void dictionary::load() {
+    try {
+        if(!PHYSFS_exists(m_filename.c_str())) {
+            log_info << m_filename << " doesn't exist, not loading world storage" << std::endl;
+        } else {
+            PHYSFS_Stat statbuf;
+            PHYSFS_stat(m_filename.c_str(), &statbuf);
+            if(statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY) {
+                log_info << m_filename << " is a directory, not loading world storage" << std::endl;
+                return;
+            }
+            auto doc = ReaderDocument::parse(m_filename);
+            auto docroot = doc.get_root();
+
+            if(!(docroot.get_name() == "save-data")) {
+                log_fatal << "file is not a supertux-storage file" << std::endl;
+                throw std::runtime_error("file is not a supertux-storage file");
+            } else {
+                auto mapping = docroot.get_mapping();
+                ReaderCollection items;
+                if(!mapping.get("items",items)) {
+                    log_fatal << "Ill formed save-data file";
+                    throw std::runtime_error("Ill formed save-data file.");
+                }
+                for(const auto& item:items.get_objects()) {
+                    log_debug << "Next item" << std::endl;
+                    if(!(item.get_name() == "item")) {
+                        log_fatal << "Ill formed save-data file (Exspected Item in Items)).";
+                        throw std::runtime_error("Ill formed save-data file (Exspected Item in Items)).");
+                    }
+                    auto imap = item.get_mapping();
+                    // Get type
+                    std::string type;
+                    imap.get("type",type);
+                    log_debug << "Loading key" << std::endl;
+                    std::string key;
+                    imap.get("key",key);
+                    log_debug << "Got key" << key << " " << std::endl;
+
+                    switch(dictionary::str2type(type)) {
+                    case DICT_STRING: {
+                        std::string value;
+                        imap.get("value",value);
+                        add(key,value);
+                        break;
+                    }
+                    case DICT_INT: {
+                        int val;
+                        imap.get("value",val);
+                        add(key,val);
+                        break;
+                    }
+                    case DICT_FLOAT: {
+                        float val;
+                        imap.get("value",val);
+                        add(key,val);
+                        break;
+                    }
+                    case DICT_BOOL: {
+                        bool val;
+                        imap.get("value",val);
+                        add(key,val);
+                        break;
+                    }
+                    case DICT_ARR: {
+                        std::unique_ptr<sqarr> arr(new sqarr());
+                        ReaderCollection itemsarr;
+                        imap.get("array-items",itemsarr);
+                        arr->load(itemsarr);
+                        add(key,std::move(arr));
+                        break;
+                    }
+                    case DICT_TABLE: {
+                      log_debug << "Loading table" << std::endl;
+                        ReaderCollection itemsdict;
+                        imap.get("dict-items",itemsdict);
+                        std::unique_ptr<sqdict> table(new sqdict());
+                        table->load(itemsdict);
+                        add(key,std::move(table));
+                        break;
+                    }
+                    }
+                }
+            }
+        }
+    } catch(const std::exception& e) {
+        log_fatal << "Couldn't load storage: " << e.what() << std::endl;
+    }
+}
+
+void
+dictionary::setFilename(const std::string& filename) {
+    m_filename = filename;
+    this->load();
+}
+
+dictionaryItem*
+dictionary::createTableEntry(const std::string& key) {
+    // TODO Replace in 2017 with insert_or_assign (C++17)
+    std::shared_ptr<dictionaryItem> foundn(new dictionaryItem());
+    foundn->key = key;
+    m_table[key] = foundn;
+    return foundn.get();
+}
+
+dictionaryItem*
+dictionary::add(const std::string& key,std::unique_ptr<boost::any> value) {
+    auto found = this->createTableEntry(key);
+    found->item = std::move(value);
+    return found;
+}
+
+void
+dictionary::add(const std::string& key,int value) {
+    // Add to dictionary
+    std::unique_ptr<boost::any> itemp(new boost::any(value));
+    auto it = add(key, std::move(itemp));
+    it->type = DICT_INT;
+}
+
+void
+dictionary::add(const std::string& key,std::string value) {
+    // Add to dictionary
+    auto it = this->createTableEntry(key);
+    it->value = value;
+    it->type = DICT_STRING;
+    log_debug << "Added " << key << std::endl;
+}
+
+void
+dictionary::add(const std::string& key,float value) {
+    // Add to dictionary
+    std::unique_ptr<boost::any> itemp(new boost::any(value));
+    auto it = add(key, std::move(itemp));
+    log_debug << "Added";
+    it->type = DICT_FLOAT;
+}
+
+void
+dictionary::add(const std::string& key,std::unique_ptr<sqarr> value) {
+    // Add to dictionary
+    auto it = this->createTableEntry(key);
+    it->valarr = std::move(value);
+    log_debug << "Added " << key << std::endl;
+    it->type = DICT_ARR;
+}
+
+void
+dictionary::add(const std::string& key,std::unique_ptr<sqdict> value) {
+    // Add to dictionary
+    auto it = this->createTableEntry(key);
+    it->valdict = std::move(value);
+    it->type = DICT_TABLE;
+    log_debug << "Added " << key << std::endl;
+}
+
+void
+dictionary::add(const std::string& key,bool value) {
+    // Add to dictionary
+    std::unique_ptr<boost::any> itemp(new boost::any(value));
+    auto it = add(key, std::move(itemp));
+    it->type = DICT_BOOL;
+}
+
+dictionaryItem*
+dictionary::get(const std::string& key) {
+    auto ptr = m_table[key];
+    if(ptr) {
+        return ptr.get();
+    } else {
+        return NULL;
+    }
+}
+/**
+ *  Function is called, when a game_session is ended
+ */
+bool
+dictionary::save() {
+    log_warning << "Saving " << m_filename << " size:" << m_table.size() << std::endl;
+    // open writer
+    std::unique_ptr<Writer> writer(new Writer(m_filename));
+    m_writer = std::move(writer);
+    m_writer->start_list("save-data");
+    m_writer->start_list("items");
+    m_writer->write_comment("Supertux Simple Storage File");
+    this->saveItems();
+    m_writer->end_list("items");
+    m_writer->end_list("save-data");
+    // close writer
+    return true;
+}
+
+void dictionary::saveItems() {
+    // Iterate through hashtable
+    for(auto const & pair:m_table) {
+        auto item = pair.second;
+        log_warning << item->key << std::endl;
+        m_writer->start_list("item");
+        m_writer->write("key",item->key);
+        this->saveItem(item.get());
+        m_writer->write("type",dictionary::getTypename(item.get()));
+        m_writer->end_list("item");
+    }
+}
+
+void dictionary::saveItem(const dictionaryItem* item) {
+    if(!(item->item) && item->type != DICT_STRING && item->type != DICT_ARR && item->type != DICT_TABLE) {
+        log_warning << "Error: Empty variable" << std::endl;
+        //return;
+    }
+    switch(item->type) {
+    case DICT_STRING:
+        m_writer->write("value",(item->value));
+        break;
+    case DICT_BOOL:
+        m_writer->write("value",*any_cast<bool>(item->item.get()));
+        break;
+    case DICT_INT:
+        m_writer->write("value",*any_cast<int>(item->item.get()));
+        break;
+    case DICT_FLOAT:
+        m_writer->write("value",*any_cast<float>(item->item.get()));
+        break;
+    case DICT_ARR:
+        item->valarr->serialize(m_writer.get());
+        break;
+    case DICT_TABLE:
+        item->valdict->serialize(m_writer.get());
+        break;
+    }
+}
+
+std::string dictionary::getTypename(dictionaryItem* i) {
+    switch(i->type) {
+    case DICT_STRING:
+        return "str";
+    case DICT_BOOL:
+        return "bool";
+    case DICT_INT:
+        return "int";
+    case DICT_FLOAT:
+        return "float";
+    case DICT_ARR:
+        return "arr";
+    case DICT_TABLE:
+        return "table";
+    }
+    return "";
+}

--- a/src/util/dictionary.hpp
+++ b/src/util/dictionary.hpp
@@ -1,0 +1,98 @@
+//  SuperTux
+//  Copyright (C) 2016 Christian Hagemeier <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_UTIL_DICTIONARY_HPP
+#define HEADER_SUPERTUX_UTIL_DICTIONARY_HPP
+#include <squirrel.h>
+#include <vector>
+#include <map>
+#include <boost/any.hpp>
+#include "util/log.hpp"
+#include "util/writer.hpp"
+#include <memory>
+#include "util/sqarrayser.hpp"
+#include "util/sqdictser.hpp"
+#include "physfs/ifile_streambuf.hpp"
+#include "util/file_system.hpp"
+#include "util/log.hpp"
+#include "util/reader_document.hpp"
+#include "util/reader_mapping.hpp"
+#include "util/reader_collection.hpp"
+
+class sqdict;
+class sqarr;
+
+using std::auto_ptr;
+
+enum dictionaryTypes {
+    DICT_STRING = 0, DICT_FLOAT, DICT_INT,DICT_BOOL, DICT_ARR, DICT_TABLE
+};
+
+
+class dictionaryItem {
+  public:
+    std::string key;
+    dictionaryTypes type;
+    std::unique_ptr<boost::any> item;
+    std::string value;
+    std::unique_ptr<sqarr> valarr;
+    std::unique_ptr<sqdict> valdict;
+    dictionaryItem():
+        key(),
+        type(),
+        item(),
+        value(),
+        valarr(),
+        valdict() {
+    };
+};
+
+
+class dictionary {
+  private:
+    std::map<std::string,std::shared_ptr<dictionaryItem>> m_table; // Hashtable with variable size
+    dictionaryItem* add(const std::string& key,std::unique_ptr<boost::any> value);
+    dictionaryItem* createTableEntry(const std::string& key);
+  public:
+    bool save();
+    void add(const std::string& key,int value);
+    void add(const std::string& key,std::string value);
+    void add(const std::string& key,float value);
+    void add(const std::string& key,bool value);
+    void add(const std::string& key,std::unique_ptr<sqarr> value);
+    void add(const std::string& key,std::unique_ptr<sqdict> value);
+    // Methods for squirrel specific types (like lists, etc)
+    void setFilename(const std::string& filename);
+    std::string getFilename(){
+      return m_filename;
+    };
+    dictionaryItem* get(const std::string& key);
+    dictionary(const std::string& filename);
+    dictionary(void); // Initialize empty
+    static dictionaryTypes str2type(const std::string& type);
+
+  private:
+    static std::string getTypename(dictionaryItem* i);
+    std::string m_filename;
+    std::unique_ptr<Writer> m_writer;
+    void saveItems();
+    void saveItem(const dictionaryItem* item);
+    void load();
+
+
+};
+
+#endif

--- a/src/util/sqarrayser.cpp
+++ b/src/util/sqarrayser.cpp
@@ -1,0 +1,309 @@
+//  SuperTux
+//  Copyright (C) 2016 Christian Hagemeier <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "util/sqarrayser.hpp"
+using boost::any;
+using boost::any_cast;
+using std::unique_ptr;
+
+void
+sqarr::loadArray(HSQUIRRELVM vm) {
+    // Iterate over the array in the vm
+    // first push 0 onto the stack
+    sq_pushnull(vm);
+    // then begin the iteration
+    while(SQ_SUCCEEDED(sq_next(vm,-2))) {
+        // Pop key
+        if(sq_gettype(vm, -2) != OT_INTEGER) {
+            log_warning << "Array contains non int key\n";
+            continue;
+        }
+        // Pop value
+        SQInteger key;
+        sq_getinteger(vm, -2, &key);
+        std::shared_ptr<sqarritem> newitem(new sqarritem());
+        newitem->type = sq_gettype(vm, -1);
+        newitem->index = key;
+        switch(sq_gettype(vm, -1)) {
+        case OT_INTEGER: {
+            SQInteger vali;
+            sq_getinteger(vm, -1, &vali);
+            std::unique_ptr<any> intp(new any((int) vali));
+            newitem->item = std::move(intp);
+            break;
+        }
+        case OT_BOOL: {
+            SQBool valb;
+            sq_getbool(vm, -1, &valb);
+            std::unique_ptr<any> boolp(new any((bool)(valb == SQTrue)));
+            newitem->item = std::move(boolp);
+            break;
+        }
+        case OT_STRING: {
+            const SQChar* str;
+            sq_getstring(vm, -1, &str);
+            newitem->string = (char*) malloc(sizeof(char)*(strlen(str)+1));
+            strcpy(newitem->string,str);
+        }
+        case OT_FLOAT: {
+            SQFloat valf;
+            sq_getfloat(vm, -1, &valf);
+            std::unique_ptr<any> valfp(new any((float) (valf)));
+            newitem->item = std::move(valfp);
+            break;
+        }
+        case OT_TABLE: {
+            std::unique_ptr<sqdict> sqi(new sqdict());
+            sqi->loadDict(vm);
+            newitem->dict = std::move(sqi);
+            break;
+        }
+        case OT_ARRAY: {
+            std::unique_ptr<sqarr> sqi(new sqarr());
+            sqi->loadArray(vm);
+            newitem->array =  std::move(sqi);
+            break;
+        }
+        default: {
+            log_warning << "Array item can't be serialized!" << std::endl;
+            break;
+        }
+        }
+        m_elements.push_back(std::move(newitem));
+        // Pop from stack
+        sq_pop(vm,2);
+    }
+    // pop the iterator
+    sq_pop(vm,1);
+}
+
+void
+sqarr::serialize(Writer* serializer) const {
+    // Method used for serializing an array
+    serializer->start_list("array-items");
+    for(const auto& item:m_elements) {
+        serializer->start_list("item");
+        serializer->write("key",item->index);
+        switch(item->type) {
+        case OT_INTEGER: {
+            try {
+                int vali =  *any_cast<int>(item->item.get());
+                serializer->write("value",vali);
+                serializer->write("type","int");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_BOOL: {
+            try {
+                bool valb =  any_cast<bool>(item->item.get());
+                serializer->write("value",valb);
+                serializer->write("type","bool");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_STRING: {
+            try {
+                serializer->write("value",item->string);
+                serializer->write("type","str");
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_FLOAT: {
+            try {
+                float vali =  *any_cast<float>(item->item.get());
+                serializer->write("value",vali);
+                serializer->write("type","float");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+        }
+        case OT_TABLE: {
+            sqdict val =  *item->dict;
+            serializer->write("type","table");
+            val.serialize(serializer);
+            break;
+        }
+        case OT_ARRAY: {
+            sqarr val =  *item->array;
+            serializer->write("type","arr");
+            val.serialize(serializer);
+            break;
+        }
+        default: {
+            log_warning << "Array item can't be serialized!" << std::endl;
+            break;
+        }
+        }
+        serializer->end_list("item");
+    }
+    serializer->end_list("array-items");
+}
+
+// Pushes array onto the vm stack
+void
+sqarr::get(HSQUIRRELVM vm) const {
+    log_debug << "Creating array" << std::endl;
+    // Push array to squirrel
+    sq_newarray (vm,0);
+    // Array is now on the stack
+    for(const auto& item:m_elements) {
+        // Get type and call the appropriate get method
+        switch(item->type) {
+        case OT_INTEGER: {
+            int val = *any_cast<int>(item->item.get());
+            log_debug << "Pushing " << val << std::endl;
+            sq_pushinteger(vm,val);
+            sq_arrayappend(vm, -2);
+            log_debug << "Pushed " << val << std::endl;
+            break;
+        }
+        case OT_BOOL: {
+            bool val = *any_cast<bool>(item->item.get());
+            sq_pushbool(vm,val);
+            sq_arrayappend(vm, -2);
+            break;
+        }
+        case OT_STRING: {
+
+            const SQChar* val = item->string;
+            // -1 indicates, that the length will  be calculated by the vm
+            sq_pushstring(vm,val,-1);
+            sq_arrayappend(vm, -2);
+            break;
+        }
+        case OT_FLOAT: {
+            float val = *any_cast<float>(item->item.get());
+            sq_pushinteger(vm,val);
+            sq_arrayappend(vm, -2);
+            break;
+        }
+        case OT_ARRAY: {
+            sqarr val =  *item->array;
+            log_debug << val.m_elements.size();
+            val.get(vm);
+
+            sq_arrayappend(vm, -2);
+
+            break;
+        }
+        case OT_TABLE: {
+            sqdict val = *item->dict;
+            val.get(vm);
+            sq_arrayappend(vm, -2);
+            break;
+        }
+        default: {
+            throw scripting::SquirrelError(vm, "Type not serializable");
+        }
+
+        }
+    }
+}
+
+void
+sqarr::load(const ReaderCollection& r) {
+    for(const auto& item:r.get_objects()) {
+        // Check that item title is "item"
+        if(!(item.get_name() == "item")) {
+            log_fatal << "Incorrect storage save data." << std::endl;
+            return;
+        }
+        ReaderMapping imap = item.get_mapping();
+        // Get key
+        int key;
+        imap.get("key",key);
+        // Get type
+        std::string typen;
+        imap.get("type",typen);
+        auto type = dictionary::str2type(typen);
+        std::shared_ptr<sqarritem> itemp(new sqarritem());
+        itemp->index = key;
+        log_debug << "Hello" << std::endl;
+
+        switch (type) {
+        case DICT_INT: {
+            int val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any(val));
+            itemp->item = std::move(container);
+            itemp->type = OT_INTEGER;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_STRING: {
+            log_debug << "Adding string item" << std::endl;
+            std::string val = "yeah";
+            imap.get("value",val);
+            char* str = (char*) malloc(sizeof(char)*(val.size()+1));
+            str[val.size()+1] = '\0';
+            strcpy(str,val.c_str());
+            itemp->string = str;
+            itemp->type = OT_STRING;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_BOOL: {
+            bool val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any( (bool) val));
+            itemp->item = std::move(container);
+            itemp->type = OT_BOOL;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_FLOAT: {
+            float val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any( (float) val));
+            itemp->item = std::move(container);
+            itemp->type = OT_FLOAT;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_TABLE: {
+            log_debug << "Adding table" << std::endl;
+            std::unique_ptr<sqdict> table(new sqdict());
+            ReaderCollection items;
+            imap.get("dict-items",items);
+            log_debug << "Loading objects" << std::endl;
+            table->load(items);
+            itemp->dict = std::move(table);
+            itemp->type = OT_TABLE;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_ARR: {
+            std::unique_ptr<sqarr> arrp(new sqarr());
+            ReaderCollection items;
+            imap.get("array-items",items);
+            arrp->load(items);
+            itemp->array = std::move(arrp);
+            itemp->type = OT_ARRAY;
+            m_elements.push_back(itemp);
+            break;
+        }
+        }
+    }
+}

--- a/src/util/sqarrayser.hpp
+++ b/src/util/sqarrayser.hpp
@@ -1,0 +1,81 @@
+//  SuperTux
+//  Copyright (C) 2016 Christian Hagemeier <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ *  Wrapper for squirrel arrays
+ * This class is used to store squirrel arrays, when they are stored.
+ *
+ */
+#ifndef HEADER_SUPERTUX_UTIL_SQARRAYSER_HPP
+#define HEADER_SUPERTUX_UTIL_SQARRAYSER_HPP
+#include <squirrel.h>
+#include <vector>
+#include <boost/any.hpp>
+#include "util/log.hpp"
+#include "util/writer.hpp"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <iostream>
+#include <memory>
+#include <boost/shared_ptr.hpp>
+#include "util/sqdictser.hpp"
+#include "util/reader_document.hpp"
+#include "util/reader_mapping.hpp"
+#include "util/reader_collection.hpp"
+
+class sqarr;
+class sqdict;
+
+class sqarritem {
+  public:
+    int index;
+
+    SQObjectType type;
+    std::unique_ptr<boost::any> item;
+    char* string; // If string is used
+    std::unique_ptr<sqdict> dict;
+    std::unique_ptr<sqarr> array;
+    explicit sqarritem():
+        index(),
+        type(),
+        item(),
+        string(NULL),
+        dict(),
+        array() {
+    };
+    sqarritem(const sqarritem&) = delete;
+    sqarritem& operator=(const sqarritem&) = delete;
+    ~sqarritem() {
+        if(string != NULL) {
+            free(string);
+        }
+    }
+};
+
+class sqarr {
+  public:
+    void loadArray(HSQUIRRELVM vm);
+    void serialize(Writer* serializer) const;
+    void get(HSQUIRRELVM vm) const;
+    void load(const ReaderCollection& r);
+    explicit sqarr():
+        m_elements() {
+    }
+    std::vector<std::shared_ptr<sqarritem>> m_elements;
+};
+
+#endif

--- a/src/util/sqdictser.cpp
+++ b/src/util/sqdictser.cpp
@@ -1,0 +1,291 @@
+#include "util/sqdictser.hpp"
+using boost::any;
+using boost::any_cast;
+
+void
+sqdict::loadDict(HSQUIRRELVM vm) {
+    // Iterate over the array in the vm
+    // first push 0 onto the stack
+    sq_pushnull(vm);
+    // then begin the iteration
+    while(SQ_SUCCEEDED(sq_next(vm,-2))) {
+        // Pop key
+        if(sq_gettype(vm, -2) != OT_STRING) {
+            log_warning << "Dict may only contain string keys!\n";
+            sq_throwerror(vm, _SC("Dict may only contain string keys!\n"));
+            continue;
+        }
+        // Pop value
+        const SQChar* key;
+        sq_getstring(vm, -2, &key);
+        std::shared_ptr<sqdictitem> newitem(new sqdictitem());
+        newitem->type = sq_gettype(vm, -1);
+        newitem->key = (char*) malloc(sizeof(char)*(strlen(key)+1));
+        strcpy(newitem->key,key);
+        newitem->key[strlen(key)] = '\0';
+        switch(sq_gettype(vm, -1)) {
+        case OT_INTEGER: {
+            SQInteger vali;
+            sq_getinteger(vm, -1, &vali);
+            std::unique_ptr<any> intp(new any((int) vali));
+            newitem->item = std::move(intp);
+            break;
+        }
+        case OT_BOOL: {
+            SQBool valb;
+            if(SQ_SUCCEEDED(sq_getbool(vm, -1, &valb))) {
+                std::unique_ptr<any> boolp(new any(valb == SQTrue));
+                newitem->item = std::move(boolp);
+            }
+        }
+        case OT_STRING: {
+            const SQChar* str;
+            sq_getstring(vm, -1, &str);
+            newitem->string = (char*) malloc(sizeof(char)*(strlen(str)+1));
+            strcpy(newitem->string,str);
+        }
+        case OT_FLOAT: {
+            SQFloat valf;
+            sq_getfloat(vm, -1, &valf);
+            std::unique_ptr<any> floatp(new any(static_cast<float> (valf)));
+            newitem->item = std::move(floatp);
+            break;
+        }
+        case OT_TABLE: {
+            std::unique_ptr<sqdict> sqi(new sqdict());
+            log_warning << "Recload "<< std::endl;
+            sqi->loadDict(vm);
+            newitem->dict =  std::move(sqi);
+            break;
+        }
+        case OT_ARRAY: {
+            std::unique_ptr<sqarr> sqi(new sqarr());
+            log_warning << "Recload "<< std::endl;
+            sqi->loadArray(vm);
+            newitem->arr =  std::move(sqi);
+            break;
+        }
+        default:
+            log_warning << "Array item can't be serialized!" << std::endl;
+            break;
+        }
+        m_elements.push_back(newitem);
+        // Pop from stack
+        sq_pop(vm,2);
+    }
+    // pop the iterator
+    sq_pop(vm,1);
+}
+
+void
+sqdict::serialize(Writer* serializer) const {
+    // Method used for serializing an array
+    serializer->start_list("dict-items");
+    for(const auto& item:m_elements) {
+        //continue;
+        serializer->start_list("item");
+        serializer->write("key",item->key);
+        switch(item->type) {
+        case OT_INTEGER: {
+            try {
+                const int vali =  *any_cast<int>(item->item.get());
+                serializer->write("value",vali);
+                serializer->write("type","int");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_BOOL: {
+            try {
+                const bool valb =  any_cast<bool>(item->item.get());
+                serializer->write("value",valb);
+                serializer->write("type","bool");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_STRING: {
+            try {
+                serializer->write("value",item->string);
+                serializer->write("type","str");
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+            break;
+        }
+        case OT_FLOAT: {
+            try {
+                const int vali =  *any_cast<float>(item->item.get());
+                serializer->write("value",vali);
+                serializer->write("type","float");
+                break;
+            } catch ( const std::exception& e ) {
+                log_warning << e.what() << std::endl;
+            }
+        }
+        case OT_TABLE: {
+            auto val =  *item->dict;
+            serializer->write("type","table");
+            val.serialize(serializer);
+            break;
+        }
+        case OT_ARRAY: {
+            auto val =  *item->arr;
+            serializer->write("type","arr");
+            val.serialize(serializer);
+            break;
+        }
+        default:
+            log_warning << "Array item can't be serialized!" << std::endl;
+            break;
+        }
+        serializer->end_list("item");
+    }
+    serializer->end_list("dict-items");
+}
+/**
+ *  Method for loading a dictionary (table) stored in memory onto the vm stack
+ *
+ */
+void
+sqdict::get(HSQUIRRELVM vm) const {
+    // Create the dictionary
+    sq_newtable(vm);
+    // Create the slots
+    for(const auto& elem:m_elements) {
+        // Push key with unknown length (-1 is used for indicating strlen call)
+        sq_pushstring(vm,elem->key,-1);
+        switch(elem->type) {
+        case OT_INTEGER: {
+            const int val = *any_cast<int>(elem->item.get());
+            log_debug << "Pushing " << val << std::endl;
+            sq_pushinteger(vm,val);
+            break;
+        }
+        case OT_BOOL: {
+            const bool val = *any_cast<bool>(elem->item.get());
+            sq_pushbool(vm,val == SQTrue);
+            break;
+        }
+        case OT_STRING: {
+
+            const SQChar* val = elem->string;
+            // -1 indicates, that the length will  be calculated by the vm
+            sq_pushstring(vm,val,-1);
+            break;
+        }
+        case OT_FLOAT: {
+            const int val = *any_cast<float>(elem->item.get());
+            sq_pushinteger(vm,val);
+            break;
+        }
+        case OT_ARRAY: {
+            auto val =  *elem->arr;
+            log_debug << val.m_elements.size();
+            val.get(vm);
+            break;
+        }
+        case OT_TABLE: {
+            auto val = *elem->dict;
+            val.get(vm);
+            break;
+        }
+
+        default: {
+            throw scripting::SquirrelError(vm, "Type not serializable");
+        }
+        }
+        if(SQ_FAILED(sq_createslot(vm, -3)))
+            throw scripting::SquirrelError(vm, "Couldn't create new index");
+    }
+}
+
+void sqdict::load(const ReaderCollection& coll) {
+    // Iterate over items
+    for(const auto& item:coll.get_objects()) {
+        // Check that item title is "item"
+        log_debug << "Adding to dict " << std::endl;
+        if(!(item.get_name() == "item")) {
+            log_fatal << "Incorrect storage save data." << std::endl;
+            return;
+        }
+        ReaderMapping imap = item.get_mapping();
+        // Get key
+        std::string key;
+        imap.get("key",key);
+        // Get type
+        std::string typen;
+        imap.get("type",typen);
+        auto type = dictionary::str2type(typen);
+        std::shared_ptr<sqdictitem> itemp(new sqdictitem());
+        char* tk = (char *) malloc(sizeof(char)*(key.size()+1));
+        tk[key.size()+1] = '\0';
+        strcpy(tk,key.c_str());
+        itemp->key = tk;
+        log_debug << "Hello";
+        switch (type) {
+        case DICT_INT: {
+            int val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any(val));
+            itemp->item = std::move(container);
+            itemp->type = OT_INTEGER;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_STRING: {
+            std::string val;
+            imap.get("value",val);
+            char* str = (char*) malloc(sizeof(char)*(val.size()+1));
+            str[val.size()+1] = '\0';
+            strcpy(str,val.c_str());
+            itemp->string = str;
+            itemp->type = OT_STRING;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_BOOL: {
+            bool val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any( (bool) val));
+            itemp->item = std::move(container);
+            itemp->type = OT_BOOL;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_FLOAT: {
+            float val;
+            imap.get("value",val);
+            std::unique_ptr<any> container(new any( (float) val));
+            itemp->item = std::move(container);
+            itemp->type = OT_FLOAT;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_TABLE: {
+            std::unique_ptr<sqdict> table(new sqdict());
+            ReaderCollection items;
+            imap.get("dict-items",items);
+            table->load(items);
+            itemp->dict = std::move(table);
+            itemp->type = OT_TABLE;
+            m_elements.push_back(itemp);
+            break;
+        }
+        case DICT_ARR: {
+            std::unique_ptr<sqarr> arrp(new sqarr());
+            ReaderCollection items;
+            imap.get("array-items",items);
+            arrp->load(items);
+            itemp->arr = std::move(arrp);
+            itemp->type = OT_ARRAY;
+            m_elements.push_back(itemp);
+            break;
+        }
+        }
+    }
+}

--- a/src/util/sqdictser.hpp
+++ b/src/util/sqdictser.hpp
@@ -1,0 +1,65 @@
+#ifndef HEADER_SUPERTUX_UTIL_SQDICTSER_HPP
+#define HEADER_SUPERTUX_UTIL_SQDICTSER_HPP
+
+#include <squirrel.h>
+#include <vector>
+#include <boost/any.hpp>
+#include "util/log.hpp"
+#include "util/writer.hpp"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <iostream>
+#include <memory>
+#include <boost/shared_ptr.hpp>
+#include "util/sqarrayser.hpp"
+#include "scripting/squirrel_error.hpp"
+#include "util/reader_document.hpp"
+#include "util/reader_mapping.hpp"
+#include "util/reader_collection.hpp"
+#include "util/sqarrayser.hpp"
+#include "util/sqdictser.hpp"
+#include "util/dictionary.hpp"
+class sqdict;
+class sqarr;
+class sqdictitem {
+  public:
+    char* key;
+    ~sqdictitem() {
+        if(string != NULL) {
+            free(string);
+        }
+        if(key != NULL) {
+            free(key);
+        }
+    }
+    SQObjectType type;
+    std::unique_ptr<boost::any> item;
+    char* string; // If string is used
+    std::unique_ptr<sqdict> dict;
+    std::unique_ptr<sqarr> arr;
+    explicit sqdictitem():
+        key(),
+        type(),
+        item(),
+        string(NULL),
+        dict(),
+        arr() {
+    };
+    sqdictitem(const sqdictitem&) = delete;
+    sqdictitem& operator=(const sqdictitem&) = delete;
+};
+
+class sqdict {
+  public:
+    void loadDict(HSQUIRRELVM vm);
+    void serialize(Writer* serializer) const;
+    void get(HSQUIRRELVM vm) const;
+    void load(const ReaderCollection& r);
+    explicit sqdict():
+        m_elements() {
+    }
+  private:
+    std::vector<std::shared_ptr<sqdictitem>> m_elements;
+};
+#endif


### PR DESCRIPTION
Currently scripts can only store data by modifying the savegamefile directly.
Now the functions store and load allow scripts to easily preserve data.
Syntax: store(varname,value), where varname is a string, and value is a
serializable object. A squirrel object is serializible iff it is of type
Array, Table, String, Int, Bool, Float. Arrays and Tables are also serializable,
iff they only contain serializible items (eg. Array of Array of Int is serializable).
To load an object the function load(varname) is provided.

Serialization
Is currently done in the form of S-Expressions.  The file is in the same
directory as the savegame file and has the extension .sss

Implementation
When a object is stored it is tranformed into a internal data structure
representing arrays (sqarray in sqarrayser.cpp) , tables (sqdict in sqdictser.cpp)
 and scalar values (stored using boost::any container). The dictionary class
provides a general storage of names and the associated item in the internal
data structure. When a worldmap is loaded a new dictionary is created,
when a worldmap is left a dictionary is destroyed, and the file is created.

The internal data structures for arrays and tables  are implemented as classes,
which all provide the following methods
- load(ReaderCollection& r)
  
  Used for loading from the file
- get(HSQUIRRELVM v)
  
  Used for pushing onto the stack
- serialize(Writer\* serialize)
  
  Used for serializing the object
- loadArray(HSQUIRRELVM v) (or loadDict)
  
  Used for loading from squirrel

Issues / Further Modifications

-Currently only basic types are storable. Extend it to "special" C++
 Classes which e.g. implement an Interface Storable or use an auto-
 matically generated wrapper for serializing some classes.

-Add option to store from the game and make such stored items "private".

Closes #530
