### PR TITLE
Use enums as opposed to #define in ObjectOption bitfield

### DIFF
--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -25,8 +25,10 @@
 #include "video/color.hpp"
 
 // ObjectOption bitfield flags
-#define OPTION_ALLOW_EMPTY (1 << 0)
-#define OPTION_VISIBLE (1 << 1)
+enum ObjectOptionFlags {
+  OPTION_ALLOW_EMPTY = (1 << 0),
+  OPTION_VISIBLE = (1 << 1)
+};
 
 class ObjectOption
 {


### PR DESCRIPTION
Follow-up to PR #653. The ObjectOption flags bitfield now uses an `enum` instead of `#define`s, as suggested by @maxteufel.