### PR TITLE
Use a bitfield for ObjectOption flags, addresses issue #558

### DIFF
--- a/src/editor/object_menu.cpp
+++ b/src/editor/object_menu.cpp
@@ -32,7 +32,7 @@ ObjectMenu::ObjectMenu(GameObject *go) :
   add_label(os.name);
   add_hl();
   for(auto& oo : os.options) {
-    if(!oo.visible) {
+    if(!(oo.flags & OPTION_VISIBLE)) {
       continue;
     }
 

--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -20,13 +20,12 @@
 #include "editor/object_option.hpp"
 
 ObjectOption::ObjectOption(MenuItemKind ip_type, const std::string& text_, void* ip,
-                           const std::string& key_, bool visible_, bool allow_empty_) :
+                           const std::string& key_, int flags_) :
   type(ip_type),
   text(text_),
   option(ip),
   key(key_),
-  visible(visible_),
-  allow_empty(allow_empty_),
+  flags(flags_),
   select()
 {
   select.clear();

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -24,21 +24,23 @@
 #include "util/gettext.hpp"
 #include "video/color.hpp"
 
+// ObjectOption bitfield flags
+#define OPTION_ALLOW_EMPTY (1 << 0)
+#define OPTION_VISIBLE (1 << 1)
+
 class ObjectOption
 {
   public:
     ObjectOption(MenuItemKind ip_type, const std::string& text_, void* ip,
-                 const std::string& key_ = std::string(), bool visible_ = true, bool allow_empty_ = true);
+                 const std::string& key_ = std::string(), int flags_ = (OPTION_ALLOW_EMPTY | OPTION_VISIBLE));
     ~ObjectOption();
 
     MenuItemKind type;
     std::string text;
     void* option;
     std::string key;
-    // Visible in object options
-    bool visible;
-    // Allow empty value?
-    bool allow_empty;
+    int flags;
+
     bool is_savable() const {
       return !key.empty();
     }
@@ -50,8 +52,7 @@ class ObjectOption
       text(blb.text),
       option(blb.option),
       key(blb.key),
-      visible(blb.visible),
-      allow_empty(blb.allow_empty),
+      flags(blb.flags),
       select(blb.select)
     { /* blb-ost */ }
 
@@ -62,8 +63,7 @@ class ObjectOption
       option = blb.option;
       select = blb.select;
       key = blb.key;
-      visible = blb.visible;
-      allow_empty = blb.allow_empty;
+      flags = blb.flags;
       return *this;
     }
 

--- a/src/editor/tip.cpp
+++ b/src/editor/tip.cpp
@@ -41,7 +41,7 @@ Tip::Tip(GameObject* object) :
   header = os.name;
 
   for(const auto& oo : os.options) {
-    if (oo.type != MN_REMOVE && oo.visible) {
+    if (oo.type != MN_REMOVE && (oo.flags & OPTION_VISIBLE)) {
       strings.push_back(oo.text + ": " + oo.to_string());
     }
   }

--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -181,7 +181,7 @@ Background::get_settings() {
   result.options.push_back( ObjectOption(MN_NUMFIELD, _("Speed x"), &speed, "speed"));
   result.options.push_back( ObjectOption(MN_NUMFIELD, _("Speed y"), &speed_y));
 
-  ObjectOption img(MN_FILE, _("Top image"), &imagefile_top, "image-top", true, false);
+  ObjectOption img(MN_FILE, _("Top image"), &imagefile_top, "image-top", (OPTION_VISIBLE));
   img.select.push_back(".png");
   img.select.push_back(".jpg");
   img.select.push_back(".gif");
@@ -189,7 +189,7 @@ Background::get_settings() {
   result.options.push_back(img);
   ObjectOption img2(MN_FILE, _("Image"), &imagefile, "image");
   img2.select = img.select;
-  ObjectOption img3(MN_FILE, _("Bottom image"), &imagefile_bottom, "image-bottom", true, false);
+  ObjectOption img3(MN_FILE, _("Bottom image"), &imagefile_bottom, "image-bottom", (OPTION_VISIBLE));
   img3.select = img.select;
   result.options.push_back(img2);
   result.options.push_back(img3);

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -88,7 +88,7 @@ GameObject::save(Writer& writer) {
         case MN_FILE:
         {
           auto value = *(reinterpret_cast<std::string*>(option.option));
-          if(!option.allow_empty && value.empty())
+          if(!(option.flags & OPTION_ALLOW_EMPTY) && value.empty())
             continue;
           writer.write(option.key, value);
         }

--- a/src/trigger/secretarea_trigger.cpp
+++ b/src/trigger/secretarea_trigger.cpp
@@ -72,10 +72,10 @@ SecretAreaTrigger::get_settings() {
   result.options.push_back( ObjectOption(MN_NUMFIELD, _("Width"), &new_size.x, "width"));
   result.options.push_back( ObjectOption(MN_NUMFIELD, _("Height"), &new_size.y, "height"));
   result.options.push_back( ObjectOption(MN_TEXTFIELD, _("Fade-tilemap"), &fade_tilemap,
-                                         "fade-tilemap", true, false));
+                                         "fade-tilemap", (OPTION_VISIBLE)));
   result.options.push_back( ObjectOption(MN_TEXTFIELD, _("Message"), &message, "message"));
   result.options.push_back( ObjectOption(MN_SCRIPT, _("Script"), &script,
-                                         "script", true, false));
+                                         "script", (OPTION_VISIBLE)));
   return result;
 }
 

--- a/src/trigger/switch.cpp
+++ b/src/trigger/switch.cpp
@@ -59,12 +59,12 @@ ObjectSettings
 Switch::get_settings() {
   ObjectSettings result(_("Switch"));
   result.options.push_back( ObjectOption(MN_TEXTFIELD, _("Name"), &name));
-  ObjectOption spr(MN_FILE, _("Sprite"), &sprite_name, "sprite", true, false);
+  ObjectOption spr(MN_FILE, _("Sprite"), &sprite_name, "sprite", (OPTION_VISIBLE));
   spr.select.push_back(".sprite");
   result.options.push_back(spr);
   result.options.push_back( ObjectOption(MN_SCRIPT, _("Turn on script"), &script, "script"));
   result.options.push_back( ObjectOption(MN_SCRIPT, _("Turn off script"), &off_script,
-                                         "off-script", true, false));
+                                         "off-script", (OPTION_VISIBLE)));
   return result;
 }
 


### PR DESCRIPTION
ObjectOption flags are now kept using a bitfield as opposed to booleans.
To check the presence of an option, use the bitwise AND operator (&) with
the ObjectOption's `flags` variable and the desired flag (declared at the
top of src/editor/object_option.hpp).

All code that I found that uses the previous booleans has been updated to use the new bitfield,
and I have done some preliminary testing on the code and it appears to work fine.