### PR TITLE
Split off recording code from GameSession class

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -23,7 +23,6 @@
 #include "control/input_manager.hpp"
 #include "gui/menu.hpp"
 #include "gui/menu_manager.hpp"
-#include "math/random_generator.hpp"
 #include "object/camera.hpp"
 #include "object/endsequence_fireworks.hpp"
 #include "object/endsequence_walkleft.hpp"
@@ -54,6 +53,7 @@
 #endif
 
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics) :
+  GameSessionRecorder(),
   reset_button(false),
   level(),
   old_level(),
@@ -72,10 +72,6 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   newspawnpoint(),
   best_level_statistics(statistics),
   m_savegame(savegame),
-  capture_demo_stream(0),
-  capture_file(),
-  playback_demo_stream(0),
-  demo_controller(0),
   play_time(0),
   edit_mode(false),
   levelintro_shown(false),
@@ -164,91 +160,13 @@ GameSession::restart_level(bool after_death)
     currentsector->play_music(LEVEL_MUSIC);
   }
 
-  if(!capture_file.empty()) {
-    int newSeed=0;               // next run uses a new seed
-    while (newSeed == 0)            // which is the next non-zero random num.
-      newSeed = gameRandom.rand();
-    g_config->random_seed = gameRandom.srand(newSeed);
-    log_info << "Next run uses random seed " << g_config->random_seed <<std::endl;
-    record_demo(capture_file);
-  }
+  start_recording();
 
   return (0);
 }
 
 GameSession::~GameSession()
 {
-  delete capture_demo_stream;
-  delete playback_demo_stream;
-  delete demo_controller;
-}
-
-void
-GameSession::record_demo(const std::string& filename)
-{
-  delete capture_demo_stream;
-
-  capture_demo_stream = new std::ofstream(filename.c_str());
-  if(!capture_demo_stream->good()) {
-    std::stringstream msg;
-    msg << "Couldn't open demo file '" << filename << "' for writing.";
-    throw std::runtime_error(msg.str());
-  }
-  capture_file = filename;
-
-  char buf[30];                            // save the seed in the demo file
-  snprintf(buf, sizeof(buf), "random_seed=%10d", g_config->random_seed);
-  for (int i=0; i==0 || buf[i-1]; i++)
-    capture_demo_stream->put(buf[i]);
-}
-
-int
-GameSession::get_demo_random_seed(const std::string& filename) const
-{
-  std::istream* test_stream = new std::ifstream(filename.c_str());
-  if(test_stream->good()) {
-    char buf[30];                     // recall the seed from the demo file
-    int seed;
-    for (int i=0; i<30 && (i==0 || buf[i-1]); i++)
-      test_stream->get(buf[i]);
-    if (sscanf(buf, "random_seed=%10d", &seed) == 1) {
-      log_info << "Random seed " << seed << " from demo file" << std::endl;
-      delete test_stream;
-      test_stream = nullptr;
-      return seed;
-    }
-    else
-      log_info << "Demo file contains no random number" << std::endl;
-  }
-  delete test_stream;
-  test_stream = nullptr;
-  return 0;
-}
-
-void
-GameSession::play_demo(const std::string& filename)
-{
-  delete playback_demo_stream;
-  delete demo_controller;
-
-  playback_demo_stream = new std::ifstream(filename.c_str());
-  if(!playback_demo_stream->good()) {
-    std::stringstream msg;
-    msg << "Couldn't open demo file '" << filename << "' for reading.";
-    throw std::runtime_error(msg.str());
-  }
-
-  Player& tux = *currentsector->player;
-  demo_controller = new CodeController();
-  tux.set_controller(demo_controller);
-
-  // skip over random seed, if it exists in the file
-  char buf[30];                            // ascii decimal seed
-  int seed;
-  for (int i=0; i<30 && (i==0 || buf[i-1]); i++)
-    playback_demo_stream->get(buf[i]);
-  if (sscanf(buf, "random_seed=%010d", &seed) != 1)
-    playback_demo_stream->seekg(0);     // old style w/o seed, restart at beg
 }
 
 void
