### PR TITLE
(WIP?) Cannon no longer unfreezable by walking at it

### DIFF
--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -167,7 +167,10 @@ Dispenser::collision(GameObject& other, const CollisionHit& hit)
       return FORCE_MOVE;
     }
     if(frozen){
-      unfreeze();
+      if(type != DT_CANNON)
+      {
+        unfreeze();
+      }  
     }
     return FORCE_MOVE;
   }

--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -166,11 +166,8 @@ Dispenser::collision(GameObject& other, const CollisionHit& hit)
       collision_squished(*player);
       return FORCE_MOVE;
     }
-    if(frozen){
-      if(type != DT_CANNON)
-      {
-        unfreeze();
-      }  
+    if(frozen && type != DT_CANNON){
+      unfreeze();
     }
     return FORCE_MOVE;
   }


### PR DESCRIPTION
This fixes #604. In my opinion at least for canons it is not expected behaviour for canons to behave that way. An open question is, if rocket launchers should break when running against them too.