### PR TITLE
Revert "Revert sprite changes in squirrel table commits"

### DIFF
--- a/src/worldmap/sprite_change.cpp
+++ b/src/worldmap/sprite_change.cpp
@@ -66,6 +66,12 @@ SpriteChange::update(float )
 {
 }
 
+bool
+SpriteChange::show_stay_action() const
+{
+  return in_stay_action;
+}
+
 void
 SpriteChange::set_stay_action()
 {
@@ -73,12 +79,12 @@ SpriteChange::set_stay_action()
 }
 
 void
-SpriteChange::clear_stay_action()
+SpriteChange::clear_stay_action(bool propagate)
 {
   in_stay_action = false;
 
   // if we are in a stay_group, also clear all stay actions in this group
-  if (!stay_group.empty()) {
+  if (!stay_group.empty() && propagate) {
     for (auto& sc : all_sprite_changes) {
       if (sc->stay_group != stay_group) continue;
       sc->in_stay_action = false;

--- a/src/worldmap/sprite_change.hpp
+++ b/src/worldmap/sprite_change.hpp
@@ -45,8 +45,14 @@ public:
 
   /**
    * Deactivates the SpriteChange's stay action, if applicable
+   * @param propagate : Also change stay actions in the same stay group
    */
-  void clear_stay_action();
+  void clear_stay_action(bool propagate = true);
+
+  /*
+   * Get the current value of in_stay_action
+   */
+   bool show_stay_action() const;
 
 public:
   Vector pos;

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -818,7 +818,7 @@ WorldMap::draw_status(DrawingContext& context)
       }
     }
 
-    for(auto special_tile : special_tiles) {
+    for(const auto& special_tile : special_tiles) {
       if (special_tile->pos == tux->get_tile_pos()) {
         /* Display an in-map message in the map, if any as been selected */
         if(!special_tile->map_message.empty() && !special_tile->passive_message)
@@ -954,6 +954,30 @@ WorldMap::save_state()
       throw std::runtime_error("failed to create '" + name + "' table entry");
     }
 
+    // sprite change objects:
+    if(sprite_changes.size() > 0)
+    {
+      sq_pushstring(vm, "sprite-changes", -1);
+      sq_newtable(vm);
+
+      for(const auto& sc : sprite_changes)
+      {
+        auto key = std::to_string(int(sc->pos.x)) + "_" +
+                   std::to_string(int(sc->pos.y));
+        sq_pushstring(vm, key.c_str(), -1);
+        sq_newtable(vm);
+        store_bool(vm, "show-stay-action", sc->show_stay_action());
+        if(SQ_FAILED(sq_createslot(vm, -3)))
+        {
+          throw std::runtime_error("failed to create '" + name + "' table entry");
+        }
+      }
+      if(SQ_FAILED(sq_createslot(vm, -3)))
+      {
+        throw std::runtime_error("failed to create '" + name + "' table entry");
+      }
+    }
+
     // levels...
     sq_pushstring(vm, "levels", -1);
     sq_newtable(vm);
@@ -1043,6 +1067,33 @@ WorldMap::load_state()
 
     // leave levels table
     sq_pop(vm, 1);
+
+    if(sprite_changes.size() > 0)
+    {
+      // load sprite change action:
+      get_table_entry(vm, "sprite-changes");
+      for(const auto& sc : sprite_changes)
+      {
+        auto key = std::to_string(int(sc->pos.x)) + "_" +
+                   std::to_string(int(sc->pos.y));
+        sq_pushstring(vm, key.c_str(), -1);
+        if(SQ_SUCCEEDED(sq_get(vm, -2))) {
+          bool show_stay_action = read_bool(vm, "show-stay-action");
+          if(show_stay_action)
+          {
+            sc->set_stay_action();
+          }
+          else
+          {
+            sc->clear_stay_action(/* propagate = */ false);
+          }
+          sq_pop(vm, 1);
+        }
+      }
+
+      // Leave sprite changes table
+      sq_pop(vm, 1);
+    }
 
     // load overall statistics
     total_stats.unserialize_from_squirrel(vm);


### PR DESCRIPTION
This reverts commit f70f8a1e99e3ee890c4ba996479a382a60f78eac.

This is interesting, because after clearing my profile directory and reverting the commits, I am not getting any errors. However, I'd like you guys to thoroughly test the change. If possible, please backup your profile directory so that you can restore it in case something gets messed up.

Thanks!