### PR TITLE
Fix Squirrel Level Edit Bug

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -56,6 +56,7 @@
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics) :
   reset_button(false),
   level(),
+  old_level(),
   statistics_backdrop(Surface::create("images/engine/menu/score-backdrop.png")),
   scripts(),
   currentsector(nullptr),
@@ -128,6 +129,7 @@ GameSession::restart_level(bool after_death)
   }
 
   try {
+    old_level = std::move(level);
     level = LevelParser::from_file(levelfile);
     level->stats.total_coins = level->get_total_coins();
     level->stats.total_badguys = level->get_total_badguys();

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -110,6 +110,7 @@ private:
   void on_escape_press();
 
   std::unique_ptr<Level> level;
+  std::unique_ptr<Level> old_level;
   SurfacePtr statistics_backdrop;
 
   // scripts


### PR DESCRIPTION
Using the function Level.edit(false) through a switch when in
edit mode currently causes the game to crash. This is due to
the current Level object being destroyed when the edit mode is
left, but squirrel is still referencing / trying to use it, and
this leads to the seg fault.

The Fix is, that the GameSession object keeps a reference to the
last delteted level, as an extra member variable, thus squirrel
can still access the level object.

Fixes #207