### PR TITLE
Added Sound Volume and Music Volume options

### DIFF
--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -19,7 +19,9 @@
 #include "audio/sound_manager.hpp"
 
 OpenALSoundSource::OpenALSoundSource() :
-  source()
+  source(),
+  _gain(1.0f),
+  _volume(1.0f)
 {
   alGenSources(1, &source);
   SoundManager::check_al_error("Couldn't create audio source: ");
@@ -113,7 +115,8 @@ OpenALSoundSource::set_velocity(const Vector& velocity)
 void
 OpenALSoundSource::set_gain(float gain)
 {
-  alSourcef(source, AL_GAIN, gain);
+  alSourcef(source, AL_GAIN, gain * _volume);
+  _gain = gain;
 }
 
 void
@@ -126,6 +129,13 @@ void
 OpenALSoundSource::set_reference_distance(float distance)
 {
   alSourcef(source, AL_REFERENCE_DISTANCE, distance);
+}
+
+void
+OpenALSoundSource::set_volume(float volume)
+{
+  _volume = volume;
+  alSourcef(source, AL_GAIN, _gain * _volume);
 }
 
 /* EOF */

--- a/src/audio/openal_sound_source.hpp
+++ b/src/audio/openal_sound_source.hpp
@@ -43,6 +43,7 @@ public:
   virtual void set_position(const Vector& position);
   virtual void set_velocity(const Vector& position);
   virtual void set_reference_distance(float distance);
+  virtual void set_volume(float volume);
 
 protected:
   friend class SoundManager;
@@ -52,6 +53,9 @@ protected:
 private:
   OpenALSoundSource(const OpenALSoundSource&) = delete;
   OpenALSoundSource& operator=(const OpenALSoundSource&) = delete;
+
+  float _gain;
+  float _volume;
 };
 
 #endif

--- a/src/audio/sound_manager.cpp
+++ b/src/audio/sound_manager.cpp
@@ -31,11 +31,13 @@ SoundManager::SoundManager() :
   device(0),
   context(0),
   sound_enabled(false),
+  sound_volume(0),
   buffers(),
   sources(),
   update_list(),
   music_source(),
   music_enabled(false),
