### PR TITLE
Don't build on AppVeyor for coverity_scan

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ os: Visual Studio 2015
 configuration: Release
 platform: x86
 
+branches:
+  except:
+    - coverity_scan # No need for Windows builds on that branch
+
 install:
 - ps: |
     Invoke-WebRequest http://download.supertuxproject.org/builddep/dependencies-win32.zip -OutFile "$env:APPVEYOR_BUILD_FOLDER/dependencies.zip"

--- a/appveyor64.yml
+++ b/appveyor64.yml
@@ -3,6 +3,10 @@ os: Visual Studio 2015
 configuration: Release
 platform: x64
 
+branches:
+  except:
+    - coverity_scan # No need for Windows builds on that branch
+
 install:
 - ps: |
     Invoke-WebRequest http://download.supertuxproject.org/builddep/dependencies-win64.zip -OutFile "$env:APPVEYOR_BUILD_FOLDER/dependencies.zip"


### PR DESCRIPTION
We don't need Windows builds for the coverity_scan branch, since Coverity feeds exclusively off of the Linux builds of that, so why waste build cycles if we discard the result anyway...