@@ -328,44 +246,6 @@ void
 GameSession::force_ghost_mode()
 {
   currentsector->get_players()[0]->set_ghost_mode(true);
-}
-
-void
-GameSession::process_events()
-{
-  // playback a demo?
-  if(playback_demo_stream != 0) {
-    demo_controller->update();
-    char left = false;
-    char right = false;
-    char up = false;
-    char down = false;
-    char jump = false;
-    char action = false;
-    playback_demo_stream->get(left);
-    playback_demo_stream->get(right);
-    playback_demo_stream->get(up);
-    playback_demo_stream->get(down);
-    playback_demo_stream->get(jump);
-    playback_demo_stream->get(action);
-    demo_controller->press(Controller::LEFT, left);
-    demo_controller->press(Controller::RIGHT, right);
-    demo_controller->press(Controller::UP, up);
-    demo_controller->press(Controller::DOWN, down);
-    demo_controller->press(Controller::JUMP, jump);
-    demo_controller->press(Controller::ACTION, action);
-  }
-
-  // save input for demo?
-  if(capture_demo_stream != 0) {
-    Controller *controller = InputManager::current()->get_controller();
-    capture_demo_stream ->put(controller->hold(Controller::LEFT));
-    capture_demo_stream ->put(controller->hold(Controller::RIGHT));
-    capture_demo_stream ->put(controller->hold(Controller::UP));
-    capture_demo_stream ->put(controller->hold(Controller::DOWN));
-    capture_demo_stream ->put(controller->hold(Controller::JUMP));
-    capture_demo_stream ->put(controller->hold(Controller::ACTION));
-  }
 }
 
 void

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -23,6 +23,7 @@
 
 #include "math/vector.hpp"
 #include "object/endsequence.hpp"
+#include "supertux/game_session_recorder.hpp"
 #include "supertux/screen.hpp"
 #include "supertux/sequence.hpp"
 #include "supertux/player_status.hpp"
@@ -39,15 +40,12 @@ class Savegame;
  * Screen that runs a Level, where Players run and jump through Sectors.
  */
 class GameSession : public Screen,
