### PR TITLE
Stop looping sounds when dead

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -306,6 +306,7 @@ Player::update(float elapsed_time)
   no_water = true;
 
   if(dying && dying_timer.check()) {
+    Sector::current()->stop_looping_sounds();
     set_bonus(NO_BONUS, true);
     dead = true;
     return;


### PR DESCRIPTION
Previously, the roaring of the haywire would persist.