### PR TITLE
Add loops property to lisp sprite definition

### DIFF
--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -73,7 +73,9 @@ Sprite::set_action(const std::string& name, int loops)
   }
 
   action = newaction;
-  animation_loops = loops;
+  // If the new action has a loops property,
+  // we prefer that over the parameter.
+  animation_loops = newaction->has_custom_loops ? newaction->loops : loops;
   frame = 0;
   frameidx = 0;
 }

--- a/src/sprite/sprite_data.cpp
+++ b/src/sprite/sprite_data.cpp
@@ -31,6 +31,8 @@ SpriteData::Action::Action() :
   hitbox_h(0),
   z_order(0),
   fps(10),
+  loops(-1),
+  has_custom_loops(false),
   surfaces()
 {
 }
@@ -91,6 +93,10 @@ SpriteData::parse_action(const ReaderMapping& lisp, const std::string& basedir)
   }
   lisp.get("z-order", action->z_order);
   lisp.get("fps", action->fps);
+  if(lisp.get("loops", action->loops))
+  {
+    action->has_custom_loops = true;
+  }
 
   std::string mirror_action;
   if (lisp.get("mirror-action", mirror_action)) {

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -62,6 +62,13 @@ private:
     /** Frames per second */
     float fps;
 
+    /** Loops (-1 = looping endlessly) */
+    int loops;
+
+    /** Flag that gets set to true if the action 
+        has custom loops defined */
+    bool has_custom_loops;
+
     std::vector<SurfacePtr> surfaces;
   };
 


### PR DESCRIPTION
@Rusty-Box I hope I understood you correctly on this one.

You can specify (loops 1) on any sprite action and it will only run once despite what may be defined in the code.

Is this what you wanted?