### PR TITLE
Fix plural forms handling

### DIFF
--- a/makepot.sh
+++ b/makepot.sh
@@ -3,7 +3,7 @@
 package_name="SuperTux"
 package_version="$(git describe --tags --match "?[0-9]*.[0-9]*.[0-9]*")"
 
-xgettext --keyword='_' -C -o data/locale/main.pot \
+xgettext --keyword='_' --keyword='__:1,2' -C -o data/locale/main.pot \
   $(find src -name "*.cpp" -or -name "*.hpp") \
   --add-comments=l10n \
   --package-name="${package_name}" --package-version="${package_version}" \

--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -105,6 +105,16 @@ std::string _(const std::string& text)
   return translate(text);
 }
 
+std::string translate_plural(const std::string& text, const std::string& text_plural, int num)
+{
+  return g_dictionary_manager->get_dictionary().translate_plural(text, text_plural, num);
+}
+
+std::string __(const std::string& text, const std::string& text_plural, int num)
+{
+  return translate_plural(text, text_plural, num);
+}
+
 void display_text_file(const std::string& filename)
 {
   ScreenManager::current()->push_screen(std::unique_ptr<Screen>(new TextScroller(filename)));

--- a/src/scripting/functions.hpp
+++ b/src/scripting/functions.hpp
@@ -107,6 +107,10 @@ void abort_screenfade();
 std::string translate(const std::string& text);
 std::string _(const std::string& text);
 
+std::string translate_plural(const std::string& text, const std::string&
+    text_plural, int num);
+std::string __(const std::string& text, const std::string& text_plural, int num);
+
 /**
  * Load a script file and executes it. This is typically used to import
  * functions from external files.

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -4889,6 +4889,78 @@ static SQInteger __wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger translate_plural_wrapper(HSQUIRRELVM vm)
+{
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg1;
+  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a string"));
+    return SQ_ERROR;
+  }
+
+  SQInteger arg2;
+  if(SQ_FAILED(sq_getinteger(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a integer"));
+    return SQ_ERROR;
+  }
+
+  try {
+    std::string return_value = scripting::translate_plural(arg0, arg1, static_cast<int> (arg2));
+
+    sq_pushstring(vm, return_value.c_str(), return_value.size());
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'translate_plural'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger ___wrapper(HSQUIRRELVM vm)
+{
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg1;
+  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a string"));
+    return SQ_ERROR;
+  }
+
+  SQInteger arg2;
+  if(SQ_FAILED(sq_getinteger(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a integer"));
+    return SQ_ERROR;
+  }
+
+  try {
+    std::string return_value = scripting::__(arg0, arg1, static_cast<int> (arg2));
+
+    sq_pushstring(vm, return_value.c_str(), return_value.size());
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function '__'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger import_wrapper(HSQUIRRELVM vm)
 {
   HSQUIRRELVM arg0 = vm;
@@ -6223,6 +6295,20 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function '_'");
+  }
+
+  sq_pushstring(v, "translate_plural", -1);
+  sq_newclosure(v, &translate_plural_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tssi");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'translate'");
+  }
+
+  sq_pushstring(v, "__", -1);
+  sq_newclosure(v, &___wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tssi");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function '__'");
   }
 
   sq_pushstring(v, "import", -1);

--- a/src/supertux/menu/editor_levelset_select_menu.cpp
+++ b/src/supertux/menu/editor_levelset_select_menu.cpp
@@ -18,6 +18,7 @@
 
 #include <physfs.h>
 #include <sstream>
+#include <boost/format.hpp>
 
 #include "editor/editor.hpp"
 #include "gui/menu_item.hpp"
@@ -76,7 +77,9 @@ EditorLevelsetSelectMenu::EditorLevelsetSelectMenu() :
                           new Levelset(level_world, /* recursively = */ true));
       int level_count = levelset->get_num_levels();
       std::ostringstream level_title;
-      level_title << title << " (" << level_count << " " << _("levels") << ")";
+      level_title << title << " (" <<
+        boost::format(__("%d level", "%d levels", level_count)) % level_count <<
+        ")";
       add_entry(i++, level_title.str());
       m_contrib_worlds.push_back(level_world);
     }

--- a/src/util/gettext.hpp
+++ b/src/util/gettext.hpp
@@ -36,12 +36,24 @@ extern std::unique_ptr<tinygettext::DictionaryManager> g_dictionary_manager;
  * http://www.mihai-nita.net/article.php?artID=20060430a
  *
  * Bad:
- *     std::string msg = _("You collected ") + num + _(" coins");
+ *     std::string greeting = _("Hello ") + name + _("!");
+ *     std::cout << _("Hello ") << name << _("!");
+ * Good:
+ *     #include <boost/format.hpp>
+ *     std::string greeting = str(boost::format(_("Hello %s!")) % name);
+ *     std::cout << boost::format(_("Hello %s!")) % name;
+ *
+ * If you need singular and plural forms use __ instead of _ and boost::format
+ * if necessary.
+ *
+ * https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+ *
+ * Bad:
  *     std::cout << _("You collected ") << num << _(" coins");
  * Good:
  *     #include <boost/format.hpp>
- *     std::string msg = str(boost::format(_("You collected %d coins")) % num);
- *     std::cout << boost::format(_("You collected %d coins")) % num;
+ *     std::cout << boost::format(__("You collected %d coin",
+ *                                   "You collected %d coins", num)) % num;
  */
 
 static inline std::string _(const std::string& message)
@@ -53,6 +65,24 @@ static inline std::string _(const std::string& message)
   else
   {
     return message;
+  }
+}
+
+static inline std::string __(const std::string& message,
+    const std::string& message_plural, int num)
+{
+  if (g_dictionary_manager)
+  {
+    return g_dictionary_manager->get_dictionary().translate_plural(message,
+        message_plural, num);
+  }
+  else if (num == 1)
+  {
+    return message;
+  }
+  else
+  {
+    return message_plural;
   }
 }
 


### PR DESCRIPTION
Plural form is needed in English and other languages with different kind of
rules. Also translation for level editor's levelset select menu was lacking
necessary context for some languages.