+  music_volume(0),
   current_music()
 {
   try {
@@ -111,6 +113,7 @@ SoundManager::intern_create_sound_source(const std::string& filename)
   assert(sound_enabled);
 
   std::unique_ptr<OpenALSoundSource> source(new OpenALSoundSource);
+  source->set_volume(sound_volume / 100.0f);
 
   ALuint buffer;
 
@@ -271,6 +274,13 @@ SoundManager::stop_music(float fadetime)
 }
 
 void
+SoundManager::set_music_volume(int volume)
+{
+  music_volume = volume;
+  if(music_source != NULL) music_source->set_volume(volume / 100.0f);
+}
+
+void
 SoundManager::play_music(const std::string& filename, bool fade)
 {
   if(filename == current_music && music_source != NULL)
@@ -299,6 +309,7 @@ SoundManager::play_music(const std::string& filename, bool fade)
     newmusic->set_sound_file(load_sound_file(filename));
     newmusic->set_looping(true);
     newmusic->set_relative(true);
+    newmusic->set_volume(music_volume / 100.0f);
     if(fade)
       newmusic->set_fading(StreamSoundSource::FadingOn, .5f);
     newmusic->play();
@@ -351,6 +362,15 @@ SoundManager::stop_sounds()
 {
   for(auto& source : sources) {
     source->stop();
+  }
+}
+
+void
+SoundManager::set_sound_volume(int volume)
+{
+  sound_volume = volume;
+  for(auto& source : sources) {
+    source->set_volume(volume / 100.0f);
   }
 }
 

--- a/src/audio/sound_manager.hpp
+++ b/src/audio/sound_manager.hpp
@@ -68,10 +68,12 @@ public:
   void pause_music(float fadetime = 0);
   void resume_music(float fadetime = 0);
   void stop_music(float fadetime = 0);
+  void set_music_volume(int volume);
 
   void pause_sounds();
   void resume_sounds();
   void stop_sounds();
+  void set_sound_volume(int volume);
 
   bool is_music_enabled() const { return music_enabled; }
   bool is_sound_enabled() const { return sound_enabled; }
@@ -109,6 +111,7 @@ private:
   ALCdevice* device;
   ALCcontext* context;
   bool sound_enabled;
+  int sound_volume;
 
   typedef std::map<std::string, ALuint> SoundBuffers;
   SoundBuffers buffers;
@@ -121,6 +124,7 @@ private:
   std::unique_ptr<StreamSoundSource> music_source;
 
   bool music_enabled;
+  int music_volume;
   std::string current_music;
 
 private:

--- a/src/audio/stream_sound_source.hpp
+++ b/src/audio/stream_sound_source.hpp
@@ -32,6 +32,7 @@ public:
   enum FadeState { NoFading, FadingOn, FadingOff, FadingPause, FadingResume };
 
   void set_fading(FadeState state, float fadetime);
+
   FadeState get_fade_state() const
   {
     return fade_state;

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -41,8 +41,8 @@ CommandLineArguments::CommandLineArguments() :
   video(),
   show_fps(),
   show_player_pos(),
-  sound_enabled(),
-  music_enabled(),
+  sound_volume(),
+  music_volume(),
   start_level(),
   enable_script_debugger(),
   start_demo(),
@@ -294,11 +294,11 @@ CommandLineArguments::parse_args(int argc, char** argv)
     }
     else if (arg == "--disable-sound" || arg == "--disable-sfx")
     {
-      sound_enabled = false;
+      sound_volume = 0;
     }
     else if (arg == "--disable-music")
     {
-      music_enabled = false;
+      music_volume = 0;
     }
     else if (arg == "--play-demo")
     {
@@ -392,8 +392,8 @@ CommandLineArguments::merge_into(Config& config)
   merge_option(video);
   merge_option(show_fps);
   merge_option(show_player_pos);
-  merge_option(sound_enabled);
-  merge_option(music_enabled);
+  merge_option(sound_volume);
+  merge_option(music_volume);
   merge_option(start_level);
   merge_option(enable_script_debugger);
   merge_option(start_demo);

--- a/src/supertux/command_line_arguments.hpp
+++ b/src/supertux/command_line_arguments.hpp
@@ -59,8 +59,8 @@ public:
   // boost::optional<bool> try_vsync;
   boost::optional<bool> show_fps;
   boost::optional<bool> show_player_pos;
-  boost::optional<bool> sound_enabled;
-  boost::optional<bool> music_enabled;
+  boost::optional<int> sound_volume;
+  boost::optional<int> music_volume;
 
   // boost::optional<int> random_seed;
 

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -39,8 +39,8 @@ Config::Config() :
   try_vsync(true),
   show_fps(false),
   show_player_pos(false),
-  sound_enabled(true),
-  music_enabled(true),
+  sound_volume(50),
+  music_volume(50),
   random_seed(0), // set by time(), by default (unless in config)
   start_level(),
   enable_script_debugger(false),
@@ -113,8 +113,8 @@ Config::load()
 
   ReaderMapping config_audio_lisp;
   if(config_lisp.get("audio", config_audio_lisp)) {
-    config_audio_lisp.get("sound_enabled", sound_enabled);
-    config_audio_lisp.get("music_enabled", music_enabled);
+    config_audio_lisp.get("sound_volume", sound_volume);
+    config_audio_lisp.get("music_volume", music_volume);
   }
 
   ReaderMapping config_control_lisp;
@@ -196,8 +196,8 @@ Config::save()
   writer.end_list("video");
 
   writer.start_list("audio");
-  writer.write("sound_enabled", sound_enabled);
-  writer.write("music_enabled", music_enabled);
+  writer.write("sound_volume", sound_volume);
+  writer.write("music_volume", music_volume);
   writer.end_list("audio");
 
   writer.start_list("control");

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -57,8 +57,8 @@ public:
   bool try_vsync;
   bool show_fps;
   bool show_player_pos;
-  bool sound_enabled;
-  bool music_enabled;
+  int sound_volume;
+  int music_volume;
 
   /** initial random seed.  0 ==> set from time() */
   int random_seed;
@@ -68,7 +68,7 @@ public:
   bool enable_script_debugger;
   std::string start_demo;
   std::string record_demo;
-  
+
   /** this variable is set if tux should spawn somewhere which isn't the "main" spawn point*/
   boost::optional<Vector> tux_spawn_pos;
 

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -218,7 +218,7 @@ public:
 	if (FileSystem::is_directory(olduserdir)) {
 	  boost::filesystem::path olduserpath(olduserdir);
 	  boost::filesystem::path userpath(userdir);
-	  
+
 	  boost::filesystem::directory_iterator end_itr;
 
 	  bool success = true;
@@ -254,7 +254,7 @@ public:
     if (!FileSystem::is_directory(userdir))
     {
 	  FileSystem::mkdir(userdir);
-	  log_info << "Created SuperTux userdir: " << userdir << std::endl;  
+	  log_info << "Created SuperTux userdir: " << userdir << std::endl;
     }
 
     if (!PHYSFS_setWriteDir(userdir.c_str()))
@@ -366,8 +366,10 @@ Main::launch_game()
 
   timelog("audio");
   SoundManager sound_manager;
-  sound_manager.enable_sound(g_config->sound_enabled);
-  sound_manager.enable_music(g_config->music_enabled);
+  sound_manager.enable_sound(g_config->sound_volume > 0 ? true : false);
+  sound_manager.enable_music(g_config->music_volume > 0 ? true : false);
+  sound_manager.set_sound_volume(g_config->sound_volume);
+  sound_manager.set_music_volume(g_config->music_volume);
 
   Console console(console_buffer);
 
@@ -458,7 +460,7 @@ Main::run(int argc, char** argv)
 	freopen((prefpath + "/console.out").c_str(), "a", stdout);
 	freopen((prefpath + "/console.err").c_str(), "a", stderr);
 #endif
- 
+
   int result = 0;
 
   try

--- a/src/supertux/menu/options_menu.hpp
+++ b/src/supertux/menu/options_menu.hpp
@@ -32,10 +32,14 @@ class OptionsMenu : public Menu
     int next_magnification;
     int next_aspect_ratio;
     int next_resolution;
+    int next_sound_volume;
+    int next_music_volume;
 
     std::vector<std::string> magnifications;
     std::vector<std::string> aspect_ratios;
     std::vector<std::string> resolutions;
+    std::vector<std::string> sound_volumes;
+    std::vector<std::string> music_volumes;
 };
 
 #endif


### PR DESCRIPTION
User can select between 0%, 25%, 50%, 75% and 100%
When sound or music are 0% they are disabled
Removed sound_enabled and music_enabled from config
Replaced those with sound_volume and music_volume

Closes #273