### PR TITLE
EditorLevelMenu: use -2 as value to check for OK

### DIFF
--- a/src/supertux/menu/editor_level_menu.cpp
+++ b/src/supertux/menu/editor_level_menu.cpp
@@ -48,7 +48,7 @@ EditorLevelMenu::EditorLevelMenu() :
   }
 
   add_hl();
-  add_entry(-1, _("OK"));
+  add_entry(-2, _("OK"));
 }
 
 EditorLevelMenu::~EditorLevelMenu()
@@ -62,7 +62,7 @@ EditorLevelMenu::~EditorLevelMenu()
 void
 EditorLevelMenu::menu_action(MenuItem* item)
 {
-  if(item->id == -1)
+  if(item->id == -2)
   {
     auto level = Editor::current()->get_level();
     if(!level->name.empty() && !level->author.empty() && !level->license.empty())


### PR DESCRIPTION
This is an attempt to fix an issue where certain values could not be changed in
the level menu. It happened because c8c330a93b89f0bf3b67bb3cd9138004aa7a3435
introduced a check for certain values upon clicking "OK". However, it did that
by checking for clicks on menu items with id = -1, which was also used for
certain other menu items. That caused the pop up menu of those menu items to
disappear immediately upon attempting to enter them.

Closes SuperTux/supertux#577 ("Editor: changing a worldmap's tileset does not
work")