+                    public GameSessionRecorder,
                     public Currenton<GameSession>
 {
 public:
   GameSession(const std::string& levelfile, Savegame& savegame, Statistics* statistics = NULL);
   ~GameSession();
-
-  void record_demo(const std::string& filename);
-  int get_demo_random_seed(const std::string& filename) const;
-  void play_demo(const std::string& filename);
 
   void draw(DrawingContext& context) override;
   void update(float frame_ratio) override;
@@ -100,8 +98,6 @@ public:
 
 private:
   void check_end_conditions();
-  void process_events();
-  void capture_demo_step();
 
   void drawstatus(DrawingContext& context);
   void draw_pause(DrawingContext& context);
@@ -138,11 +134,6 @@ private:
 
   Statistics* best_level_statistics;
   Savegame& m_savegame;
-
-  std::ostream* capture_demo_stream;
-  std::string capture_file;
-  std::istream* playback_demo_stream;
-  CodeController* demo_controller;
 
   float play_time; /**< total time in seconds that this session ran interactively */
 

--- a/src/supertux/game_session_recorder.cpp
+++ b/src/supertux/game_session_recorder.cpp
@@ -1,0 +1,163 @@
+//  SuperTux
+//  Copyright (C) 2017 Tobias Markus <tobbi.bugs@googlemail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/game_session_recorder.hpp"
+
+#include <fstream>
+
+#include "control/input_manager.hpp"
+#include "math/random_generator.hpp"
+#include "object/player.hpp"
+#include "supertux/game_session.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/sector.hpp"
+#include "util/log.hpp"
+
+GameSessionRecorder::GameSessionRecorder() :
+  capture_demo_stream(0),
+  capture_file(),
+  playback_demo_stream(0),
+  demo_controller(0)
+{
+}
+
+GameSessionRecorder::~GameSessionRecorder()
+{
+  delete capture_demo_stream;
+  delete playback_demo_stream;
+  delete demo_controller;
+}
+
+void
+GameSessionRecorder::start_recording()
+{
+  if(!capture_file.empty()) {
+    int newSeed = 0;               // next run uses a new seed
+    while (newSeed == 0)            // which is the next non-zero random num.
+      newSeed = gameRandom.rand();
+    g_config->random_seed = gameRandom.srand(newSeed);
+    log_info << "Next run uses random seed " << g_config->random_seed <<std::endl;
+    record_demo(capture_file);
+  }
+}
+
+void
+GameSessionRecorder::record_demo(const std::string& filename)
+{
+  delete capture_demo_stream;
+
+  capture_demo_stream = new std::ofstream(filename.c_str());
+  if(!capture_demo_stream->good()) {
+    std::stringstream msg;
+    msg << "Couldn't open demo file '" << filename << "' for writing.";
+    throw std::runtime_error(msg.str());
+  }
+  capture_file = filename;
+
+  char buf[30];                            // save the seed in the demo file
+  snprintf(buf, sizeof(buf), "random_seed=%10d", g_config->random_seed);
+  for (int i = 0; i == 0 || buf[i-1]; i++)
+    capture_demo_stream->put(buf[i]);
+}
+
+int
+GameSessionRecorder::get_demo_random_seed(const std::string& filename) const
+{
+  std::istream* test_stream = new std::ifstream(filename.c_str());
+  if(test_stream->good()) {
+    char buf[30];                     // recall the seed from the demo file
+    int seed;
+    for (int i=0; i<30 && (i==0 || buf[i-1]); i++)
+      test_stream->get(buf[i]);
+    if (sscanf(buf, "random_seed=%10d", &seed) == 1) {
+      log_info << "Random seed " << seed << " from demo file" << std::endl;
+      delete test_stream;
+      test_stream = nullptr;
+      return seed;
+    }
+    else
+      log_info << "Demo file contains no random number" << std::endl;
+  }
+  delete test_stream;
+  test_stream = nullptr;
+  return 0;
+}
+
+void
+GameSessionRecorder::play_demo(const std::string& filename)
+{
+  delete playback_demo_stream;
+  delete demo_controller;
+
+  playback_demo_stream = new std::ifstream(filename.c_str());
+  if(!playback_demo_stream->good()) {
+    std::stringstream msg;
+    msg << "Couldn't open demo file '" << filename << "' for reading.";
+    throw std::runtime_error(msg.str());
+  }
+
+  Player& tux = *GameSession::current()->get_current_sector()->player;
+  demo_controller = new CodeController();
+  tux.set_controller(demo_controller);
+
+  // skip over random seed, if it exists in the file
+  char buf[30];                            // ascii decimal seed
+  int seed;
+  for (int i=0; i<30 && (i==0 || buf[i-1]); i++)
+    playback_demo_stream->get(buf[i]);
+  if (sscanf(buf, "random_seed=%010d", &seed) != 1)
+    playback_demo_stream->seekg(0);     // old style w/o seed, restart at beg
+}
+
+void
+GameSessionRecorder::process_events()
+{
+  // playback a demo?
+  if(playback_demo_stream != 0) {
+    demo_controller->update();
+    char left = false;
+    char right = false;
+    char up = false;
+    char down = false;
+    char jump = false;
+    char action = false;
+    playback_demo_stream->get(left);
+    playback_demo_stream->get(right);
+    playback_demo_stream->get(up);
+    playback_demo_stream->get(down);
+    playback_demo_stream->get(jump);
+    playback_demo_stream->get(action);
+    demo_controller->press(Controller::LEFT, left);
+    demo_controller->press(Controller::RIGHT, right);
+    demo_controller->press(Controller::UP, up);
+    demo_controller->press(Controller::DOWN, down);
+    demo_controller->press(Controller::JUMP, jump);
+    demo_controller->press(Controller::ACTION, action);
+  }
+
+  // save input for demo?
+  if(capture_demo_stream != 0) {
+    Controller *controller = InputManager::current()->get_controller();
+    capture_demo_stream ->put(controller->hold(Controller::LEFT));
+    capture_demo_stream ->put(controller->hold(Controller::RIGHT));
+    capture_demo_stream ->put(controller->hold(Controller::UP));
+    capture_demo_stream ->put(controller->hold(Controller::DOWN));
+    capture_demo_stream ->put(controller->hold(Controller::JUMP));
+    capture_demo_stream ->put(controller->hold(Controller::ACTION));
+  }
+}
+

--- a/src/supertux/game_session_recorder.hpp
+++ b/src/supertux/game_session_recorder.hpp
@@ -1,0 +1,50 @@
+//  SuperTux
+//  Copyright (C) 2017 Tobias Markus <tobbi.bugs@googlemail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_GAME_SESSION_RECORDER_HPP
+#define HEADER_SUPERTUX_SUPERTUX_GAME_SESSION_RECORDER_HPP
+
+#include <string>
+
+#include "control/codecontroller.hpp"
+
+class GameSessionRecorder
+{
+public:
+  GameSessionRecorder();
+  virtual ~GameSessionRecorder();
+
+  void start_recording();
+  void record_demo(const std::string& filename);
+  int get_demo_random_seed(const std::string& filename) const;
+  void play_demo(const std::string& filename);
+  void process_events();
+
+private:
+  void capture_demo_step();
+
+  std::ostream* capture_demo_stream;
+  std::string capture_file;
+  std::istream* playback_demo_stream;
+  CodeController* demo_controller;
+
+private:
+  GameSessionRecorder(const GameSessionRecorder&) = delete;
+  GameSessionRecorder& operator=(const GameSessionRecorder&) = delete;
+};
+
+#endif
+


### PR DESCRIPTION
Fixes #703

This refactoring allows us to split off the recording code from the GameSession class and makes the whole thing much more readable.

Please, review it carefully.