### PR TITLE
Add LayerItem class for editor layers

### DIFF
--- a/src/editor/layer_icon.cpp
+++ b/src/editor/layer_icon.cpp
@@ -70,28 +70,9 @@ LayerIcon::get_zpos() const {
     return std::numeric_limits<int>::min();
   }
 
-  if (is_tilemap) { //When the layer is a tilemap, the class is obvious.
-    return ((TileMap*)layer)->get_layer();
-  }
-
-  auto bkgrd = dynamic_cast<Background*>(layer);
-  if (bkgrd) {
-    return bkgrd->get_layer();
-  }
-
-  auto grd = dynamic_cast<Gradient*>(layer);
-  if (grd) {
-    return grd->get_layer();
-  }
-
-  auto ps = dynamic_cast<ParticleSystem*>(layer);
-  if (ps) {
-    return ps->get_layer();
-  }
-
-  auto psi = dynamic_cast<ParticleSystem_Interactive*>(layer);
-  if (psi) {
-    return psi->get_layer();
+  auto layer_item = dynamic_cast<LayerItem*>(layer);
+  if(layer_item) {
+    return layer_item->get_layer();
   }
 
   return std::numeric_limits<int>::min();

--- a/src/editor/layer_item.hpp
+++ b/src/editor/layer_item.hpp
@@ -1,0 +1,65 @@
+//  SuperTux
+//  Copyright (C) 2017 Tobias Markus <tobbi.bugs@googlemail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_EDITOR_LAYER_ITEM_CPP
+#define HEADER_SUPERTUX_EDITOR_LAYER_ITEM_CPP
+
+/**
+ * This abstract class is used for objects that
+ * are displayed as layers in the editor. This is
+ * a cleaner solution than defining an appropriate
+ * get_layer() method on each object separately.
+ **/
+class LayerItem
+{
+private:
+  /**
+   * Pointer to the actual layer variable
+   */
+  int* layer;
+
+public:
+  /**
+   * Constructor
+   * @param layer Pointer to the layer we want to return
+   */
+  LayerItem(int* layer):
+    layer(layer)
+  {
+  }
+
+  /**
+   * Returns the value of the actual layer
+   * @return layer Number of the layer in question
+   */
+  int get_layer() const {
+    return *layer;
+  }
+
+  /**
+   * Sets the layer of this item
+   * @param layer Number of the layer in question
+   */
+  void set_layer(int layer) {
+    *(this->layer) = layer;
+  }
+
+private:
+  LayerItem(const LayerItem&) = delete;
+  LayerItem& operator=(const LayerItem&) = delete;
+};
+
+#endif

--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -31,6 +31,7 @@
 
 Background::Background() :
   ExposedObject<Background, scripting::Background>(this),
+  LayerItem(&layer),
   alignment(NO_ALIGNMENT),
   layer(LAYER_BACKGROUND0),
   imagefile_top(),
@@ -51,6 +52,7 @@ Background::Background() :
 
 Background::Background(const ReaderMapping& reader) :
   ExposedObject<Background, scripting::Background>(this),
+  LayerItem(&layer),
   alignment(NO_ALIGNMENT),
   layer(LAYER_BACKGROUND0),
   imagefile_top(),

--- a/src/object/background.hpp
+++ b/src/object/background.hpp
@@ -17,6 +17,7 @@
 #ifndef HEADER_SUPERTUX_OBJECT_BACKGROUND_HPP
 #define HEADER_SUPERTUX_OBJECT_BACKGROUND_HPP
 
+#include "editor/layer_item.hpp"
 #include "scripting/background.hpp"
 #include "scripting/exposed_object.hpp"
 #include "supertux/game_object.hpp"
@@ -24,7 +25,8 @@
 #include "video/drawing_context.hpp"
 
 class Background : public GameObject,
-                   public ExposedObject<Background, scripting::Background>
+                   public ExposedObject<Background, scripting::Background>,
+                   public LayerItem
 {
 public:
   Background();
@@ -50,9 +52,6 @@ public:
   std::string get_class() const {
     return "background";
   }
-
-  int get_layer() const
-  { return layer; }
 
   std::string get_display_name() const {
     return _("Background");

--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -28,6 +28,7 @@
 
 Gradient::Gradient() :
   ExposedObject<Gradient, scripting::Gradient>(this),
+  LayerItem(&layer),
   layer(LAYER_BACKGROUND0),
   gradient_top(),
   gradient_bottom(),
@@ -38,6 +39,7 @@ Gradient::Gradient() :
 
 Gradient::Gradient(const ReaderMapping& reader) :
   ExposedObject<Gradient, scripting::Gradient>(this),
+  LayerItem(&layer),
   layer(LAYER_BACKGROUND0),
   gradient_top(),
   gradient_bottom(),

--- a/src/object/gradient.hpp
+++ b/src/object/gradient.hpp
@@ -17,6 +17,7 @@
 #ifndef HEADER_SUPERTUX_OBJECT_GRADIENT_HPP
 #define HEADER_SUPERTUX_OBJECT_GRADIENT_HPP
 
+#include "editor/layer_item.hpp"
 #include "scripting/exposed_object.hpp"
 #include "scripting/gradient.hpp"
 #include "supertux/game_object.hpp"
@@ -25,7 +26,8 @@
 class ReaderMapping;
 
 class Gradient : public GameObject,
-                 public ExposedObject<Gradient, scripting::Gradient>
+                 public ExposedObject<Gradient, scripting::Gradient>,
+                 public LayerItem
 {
 public:
   Gradient();
@@ -58,9 +60,6 @@ public:
   std::string get_display_name() const {
     return _("Gradient");
   }
-
-  int get_layer() const
-  { return layer; }
 
   virtual ObjectSettings get_settings();
 

--- a/src/object/particlesystem.cpp
+++ b/src/object/particlesystem.cpp
@@ -26,6 +26,7 @@
 
 ParticleSystem::ParticleSystem(float max_particle_size_) :
   ExposedObject<ParticleSystem, scripting::ParticleSystem>(this),
+  LayerItem(&z_pos),
   max_particle_size(max_particle_size_),
   z_pos(LAYER_BACKGROUND1),
   particles(),

--- a/src/object/particlesystem.hpp
+++ b/src/object/particlesystem.hpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include "editor/layer_item.hpp"
 #include "math/vector.hpp"
 #include "scripting/exposed_object.hpp"
 #include "scripting/particlesystem.hpp"
@@ -42,7 +43,8 @@
  * function.
  */
 class ParticleSystem : public GameObject,
-                       public ExposedObject<ParticleSystem, scripting::ParticleSystem>
+                       public ExposedObject<ParticleSystem, scripting::ParticleSystem>,
+                       public LayerItem
 {
 public:
   ParticleSystem(float max_particle_size = 60);
@@ -60,9 +62,6 @@ public:
   virtual void draw(DrawingContext& context) override;
   void set_enabled(bool enabled_);
   bool get_enabled() const;
-
-  int get_layer() const
-  { return z_pos; }
 
 protected:
   class Particle

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -33,6 +33,7 @@
 
 TileMap::TileMap(const TileSet *new_tileset) :
   ExposedObject<TileMap, scripting::TileMap>(this),
+  LayerItem(&z_pos),
   editor_active(true),
   tileset(new_tileset),
   tiles(),
@@ -63,6 +64,7 @@ TileMap::TileMap(const TileSet *new_tileset) :
 
 TileMap::TileMap(const TileSet *tileset_, const ReaderMapping& reader) :
   ExposedObject<TileMap, scripting::TileMap>(this),
+  LayerItem(&z_pos),
   editor_active(true),
   tileset(tileset_),
   tiles(),

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 
+#include "editor/layer_item.hpp"
 #include "object/path_walker.hpp"
 #include "scripting/exposed_object.hpp"
 #include "scripting/tilemap.hpp"
@@ -33,7 +34,8 @@ class TileSet;
  * This class is responsible for drawing the level tiles
  */
 class TileMap : public GameObject,
-                public ExposedObject<TileMap, scripting::TileMap>
+                public ExposedObject<TileMap, scripting::TileMap>,
+                public LayerItem
 {
 public:
   TileMap(const TileSet *tileset);
@@ -115,12 +117,6 @@ public:
   /* Returns the half-open rectangle of (x, y) tile indices
    * that overlap the given rectangle in the sector. */
   Rect get_tiles_overlapping(const Rectf &rect) const;
-
-  int get_layer() const
-  { return z_pos; }
-
-  void set_layer(int layer_)
-  { z_pos = layer_; }
 
   bool is_solid() const
   { return real_solid && effective_solid; }


### PR DESCRIPTION
Fixes #701

I know this is more additions than deletions but checking whether something is a layer in the editor becomes easier this way.

