### PR TITLE
Improve Add-On manager

### DIFF
--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -25,7 +25,6 @@
 #include "util/reader.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
-#include "util/reader_collection.hpp"
 #include "util/writer.hpp"
 
 namespace {
@@ -92,20 +91,7 @@ Addon::parse(const ReaderMapping& lisp)
     lisp.get("url", addon->m_url);
     lisp.get("md5", addon->m_md5);
     lisp.get("format", addon->m_format);
-    lisp.get("difficulty",addon->m_difficulty);
-    lisp.get("rating",addon->m_rating);
-    ReaderCollection r;
-    if(lisp.get("screenshots",r))
-      for(auto& orr:r.get_objects())
-      {
-        std::string caption = "", url = "", local = "";
-        auto rm = orr.get_mapping();
-        rm.get("url",url);
-        rm.get("text",caption);
-        rm.get("url-local",local);
-        Screenshot s(url,local,caption);
-        addon->m_screenshots.push_back(s);
-      }
+
     return addon;
   }
   catch(const std::exception& err)
@@ -151,9 +137,6 @@ Addon::Addon() :
   m_format(0),
   m_url(),
   m_md5(),
-  m_screenshots(),
-  m_rating(-10),
-  m_difficulty(-10),
   m_install_filename(),
   m_enabled(false)
 {}

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -25,6 +25,7 @@
 #include "util/reader.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
+#include "util/reader_collection.hpp"
 #include "util/writer.hpp"
 
 namespace {
@@ -91,7 +92,20 @@ Addon::parse(const ReaderMapping& lisp)
     lisp.get("url", addon->m_url);
     lisp.get("md5", addon->m_md5);
     lisp.get("format", addon->m_format);
-
+    lisp.get("difficulty",addon->m_difficulty);
+    lisp.get("rating",addon->m_rating);
+    ReaderCollection r;
+    if(lisp.get("screenshots",r))
+      for(auto& orr:r.get_objects())
+      {
+        std::string caption = "", url = "", local = "";
+        auto rm = orr.get_mapping();
+        rm.get("url",url);
+        rm.get("text",caption);
+        rm.get("url-local",local);
+        Screenshot s(url,local,caption);
+        addon->m_screenshots.push_back(s);
+      }
     return addon;
   }
   catch(const std::exception& err)
@@ -137,6 +151,9 @@ Addon::Addon() :
   m_format(0),
   m_url(),
   m_md5(),
+  m_screenshots(),
+  m_rating(-10),
+  m_difficulty(-10),
   m_install_filename(),
   m_enabled(false)
 {}

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -21,41 +21,8 @@
 #include <assert.h>
 #include <memory>
 #include <string>
-#include <vector>
+
 #include "util/reader_fwd.hpp"
-
-struct Screenshot {
-private:
-  std::string m_url, m_local , m_caption;
-public:
-  Screenshot(std::string url,std::string local,std::string caption):
-  m_url(url),
-  m_local(local),
-  m_caption(caption)
-  {
-
-  }
-
-  std::string get_url() const
-  {
-      return m_url;
-  }
-
-  std::string get_caption() const
-  {
-    return m_caption;
-  }
-
-  std::string get_local() const
-  {
-    return m_local;
-  }
-
-  bool has_local() const
-  {
-    return m_local != "";
-  }
-};
 
 class Addon
 {
@@ -83,10 +50,7 @@ private:
   // additional fields provided for addons from an addon repository
   std::string m_url;
   std::string m_md5;
-  // additional fields provided by Gallery-Addons
-  std::vector< Screenshot > m_screenshots;
-  int m_rating;
-  int m_difficulty;
+
   // fields filled by the AddonManager
   std::string m_install_filename;
   bool m_enabled;
@@ -116,17 +80,6 @@ public:
   void set_install_filename(const std::string& absolute_filename, const std::string& md5);
   void set_enabled(bool v);
 
-  std::vector< Screenshot >& get_screenshots() {
-    return m_screenshots;
-  }
-
-  int getRating() const {
-    return m_rating;
-  }
-
-  int getDifficulty() const {
-    return m_difficulty;
-  }
 private:
   Addon(const Addon&) = delete;
   Addon& operator=(const Addon&) = delete;

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -28,7 +28,7 @@ struct Screenshot {
 private:
   std::string m_url, m_local , m_caption;
 public:
-  Screenshot(std::string url,std::string local,std::string caption):
+  Screenshot(std::string& url,std::string& local,std::string& caption):
   m_url(url),
   m_local(local),
   m_caption(caption)

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -21,8 +21,41 @@
 #include <assert.h>
 #include <memory>
 #include <string>
-
+#include <vector>
 #include "util/reader_fwd.hpp"
+
+struct Screenshot {
+private:
+  std::string m_url, m_local , m_caption;
+public:
+  Screenshot(std::string url,std::string local,std::string caption):
+  m_url(url),
+  m_local(local),
+  m_caption(caption)
+  {
+
+  }
+
+  std::string get_url() const
+  {
+      return m_url;
+  }
+
+  std::string get_caption() const
+  {
+    return m_caption;
+  }
+
+  std::string get_local() const
+  {
+    return m_local;
+  }
+
+  bool has_local() const
+  {
+    return m_local != "";
+  }
+};
 
 class Addon
 {
@@ -50,7 +83,10 @@ private:
   // additional fields provided for addons from an addon repository
   std::string m_url;
   std::string m_md5;
-
+  // additional fields provided by Gallery-Addons
+  std::vector< Screenshot > m_screenshots;
+  int m_rating;
+  int m_difficulty;
   // fields filled by the AddonManager
   std::string m_install_filename;
   bool m_enabled;
@@ -80,6 +116,17 @@ public:
   void set_install_filename(const std::string& absolute_filename, const std::string& md5);
   void set_enabled(bool v);
 
+  std::vector< Screenshot >& get_screenshots() {
+    return m_screenshots;
+  }
+
+  int getRating() const {
+    return m_rating;
+  }
+
+  int getDifficulty() const {
+    return m_difficulty;
+  }
 private:
   Addon(const Addon&) = delete;
   Addon& operator=(const Addon&) = delete;

--- a/src/gui/item_keyvalue.cpp
+++ b/src/gui/item_keyvalue.cpp
@@ -1,0 +1,50 @@
+//  SuperTux
+//  Copyright (C) 2017 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gui/item_keyvalue.hpp"
+
+#include "gui/menu_action.hpp"
+#include "math/vector.hpp"
+#include "supertux/colorscheme.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/resources.hpp"
+#include "video/color.hpp"
+#include "video/drawing_context.hpp"
+#include "video/font.hpp"
+#include "video/renderer.hpp"
+#include "video/video_system.hpp"
+
+void KeyValueLabel::draw(DrawingContext &context, const Vector & pos, int menu_width,
+                         bool active) {
+  std::string r_input = value;
+  context.draw_text(
+      Resources::normal_font, r_input,
+      Vector(pos.x + menu_width - 16,
+             pos.y - int(Resources::normal_font->get_height() / 2)),
+      ALIGN_RIGHT, LAYER_GUI, ColorScheme::Menu::field_color);
+  context.draw_text(
+      Resources::normal_font, text,
+      Vector(pos.x + 16, pos.y - int(Resources::normal_font->get_height() / 2)),
+      ALIGN_LEFT, LAYER_GUI,
+      active ? ColorScheme::Menu::active_color : get_color());
+}
+
+int KeyValueLabel::get_width() const {
+  return Resources::normal_font->get_text_width(value) +
+         Resources::normal_font->get_text_width(text) + 16;
+}
+
+void KeyValueLabel::event(const SDL_Event &ev) {}

--- a/src/gui/item_keyvalue.hpp
+++ b/src/gui/item_keyvalue.hpp
@@ -1,0 +1,52 @@
+//  SuperTux
+//  Copyright (C) 2017 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_GUI_ITEM_KEYVALUEFIELD_HPP
+#define HEADER_SUPERTUX_GUI_ITEM_KEYVALUEFIELD_HPP
+
+#include "gui/menu_item.hpp"
+#include "supertux/colorscheme.hpp"
+
+class KeyValueLabel : public MenuItem {
+private:
+  const std::string value;
+
+  KeyValueLabel(const KeyValueLabel &);
+  KeyValueLabel &operator=(const KeyValueLabel &);
+
+public:
+  KeyValueLabel(const std::string &key_, const std::string &value_)
+      : MenuItem(key_), value(value_) {}
+
+  /** Draws the menu item. */
+  virtual void draw(DrawingContext &, const Vector & pos, int menu_width, bool active);
+
+  /** Returns the minimum width of the menu item. */
+  virtual int get_width() const;
+
+  /** Processes the menu action. */
+  virtual bool changes_width() const { return true; }
+  virtual bool skippable() const { return true; }
+  virtual Color get_color() const { return ColorScheme::Menu::label_color; }
+  virtual void event(const SDL_Event &ev);
+  virtual void process_action(const MenuAction &action) {}
+
+  ~KeyValueLabel() {}
+};
+
+#endif // HEADER_SUPERTUX_GUI_ITEM_INTFIELD_HPP
+
+/* EOF */

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -256,6 +256,20 @@ Menu::add_badguy_select(const std::string& text, std::vector<std::string>* badgu
   return add_item(std::move(item));
 }
 
+MenuItem*
+Menu::add_slideshow(std::vector<SurfacePtr>& images, std::vector< std::string >& text, int switchTime )
+{
+  std::unique_ptr<Slideshow> item(new Slideshow(images, text, switchTime));
+  return add_item(std::move(item));
+}
+
+MenuItem*
+Menu::add_keyvalue(const std::string& key, const std::string& value )
+{
+  std::unique_ptr<KeyValueLabel> item(new KeyValueLabel(key, value));
+  return add_item(std::move(item));
+}
+
 void
 Menu::clear()
 {
@@ -406,7 +420,10 @@ Menu::draw_item(DrawingContext& context, int index)
   MenuItem* pitem = items[index].get();
 
   float x_pos       = pos.x - menu_width_/2;
-  float y_pos       = pos.y + 24*index - menu_height/2 + 12;
+  float sump = 0;
+  for(int i = 0;i<index;i++)
+    sump += items[i]->get_height();
+  float y_pos       = pos.y + sump - menu_height/2 + 12;
 
   pitem->draw(context, Vector(x_pos, y_pos), menu_width_, active_item == index);
 
@@ -450,7 +467,12 @@ Menu::get_width() const
 float
 Menu::get_height() const
 {
-  return items.size() * 24;
+  float height = 0;
+  for(auto& i:items)
+  {
+    height += i->get_height();
+  }
+  return height;
 }
 
 void
@@ -573,6 +595,14 @@ Menu::event(const SDL_Event& ev)
       {
         int new_active_item
           = static_cast<int> ((y - (pos.y - get_height()/2)) / 24);
+        float itemHeight = 0;
+        for(size_t i = 0;i<items.size();i++)
+        {
+          if((y - (pos.y - get_height()/2))  > itemHeight)
+            new_active_item = i;
+          itemHeight += items[i]->get_height();
+
+        }
 
         /* only change the mouse focus to a selectable item */
         if (!items[new_active_item]->skippable())

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -23,6 +23,7 @@
 
 #include "math/vector.hpp"
 #include "video/color.hpp"
+#include "video/surface.hpp"
 
 class Color;
 class DrawingContext;
@@ -58,6 +59,8 @@ public:
   MenuItem* add_color_display(Color* color, int id = -1);
   MenuItem* add_color_channel(float* input, Color channel, int id = -1);
 
+  MenuItem* add_slideshow(std::vector<SurfacePtr>& images, std::vector< std::string >& text, int time );
+  MenuItem* add_keyvalue(const std::string& key, const std::string& value );
   virtual void menu_action(MenuItem* item) = 0;
 
   /**

--- a/src/gui/menu_item.hpp
+++ b/src/gui/menu_item.hpp
@@ -47,6 +47,10 @@ class MenuItem
     /** Returns the minimum width of the menu item. */
     virtual int get_width() const;
 
+    /** */
+    virtual int get_height() const {
+      return 24;
+    }
     /** Processes the menu action. */
     virtual void process_action(const MenuAction& action) { }
 
@@ -97,5 +101,7 @@ class MenuItem
   #include "gui/item_stringselect.hpp"
   #include "gui/item_textfield.hpp"
   #include "gui/item_toggle.hpp"
+  #include "gui/menu_slideshow.hpp"
+  #include "gui/item_keyvalue.hpp"
 #endif
 /* EOF */

--- a/src/gui/menu_slideshow.cpp
+++ b/src/gui/menu_slideshow.cpp
@@ -1,0 +1,31 @@
+#include "gui/menu.hpp"
+#include "gui/menu_manager.hpp"
+#include "gui/menu_slideshow.hpp"
+#include "math/vector.hpp"
+#include "supertux/colorscheme.hpp"
+#include "supertux/menu/menu_storage.hpp"
+#include "supertux/resources.hpp"
+#include "supertux/timer.hpp"
+#include "video/color.hpp"
+#include "video/drawing_context.hpp"
+#include "video/font.hpp"
+#include "video/renderer.hpp"
+#include "video/video_system.hpp"
+
+void Slideshow::draw(DrawingContext &context, const Vector & pos, int menu_width,
+                     bool active) {
+  if (m_images.size() == 0)
+    return;
+  int index = int(real_time / 3) % m_images.size();
+  std::string text = m_text[index];
+  int opx = pos.x;
+  context.draw_surface(
+      m_images[index],
+      Vector(pos.x + menu_width / 2 - m_images[index]->get_width() / 2, pos.y),
+      LAYER_GUI);
+  context.draw_text(
+      Resources::small_font, text,
+      Vector(opx + menu_width / 2, pos.y + m_images[index]->get_height() + 3),
+      ALIGN_CENTER, LAYER_GUI,
+      active ? ColorScheme::Menu::active_color : get_color());
+}

--- a/src/gui/menu_slideshow.cpp
+++ b/src/gui/menu_slideshow.cpp
@@ -1,3 +1,19 @@
+//  SuperTux
+//  Copyright (C) 2018 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include "gui/menu.hpp"
 #include "gui/menu_manager.hpp"
 #include "gui/menu_slideshow.hpp"

--- a/src/gui/menu_slideshow.cpp
+++ b/src/gui/menu_slideshow.cpp
@@ -17,14 +17,14 @@ void Slideshow::draw(DrawingContext &context, const Vector & pos, int menu_width
   if (m_images.size() == 0)
     return;
   int index = int(real_time / 3) % m_images.size();
-  std::string text = m_text[index];
+  std::string caption = m_text[index];
   int opx = pos.x;
   context.draw_surface(
       m_images[index],
       Vector(pos.x + menu_width / 2 - m_images[index]->get_width() / 2, pos.y),
       LAYER_GUI);
   context.draw_text(
-      Resources::small_font, text,
+      Resources::small_font, caption,
       Vector(opx + menu_width / 2, pos.y + m_images[index]->get_height() + 3),
       ALIGN_CENTER, LAYER_GUI,
       active ? ColorScheme::Menu::active_color : get_color());

--- a/src/gui/menu_slideshow.hpp
+++ b/src/gui/menu_slideshow.hpp
@@ -19,15 +19,17 @@ private:
   int maxW = 0;
 
 public:
-  Slideshow(std::vector<SurfacePtr> &images, std::vector<std::string> &text,
+  Slideshow(std::vector<SurfacePtr> &images, std::vector<std::string> &texts,
             int time)
-      : MenuItem("") {
-    m_images = images;
+      : MenuItem(""),
+      m_time(time),
+      m_images(images),
+      m_text(texts)
+       {
     for (auto &ptr : images) {
       maxH = std::max(maxH, ptr->get_height());
       maxW = std::max(maxW, ptr->get_width());
     }
-    m_text = text;
   }
 
   virtual bool skippable() const { return true; }

--- a/src/gui/menu_slideshow.hpp
+++ b/src/gui/menu_slideshow.hpp
@@ -1,0 +1,48 @@
+#ifndef HEADER_SUPERTUX_GUI_MENU_SLIDESHOW_HPP
+#define HEADER_SUPERTUX_GUI_MENU_SLIDESHOW_HPP
+
+#include <SDL.h>
+#include <list>
+#include <memory>
+
+#include "gui/menu_item.hpp"
+#include "video/surface.hpp"
+
+class Slideshow : public MenuItem {
+private:
+  Slideshow(const Slideshow &);
+  Slideshow &operator=(const Slideshow &);
+  int m_time;
+  std::vector<SurfacePtr> m_images;
+  std::vector<std::string> m_text;
+  int maxH = 0;
+  int maxW = 0;
+
+public:
+  Slideshow(std::vector<SurfacePtr> &images, std::vector<std::string> &text,
+            int time)
+      : MenuItem("") {
+    m_images = images;
+    for (auto &ptr : images) {
+      maxH = std::max(maxH, ptr->get_height());
+      maxW = std::max(maxW, ptr->get_width());
+    }
+    m_text = text;
+  }
+
+  virtual bool skippable() const { return true; }
+
+  virtual int get_width() const { return maxW + 100; };
+
+  virtual bool changes_width() const { return true; }
+
+  virtual int get_height() const { return maxH + 30; }
+
+  virtual void process_action(const MenuAction &action) {}
+  ~Slideshow() {}
+  void draw(DrawingContext &context, const Vector & pos, int menu_width, bool active);
+};
+
+#endif
+
+/* EOF */

--- a/src/gui/menu_slideshow.hpp
+++ b/src/gui/menu_slideshow.hpp
@@ -1,3 +1,19 @@
+//  SuperTux
+//  Copyright (C) 2018 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #ifndef HEADER_SUPERTUX_GUI_MENU_SLIDESHOW_HPP
 #define HEADER_SUPERTUX_GUI_MENU_SLIDESHOW_HPP
 

--- a/src/supertux/menu/addon_gallery.cpp
+++ b/src/supertux/menu/addon_gallery.cpp
@@ -30,11 +30,11 @@ void AddonGallery::refresh() {
   // If the Add-On is installed do not download, instead load locally
   try {
     std::vector<std::string> installedAddons =
-        m_addon_manager->get_installed_addons();
+        m_addon_manager.get_installed_addons();
     bool installed = (std::find(installedAddons.begin(), installedAddons.end(),
                                 m_addon) != installedAddons.end());
-    Addon &a = installed ? m_addon_manager->get_installed_addon(m_addon)
-                         : m_addon_manager->get_repository_addon(m_addon);
+    Addon &a = installed ? m_addon_manager.get_installed_addon(m_addon)
+                         : m_addon_manager.get_repository_addon(m_addon);
     std::vector<std::pair<std::string, std::string>> availableScreenshots;
     // If installed mount the add-on
     std::string mountpoint;
@@ -115,7 +115,7 @@ void AddonGallery::refresh() {
     add_keyvalue("Version", boost::str(boost::format("%d") % a.get_version()));
     if (installed) {
       try {
-        Addon &possibleUpdate = m_addon_manager->get_repository_addon(m_addon);
+        Addon &possibleUpdate = m_addon_manager.get_repository_addon(m_addon);
         if (possibleUpdate.get_version() >= a.get_version() &&
             possibleUpdate.get_md5() != a.get_md5()) {
           add_entry(MN_ADDONGALLERY_UPDATE, _("Update"));
@@ -145,12 +145,12 @@ void AddonGallery::refresh() {
 AddonGallery::~AddonGallery() {
   // Clean the cached files up
   std::set<std::string> correctHash;
-  for (auto id : m_addon_manager->get_installed_addons()) {
-    auto &a = m_addon_manager->get_installed_addon(id);
+  for (auto id : m_addon_manager.get_installed_addons()) {
+    auto &a = m_addon_manager.get_installed_addon(id);
     correctHash.insert(a.get_md5());
   }
-  for (auto id : m_addon_manager->get_repository_addons()) {
-    auto &a = m_addon_manager->get_installed_addon(id);
+  for (auto id : m_addon_manager.get_repository_addons()) {
+    auto &a = m_addon_manager.get_repository_addon(id);
     correctHash.insert(a.get_md5());
   }
   PhysFSFileSystem pfs;

--- a/src/supertux/menu/addon_gallery.cpp
+++ b/src/supertux/menu/addon_gallery.cpp
@@ -1,3 +1,19 @@
+//  SuperTux
+//  Copyright (C) 2018 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include "physfs/physfs_file_system.hpp"
 #include "supertux/menu/addon_gallery.hpp"
 #include "util/file_system.hpp"

--- a/src/supertux/menu/addon_gallery.cpp
+++ b/src/supertux/menu/addon_gallery.cpp
@@ -1,0 +1,139 @@
+#include "physfs/physfs_file_system.hpp"
+#include "supertux/menu/addon_gallery.hpp"
+#include "util/file_system.hpp"
+#include <physfs.h>
+
+std::string addon_type_to_translated_string(Addon::Type type) {
+  switch (type) {
+  case Addon::LEVELSET:
+    return _("Levelset");
+
+  case Addon::WORLDMAP:
+    return _("Worldmap");
+
+  case Addon::WORLD:
+    return _("World");
+
+  case Addon::LANGUAGEPACK:
+    return "";
+
+  default:
+    return _("Unknown");
+  }
+}
+
+void AddonGallery::refresh() {
+  clear();
+  Downloader d;
+  // If the Add-On is installed do not download, instead load locally
+  try {
+    std::vector<std::string> installedAddons =
+        m_addon_manager->get_installed_addons();
+    bool installed = (std::find(installedAddons.begin(), installedAddons.end(),
+                                addon) != installedAddons.end());
+    Addon &a = installed ? m_addon_manager->get_installed_addon(addon)
+                         : m_addon_manager->get_repository_addon(addon);
+    std::vector<std::pair<std::string, std::string>> availableScreenshots;
+    // If installed mount the add-on
+    std::string mountpoint;
+    switch (a.get_format()) {
+      case Addon::ORIGINAL:
+        mountpoint = "";
+        break;
+      default:
+        mountpoint = "custom/" + a.get_id();
+        break;
+    }
+    bool mounted = installed;
+    if (installed && !a.is_enabled())
+      if (PHYSFS_mount(a.get_install_filename().c_str(), mountpoint.c_str(),
+                       0) == 0) {
+        log_warning << "Could not add " << a.get_install_filename()
+                    << " to search path: " << PHYSFS_getLastError()
+                    << std::endl;
+        mounted = false;
+      }
+    for (size_t i = 0; i < a.get_screenshots().size(); i++) {
+      try {
+        if (!a.get_screenshots()[i].has_local() || !mounted) {
+          try {
+            d.download(a.get_screenshots()[i].get_url(),
+                       boost::str(boost::format("screenshot-%d.png") % i));
+            availableScreenshots.push_back(std::make_pair(
+                boost::str(boost::format("screenshot-%d.png") % i),
+                a.get_screenshots()[i].get_caption()));
+          } catch (const std::exception &err) {
+            log_debug << "Error when downloading: " << err.what() << std::endl;
+          }
+        } else {
+          std::string path =
+              FileSystem::join(FileSystem::join(mountpoint, "screenshots"),
+                               a.get_screenshots()[i].get_local());
+          log_debug << path << std::endl;
+          if (PHYSFS_exists(path.c_str()))
+          {
+            availableScreenshots.push_back(
+                std::make_pair(path, a.get_screenshots()[i].get_caption()));
+          }else{
+            log_debug << "Path to archive not found" << std::endl;
+          }
+        }
+        log_debug << "Loaded screenshot " << i << std::endl;
+      } catch (const std::exception &err) {
+      }
+    }
+    add_label(a.get_title());
+    add_hl();
+    std::vector<SurfacePtr> images;
+    std::vector<std::string> text;
+    for (auto &p : availableScreenshots) {
+      log_debug << "CREATING SURFACE " << std::endl;
+
+      images.push_back(Surface::create(p.first));
+      text.push_back(p.second);
+    }
+    // If the add-on had to be mounted because it was disabled, unmount it
+    if (mounted && !a.is_enabled()) {
+      PHYSFS_unmount(a.get_install_filename().c_str());
+    }
+    add_slideshow(images, text, 0);
+    std::string type = addon_type_to_translated_string(a.get_type());
+    add_keyvalue("Typ", "Weltkarte");
+    add_keyvalue("Author", a.get_author());
+    add_keyvalue("Rating",
+                 (a.getRating() == -10)
+                     ? "?/10"
+                     : boost::str(boost::format("%d/10") % a.getRating()));
+    add_keyvalue("Schwierigkeit",
+                 (a.getDifficulty() == -10)
+                     ? "?/10"
+                     : boost::str(boost::format("%d/10") % a.getDifficulty()));
+    add_keyvalue("Version", boost::str(boost::format("%d") % a.get_version()));
+    if (installed) {
+      try {
+        Addon &possibleUpdate = m_addon_manager->get_repository_addon(addon);
+        if (possibleUpdate.get_version() >= a.get_version() &&
+            possibleUpdate.get_md5() != a.get_md5()) {
+          add_entry(MN_ADDONGALLERY_UPDATE, _("Update"));
+        } else {
+          add_inactive(_("Update"));
+        }
+      } catch (const std::exception &err) {
+        add_inactive(_("Update"));
+      }
+
+      if (a.is_enabled())
+        add_entry(MN_ADDONGALLERY_DEACTIVATE, _("Deactivate"));
+      else
+        add_entry(MN_ADDONGALLERY_DEACTIVATE, _("Activate"));
+    } else {
+      add_entry(MN_ADDONGALLERY_INSTALL, _("Install"));
+      add_inactive(_("Remove"));
+    }
+    add_back(_("Close"));
+  } catch (const std::exception &err) {
+    std::stringstream msg;
+    msg << "Problem when loading gallery: " << err.what();
+    throw std::runtime_error(msg.str());
+  }
+}

--- a/src/supertux/menu/addon_gallery.hpp
+++ b/src/supertux/menu/addon_gallery.hpp
@@ -18,11 +18,11 @@ enum {
 };
 private:
   AddonManager* m_addon_manager =AddonManager::current() ;
-  std::string addon;
+  std::string m_addon;
 public:
   void refresh();
-  AddonGallery(std::string addon){
-    this->addon = addon;
+  AddonGallery(const std::string& addon):
+  m_addon(addon){
     refresh();
   }
 
@@ -31,17 +31,16 @@ public:
   {
     if(item->id == MN_ADDONGALLERY_INSTALL || item->id == MN_ADDONGALLERY_UPDATE)
     {
-        auto status = m_addon_manager->request_install_addon(this->addon);
+        auto status = m_addon_manager->request_install_addon(m_addon);
         std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, false));
-        dialog->set_title(str(boost::format( _((item->id == MN_ADDONGALLERY_INSTALL)?"Downloading %s":"Updating %s") ) % this->addon));
+        dialog->set_title(str(boost::format( _((item->id == MN_ADDONGALLERY_INSTALL)?"Downloading %s":"Updating %s") ) % m_addon));
         status->then([this](bool success)
         {
           if (success)
           {
             try
             {
-              m_addon_manager->enable_addon(this->addon);
-
+              m_addon_manager->enable_addon(m_addon);
             }
             catch(const std::exception& err)
             {
@@ -57,12 +56,12 @@ public:
     }
     if(item->id == MN_ADDONGALLERY_DEACTIVATE)
     {
-      bool activated = m_addon_manager->get_installed_addon(addon).is_enabled();
+      bool activated = m_addon_manager->get_installed_addon(m_addon).is_enabled();
       if(activated)
       {
-        m_addon_manager->disable_addon(addon);
+        m_addon_manager->disable_addon(m_addon);
       }else{
-        m_addon_manager->enable_addon(addon);
+        m_addon_manager->enable_addon(m_addon);
       }
       clear();
       refresh();
@@ -71,8 +70,7 @@ public:
 
   }
 
-  ~AddonGallery(){
-  };
+  ~AddonGallery();
 
 
 };

--- a/src/supertux/menu/addon_gallery.hpp
+++ b/src/supertux/menu/addon_gallery.hpp
@@ -1,3 +1,19 @@
+//  SuperTux
+//  Copyright (C) 2018 christ2go <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #ifndef HEADER_SUPERTUX_SUPERTUX_MENU_ADDON_GALLERY_HPP
 #define HEADER_SUPERTUX_SUPERTUX_MENU_ADDON_GALLERY_HPP
 

--- a/src/supertux/menu/addon_gallery.hpp
+++ b/src/supertux/menu/addon_gallery.hpp
@@ -1,0 +1,80 @@
+#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_ADDON_GALLERY_HPP
+#define HEADER_SUPERTUX_SUPERTUX_MENU_ADDON_GALLERY_HPP
+
+#include "gui/menu.hpp"
+#include "addon/downloader.hpp"
+#include "addon/addon.hpp"
+#include "gui/menu_item.hpp"
+#include "gui/menu_manager.hpp"
+#include <boost/format.hpp>
+#include "addon/addon_manager.hpp"
+#include "util/gettext.hpp"
+#include "supertux/menu/download_dialog.hpp"
+
+class AddonGallery : public Menu
+{
+enum {
+  MN_ADDONGALLERY_INSTALL, MN_ADDONGALLERY_UPDATE, MN_ADDONGALLERY_DEACTIVATE
+};
+private:
+  AddonManager* m_addon_manager =AddonManager::current() ;
+  std::string addon;
+public:
+  void refresh();
+  AddonGallery(std::string addon){
+    this->addon = addon;
+    refresh();
+  }
+
+
+  void menu_action(MenuItem* item)
+  {
+    if(item->id == MN_ADDONGALLERY_INSTALL || item->id == MN_ADDONGALLERY_UPDATE)
+    {
+        auto status = m_addon_manager->request_install_addon(this->addon);
+        std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, false));
+        dialog->set_title(str(boost::format( _((item->id == MN_ADDONGALLERY_INSTALL)?"Downloading %s":"Updating %s") ) % this->addon));
+        status->then([this](bool success)
+        {
+          if (success)
+          {
+            try
+            {
+              m_addon_manager->enable_addon(this->addon);
+
+            }
+            catch(const std::exception& err)
+            {
+              log_warning << "Enabling add-on failed: " << err.what() << std::endl;
+            }
+            refresh();
+            MenuManager::instance().refresh();
+          }
+
+        });
+        MenuManager::instance().set_dialog(std::move(dialog));
+        return;
+    }
+    if(item->id == MN_ADDONGALLERY_DEACTIVATE)
+    {
+      bool activated = m_addon_manager->get_installed_addon(addon).is_enabled();
+      if(activated)
+      {
+        m_addon_manager->disable_addon(addon);
+      }else{
+        m_addon_manager->enable_addon(addon);
+      }
+      clear();
+      refresh();
+    }
+
+
+  }
+
+  ~AddonGallery(){
+  };
+
+
+};
+
+#endif

--- a/src/supertux/menu/addon_gallery.hpp
+++ b/src/supertux/menu/addon_gallery.hpp
@@ -17,12 +17,14 @@ enum {
   MN_ADDONGALLERY_INSTALL, MN_ADDONGALLERY_UPDATE, MN_ADDONGALLERY_DEACTIVATE
 };
 private:
-  AddonManager* m_addon_manager =AddonManager::current() ;
+  AddonManager& m_addon_manager;
   std::string m_addon;
 public:
   void refresh();
   AddonGallery(const std::string& addon):
-  m_addon(addon){
+  m_addon_manager(*AddonManager::current()),
+  m_addon(addon)
+  {
     refresh();
   }
 
@@ -31,7 +33,7 @@ public:
   {
     if(item->id == MN_ADDONGALLERY_INSTALL || item->id == MN_ADDONGALLERY_UPDATE)
     {
-        auto status = m_addon_manager->request_install_addon(m_addon);
+        auto status = m_addon_manager.request_install_addon(m_addon);
         std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, false));
         dialog->set_title(str(boost::format( _((item->id == MN_ADDONGALLERY_INSTALL)?"Downloading %s":"Updating %s") ) % m_addon));
         status->then([this](bool success)
@@ -40,7 +42,7 @@ public:
           {
             try
             {
-              m_addon_manager->enable_addon(m_addon);
+              m_addon_manager.enable_addon(m_addon);
             }
             catch(const std::exception& err)
             {
@@ -56,12 +58,12 @@ public:
     }
     if(item->id == MN_ADDONGALLERY_DEACTIVATE)
     {
-      bool activated = m_addon_manager->get_installed_addon(m_addon).is_enabled();
+      bool activated = m_addon_manager.get_installed_addon(m_addon).is_enabled();
       if(activated)
       {
-        m_addon_manager->disable_addon(m_addon);
+        m_addon_manager.disable_addon(m_addon);
       }else{
-        m_addon_manager->enable_addon(m_addon);
+        m_addon_manager.enable_addon(m_addon);
       }
       clear();
       refresh();

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -16,9 +16,9 @@
 
 #include "supertux/menu/addon_menu.hpp"
 
-#include <config.h>
 #include <algorithm>
 #include <boost/format.hpp>
+#include <config.h>
 #include <tinygettext/language.hpp>
 
 #include "addon/addon.hpp"
@@ -27,6 +27,7 @@
 #include "gui/menu.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
+#include "supertux/menu/addon_gallery.hpp"
 #include "supertux/menu/download_dialog.hpp"
 #include "util/gettext.hpp"
 
@@ -35,59 +36,48 @@ namespace {
 #define IS_REPOSITORY_MENU_ID(idx) ((idx - MNID_ADDON_LIST_START) % 2 == 0)
 #define IS_INSTALLED_MENU_ID(idx) ((idx - MNID_ADDON_LIST_START) % 2 == 1)
 
-#define MAKE_REPOSITORY_MENU_ID(idx) (MNID_ADDON_LIST_START + 2*idx+0)
-#define MAKE_INSTALLED_MENU_ID(idx) (MNID_ADDON_LIST_START + 2*idx+1)
+#define MAKE_REPOSITORY_MENU_ID(idx) (MNID_ADDON_LIST_START + 2 * idx + 0)
+#define MAKE_INSTALLED_MENU_ID(idx) (MNID_ADDON_LIST_START + 2 * idx + 1)
 
 #define UNPACK_REPOSITORY_MENU_ID(idx) (((idx - MNID_ADDON_LIST_START) - 0) / 2)
 #define UNPACK_INSTALLED_MENU_ID(idx) (((idx - MNID_ADDON_LIST_START) - 1) / 2)
 
-std::string addon_type_to_translated_string(Addon::Type type)
-{
-  switch (type)
-  {
-    case Addon::LEVELSET:
-      return _("Levelset");
+std::string addon_type_to_translated_string(Addon::Type type) {
+  switch (type) {
+  case Addon::LEVELSET:
+    return _("Levelset");
 
-    case Addon::WORLDMAP:
-      return _("Worldmap");
+  case Addon::WORLDMAP:
+    return _("Worldmap");
 
-    case Addon::WORLD:
-      return _("World");
+  case Addon::WORLD:
+    return _("World");
 
-    case Addon::LANGUAGEPACK:
-      return "";
+  case Addon::LANGUAGEPACK:
+    return "";
 
-    default:
-      return _("Unknown");
+  default:
+    return _("Unknown");
   }
 }
 
-std::string generate_menu_item_text(const Addon& addon)
-{
+std::string generate_menu_item_text(const Addon &addon) {
   std::string text;
   std::string type = addon_type_to_translated_string(addon.get_type());
 
-  if(addon.get_type() == Addon::LANGUAGEPACK)
-  {
+  if (addon.get_type() == Addon::LANGUAGEPACK) {
     using tinygettext::Language;
     std::string langname = Language::from_env(addon.get_title()).get_name();
-    if(langname.empty())
-    {
+    if (langname.empty()) {
       langname = addon.get_title();
     }
-    text = str(boost::format("\"%s\"")
-               % langname);
-  }
-  else if(!addon.get_author().empty())
-  {
-    text = str(boost::format(_("%s \"%s\" by \"%s\""))
-               % type % addon.get_title() % addon.get_author());
-  }
-  else
-  {
+    text = str(boost::format("\"%s\"") % langname);
+  } else if (!addon.get_author().empty()) {
+    text = str(boost::format(_("%s \"%s\" by \"%s\"")) % type %
+               addon.get_title() % addon.get_author());
+  } else {
     // Only addon type and name, no need for translation.
-    text = str(boost::format("%s \"%s\"")
-               % type % addon.get_title());
+    text = str(boost::format("%s \"%s\"") % type % addon.get_title());
   }
 
   return text;
@@ -95,32 +85,24 @@ std::string generate_menu_item_text(const Addon& addon)
 
 } // namespace
 
-AddonMenu::AddonMenu(bool language_pack_mode, bool auto_install_langpack) :
-  m_addon_manager(*AddonManager::current()),
-  m_installed_addons(),
-  m_repository_addons(),
-  m_addons_enabled(),
-  m_language_pack_mode(language_pack_mode),
-  m_auto_install_langpack(auto_install_langpack)
-{
+AddonMenu::AddonMenu(bool language_pack_mode, bool auto_install_langpack)
+    : m_addon_manager(*AddonManager::current()), m_installed_addons(),
+      m_repository_addons(), m_addons_enabled(),
+      m_language_pack_mode(language_pack_mode),
+      m_auto_install_langpack(auto_install_langpack) {
   refresh();
-  if(auto_install_langpack)
-  {
-    const std::string& language = g_dictionary_manager->get_language().get_language();
-    if(language == "en")
+  if (auto_install_langpack) {
+    const std::string &language =
+        g_dictionary_manager->get_language().get_language();
+    if (language == "en")
       return;
     check_online();
   }
 }
 
-AddonMenu::~AddonMenu()
-{
-  delete[] m_addons_enabled;
-}
+AddonMenu::~AddonMenu() { delete[] m_addons_enabled; }
 
-void
-AddonMenu::refresh()
-{
+void AddonMenu::refresh() {
   m_installed_addons = m_addon_manager.get_installed_addons();
   m_repository_addons = m_addon_manager.get_repository_addons();
 
@@ -130,66 +112,53 @@ AddonMenu::refresh()
   rebuild_menu();
 }
 
-void
-AddonMenu::rebuild_menu()
-{
+void AddonMenu::rebuild_menu() {
   clear();
-  if(m_language_pack_mode)
-  {
+  if (m_language_pack_mode) {
     add_label(_("Language packs"));
-  }
-  else
-  {
+  } else {
     add_label(_("Add-ons"));
   }
   add_hl();
 
-  if(!m_language_pack_mode)
-  {
+  if (!m_language_pack_mode) {
     add_entry(MNID_LANGPACK_MODE, _("View Language Packs"));
-  }
-  else
-  {
+  } else {
     add_entry(MNID_LANGPACK_MODE, _("View Add-ons"));
   }
 
-  if (m_installed_addons.empty())
-  {
-    if (!m_repository_addons.empty())
-    {
-      if(m_language_pack_mode)
-      {
+  if (m_installed_addons.empty()) {
+    if (!m_repository_addons.empty()) {
+      if (m_language_pack_mode) {
         add_inactive(_("No Language packs installed"));
-      }
-      else
-      {
+      } else {
         add_inactive(_("No Add-ons installed"));
       }
-    }
-    else
-    {
-      if(m_language_pack_mode)
-      {
+    } else {
+      if (m_language_pack_mode) {
         add_inactive(_("No Language packs found"));
-      }
-      else
-      {
+      } else {
         add_inactive(_("No Add-ons found"));
       }
     }
-  }
-  else
-  {
+  } else {
     int idx = 0;
-    for (const auto& addon_id : m_installed_addons)
-    {
-      const Addon& addon = m_addon_manager.get_installed_addon(addon_id);
+    for (const auto &addon_id : m_installed_addons) {
+      const Addon &addon = m_addon_manager.get_installed_addon(addon_id);
       m_addons_enabled[idx] = addon.is_enabled();
-      if(addon_visible(addon))
-      {
-        std::string text = generate_menu_item_text(addon);
-        add_toggle(MAKE_INSTALLED_MENU_ID(idx), text, m_addons_enabled + idx);
-      }
+      std::string text = generate_menu_item_text(addon);
+      if (!m_language_pack_mode)
+        try {
+          const Addon &update_for_addon =
+              m_addon_manager.get_repository_addon(addon_id);
+          if (update_for_addon.get_md5() != addon.get_md5() &&
+              update_for_addon.get_version() >= addon.get_version()) {
+            text += " (* Update available *)";
+          }
+        } catch (const std::exception &err) {
+        }
+      if (addon_visible(addon))
+        add_entry(MAKE_INSTALLED_MENU_ID(idx), text);
       idx += 1;
     }
   }
@@ -199,190 +168,175 @@ AddonMenu::rebuild_menu()
   {
     bool have_new_stuff = false;
     int idx = 0;
-    for (const auto& addon_id : m_repository_addons)
-    {
-      const Addon& addon = m_addon_manager.get_repository_addon(addon_id);
-
-      try
-      {
+    for (const auto &addon_id : m_repository_addons) {
+      const Addon &addon = m_addon_manager.get_repository_addon(addon_id);
+      try {
         // addon is already installed, so check if they are the same
-        Addon& installed_addon = m_addon_manager.get_installed_addon(addon_id);
+        Addon &installed_addon = m_addon_manager.get_installed_addon(addon_id);
         if (installed_addon.get_md5() == addon.get_md5() ||
-            installed_addon.get_version() > addon.get_version())
-        {
-          log_debug << "ignoring already installed add-on " << installed_addon.get_id() << std::endl;
-        }
-        else
-        {
-          log_debug << installed_addon.get_id() << " is installed, but updated: '"
-                    << installed_addon.get_md5() << "' vs '" << addon.get_md5() << "'  '"
-                    << installed_addon.get_version() << "' vs '" << addon.get_version() << "'"
-                    << std::endl;
-          if(addon_visible(addon))
-          {
+            installed_addon.get_version() > addon.get_version()) {
+          log_debug << "ignoring already installed add-on "
+                    << installed_addon.get_id() << std::endl;
+        } else {
+          log_debug << installed_addon.get_id()
+                    << " is installed, but updated: '"
+                    << installed_addon.get_md5() << "' vs '" << addon.get_md5()
+                    << "'  '" << installed_addon.get_version() << "' vs '"
+                    << addon.get_version() << "'" << std::endl;
+          if (addon_visible(addon) && m_language_pack_mode) {
             std::string text = generate_menu_item_text(addon);
-            add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s *NEW*") ) % text));
+            add_entry(MAKE_REPOSITORY_MENU_ID(idx),
+                      str(boost::format(_("Install %s *NEW*")) % text));
             have_new_stuff = true;
           }
         }
-      }
-      catch(const std::exception& err)
-      {
+      } catch (const std::exception &err) {
         // addon is not installed
-        if(addon_visible(addon))
-        {
+        if (addon_visible(addon)) {
           std::string text = generate_menu_item_text(addon);
-          add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s") ) % text));
+          add_entry(MAKE_REPOSITORY_MENU_ID(idx),
+                    str(boost::format(_("Install %s")) % text));
           have_new_stuff = true;
         }
       }
       idx += 1;
     }
 
-    if (!have_new_stuff && m_addon_manager.has_been_updated())
-    {
-      if(m_language_pack_mode)
-      {
-        add_inactive(_("No new Language packs found"));
-      }
-      else
-      {
+    if (!have_new_stuff && m_addon_manager.has_been_updated()) {
+      if (m_language_pack_mode) {
+      } else {
         add_inactive(_("No new Add-ons found"));
       }
     }
   }
 
-  if (!m_addon_manager.has_online_support())
-  {
+  if (!m_addon_manager.has_online_support()) {
     add_inactive(_("Check Online (disabled)"));
-  }
-  else
-  {
+    if (!m_language_pack_mode) {
+      add_inactive(_("Update all Add-Ons"));
+    }
+  } else {
     add_entry(MNID_CHECK_ONLINE, _("Check Online"));
+    if (!m_language_pack_mode)
+      add_entry(MNID_UPDATE_ADDONS, _("Update Add-Ons"));
   }
 
   add_hl();
   add_back(_("Back"));
 }
 
-void
-AddonMenu::menu_action(MenuItem* item)
-{
+void AddonMenu::menu_action(MenuItem *item) {
   if (item->id == MNID_CHECK_ONLINE) // check if "Check Online" was chosen
   {
     check_online();
-  }
-  else if(item->id == MNID_LANGPACK_MODE)
-  {
+  } else if (item->id == MNID_UPDATE_ADDONS) {
+    for (auto &addon : m_installed_addons) {
+      Addon &a = m_addon_manager.get_installed_addon(addon);
+      try {
+        Addon &possibleUpdate = m_addon_manager.get_repository_addon(addon);
+        if (possibleUpdate.get_version() >= a.get_version() &&
+            possibleUpdate.get_md5() != a.get_md5()) {
+          // Install the update
+          this->install_addon(possibleUpdate, true);
+        }
+      } catch (const std::exception &err) {
+        // Ignore: Add-On was not found in repository
+      }
+    }
+  } else if (item->id == MNID_LANGPACK_MODE) {
     m_language_pack_mode = !m_language_pack_mode;
     rebuild_menu();
     on_window_resize();
     return;
-  }
-  else if (MNID_ADDON_LIST_START <= item->id)
-  {
-    if (IS_INSTALLED_MENU_ID(item->id))
-    {
+  } else if (MNID_ADDON_LIST_START <= item->id) {
+    if (IS_INSTALLED_MENU_ID(item->id)) {
       int idx = UNPACK_INSTALLED_MENU_ID(item->id);
-      if (0 <= idx && idx < static_cast<int>(m_installed_addons.size()))
-      {
-        const Addon& addon = m_addon_manager.get_installed_addon(m_installed_addons[idx]);
-        toggle_addon(addon);
-      }
-    }
-    else if (IS_REPOSITORY_MENU_ID(item->id))
-    {
-      int idx = UNPACK_REPOSITORY_MENU_ID(item->id);
-      if (0 <= idx && idx < static_cast<int>(m_repository_addons.size()))
-      {
-        const Addon& addon = m_addon_manager.get_repository_addon(m_repository_addons[idx]);
+      // Only load Gallery for real add-ons
+      if (0 <= idx && idx < static_cast<int>(m_installed_addons.size()) &&
+          !m_language_pack_mode) {
+        std::unique_ptr<Menu> g(new AddonGallery(m_installed_addons[idx]));
+        MenuManager::instance().push_menu(std::move(g));
+      } else if (0 <= idx &&
+                 idx < static_cast<int>(m_installed_addons.size()) &&
+                 m_language_pack_mode) {
+        const Addon &addon =
+            m_addon_manager.get_installed_addon(m_installed_addons[idx]);
         install_addon(addon);
       }
+    } else if (IS_REPOSITORY_MENU_ID(item->id)) {
+
+      int idx = UNPACK_REPOSITORY_MENU_ID(item->id);
+      if (0 <= idx && idx < static_cast<int>(m_repository_addons.size()) &&
+          !m_language_pack_mode) {
+        std::unique_ptr<Menu> g(new AddonGallery(m_repository_addons[idx]));
+        MenuManager::instance().push_menu(std::move(g));
+      } else if (0 <= idx &&
+                 idx < static_cast<int>(m_repository_addons.size())) {
+        install_addon(
+            m_addon_manager.get_repository_addon(m_repository_addons[idx]));
+      }
     }
-  }
-  else
-  {
+  } else {
     log_warning << "Unknown menu item clicked: " << item->id << std::endl;
   }
 }
 
-bool
-AddonMenu::addon_visible(const Addon& addon) const
-{
+bool AddonMenu::addon_visible(const Addon &addon) const {
   bool is_langpack = (addon.get_type() == Addon::LANGUAGEPACK);
-  return (m_language_pack_mode && is_langpack) || (!m_language_pack_mode && !is_langpack);
+  return (m_language_pack_mode && is_langpack) ||
+         (!m_language_pack_mode && !is_langpack);
 }
 
-void
-AddonMenu::check_online()
-{
-  try
-  {
+void AddonMenu::check_online() {
+  try {
     TransferStatusPtr status = m_addon_manager.request_check_online();
-    status->then([this](bool success)
-    {
-      if (success)
-      {
-        if(m_auto_install_langpack)
-        {
-          const std::string& langpack_id = "langpack-" + g_dictionary_manager->get_language().get_language();
+    status->then([this](bool success) {
+      if (success) {
+        if (m_auto_install_langpack) {
+          const std::string &langpack_id =
+              "langpack-" + g_dictionary_manager->get_language().get_language();
           install_addon(m_addon_manager.get_repository_addon(langpack_id));
-        }
-        else
-        {
+        } else {
           refresh();
         }
-      }
-      else
-      {
-        if(m_auto_install_langpack)
-        {
+      } else {
+        if (m_auto_install_langpack) {
           MenuManager::instance().set_dialog({});
           MenuManager::instance().clear_menu_stack();
         }
       }
     });
-    std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, m_auto_install_langpack));
+    std::unique_ptr<DownloadDialog> dialog(
+        new DownloadDialog(status, false, m_auto_install_langpack));
     dialog->set_title(_("Downloading Add-On Repository Index"));
     MenuManager::instance().set_dialog(std::move(dialog));
-  }
-  catch (std::exception& e)
-  {
-    log_warning << "Check for available Add-ons failed: " << e.what() << std::endl;
+  } catch (std::exception &e) {
+    log_warning << "Check for available Add-ons failed: " << e.what()
+                << std::endl;
   }
 }
 
-void
-AddonMenu::install_addon(const Addon& addon)
-{
+void AddonMenu::install_addon(const Addon &addon, bool update) {
   auto addon_id = addon.get_id();
   TransferStatusPtr status = m_addon_manager.request_install_addon(addon_id);
-  std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, m_auto_install_langpack));
-  dialog->set_title(str(boost::format( _("Downloading %s") ) % generate_menu_item_text(addon)));
-  status->then([this, addon_id](bool success)
-  {
-    if (success)
-    {
-      try
-      {
+  std::unique_ptr<DownloadDialog> dialog(
+      new DownloadDialog(status, update, m_auto_install_langpack));
+  dialog->set_title(
+      str(boost::format(_(update ? "Updating %s" : "Downloading %s")) %
+          generate_menu_item_text(addon)));
+  status->then([this, addon_id, update](bool success) {
+    if (success) {
+      try {
         m_addon_manager.enable_addon(addon_id);
-        if(m_auto_install_langpack)
-        {
-          MenuManager::instance().set_dialog({});
-          MenuManager::instance().clear_menu_stack();
+        if (m_auto_install_langpack || update) {
           return;
         }
-      }
-      catch(const std::exception& err)
-      {
+      } catch (const std::exception &err) {
         log_warning << "Enabling add-on failed: " << err.what() << std::endl;
       }
       refresh();
-    }
-    else
-    {
-      if(m_auto_install_langpack)
-      {
+    } else {
+      if (m_auto_install_langpack) {
         MenuManager::instance().set_dialog({});
         MenuManager::instance().clear_menu_stack();
       }
@@ -391,25 +345,19 @@ AddonMenu::install_addon(const Addon& addon)
   MenuManager::instance().set_dialog(std::move(dialog));
 }
 
-void
-AddonMenu::toggle_addon(const Addon& addon)
-{
-  if(addon.is_enabled())
-  {
+void AddonMenu::toggle_addon(const Addon &addon) {
+  if (addon.is_enabled()) {
     m_addon_manager.disable_addon(addon.get_id());
-  }
-  else
-  {
+  } else {
     m_addon_manager.enable_addon(addon.get_id());
   }
-  if(addon.get_type() == Addon::LANGUAGEPACK)
-  {
+  if (addon.get_type() == Addon::LANGUAGEPACK) {
     std::unique_ptr<Dialog> dialog(new Dialog);
-    dialog->set_text(_("Please restart SuperTux\nfor these changes to take effect."));
+    dialog->set_text(
+        _("Please restart SuperTux\nfor these changes to take effect."));
     dialog->add_cancel_button(_("OK"));
     MenuManager::instance().set_dialog(std::move(dialog));
   }
 }
-
 
 /* EOF */

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -16,9 +16,9 @@
 
 #include "supertux/menu/addon_menu.hpp"
 
+#include <config.h>
 #include <algorithm>
 #include <boost/format.hpp>
-#include <config.h>
 #include <tinygettext/language.hpp>
 
 #include "addon/addon.hpp"
@@ -27,7 +27,6 @@
 #include "gui/menu.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
-#include "supertux/menu/addon_gallery.hpp"
 #include "supertux/menu/download_dialog.hpp"
 #include "util/gettext.hpp"
 
@@ -36,48 +35,59 @@ namespace {
 #define IS_REPOSITORY_MENU_ID(idx) ((idx - MNID_ADDON_LIST_START) % 2 == 0)
 #define IS_INSTALLED_MENU_ID(idx) ((idx - MNID_ADDON_LIST_START) % 2 == 1)
 
-#define MAKE_REPOSITORY_MENU_ID(idx) (MNID_ADDON_LIST_START + 2 * idx + 0)
-#define MAKE_INSTALLED_MENU_ID(idx) (MNID_ADDON_LIST_START + 2 * idx + 1)
+#define MAKE_REPOSITORY_MENU_ID(idx) (MNID_ADDON_LIST_START + 2*idx+0)
+#define MAKE_INSTALLED_MENU_ID(idx) (MNID_ADDON_LIST_START + 2*idx+1)
 
 #define UNPACK_REPOSITORY_MENU_ID(idx) (((idx - MNID_ADDON_LIST_START) - 0) / 2)
 #define UNPACK_INSTALLED_MENU_ID(idx) (((idx - MNID_ADDON_LIST_START) - 1) / 2)
 
-std::string addon_type_to_translated_string(Addon::Type type) {
-  switch (type) {
-  case Addon::LEVELSET:
-    return _("Levelset");
+std::string addon_type_to_translated_string(Addon::Type type)
+{
+  switch (type)
+  {
+    case Addon::LEVELSET:
+      return _("Levelset");
 
-  case Addon::WORLDMAP:
-    return _("Worldmap");
+    case Addon::WORLDMAP:
+      return _("Worldmap");
 
-  case Addon::WORLD:
-    return _("World");
+    case Addon::WORLD:
+      return _("World");
 
-  case Addon::LANGUAGEPACK:
-    return "";
+    case Addon::LANGUAGEPACK:
+      return "";
 
-  default:
-    return _("Unknown");
+    default:
+      return _("Unknown");
   }
 }
 
-std::string generate_menu_item_text(const Addon &addon) {
+std::string generate_menu_item_text(const Addon& addon)
+{
   std::string text;
   std::string type = addon_type_to_translated_string(addon.get_type());
 
-  if (addon.get_type() == Addon::LANGUAGEPACK) {
+  if(addon.get_type() == Addon::LANGUAGEPACK)
+  {
     using tinygettext::Language;
     std::string langname = Language::from_env(addon.get_title()).get_name();
-    if (langname.empty()) {
+    if(langname.empty())
+    {
       langname = addon.get_title();
     }
-    text = str(boost::format("\"%s\"") % langname);
-  } else if (!addon.get_author().empty()) {
-    text = str(boost::format(_("%s \"%s\" by \"%s\"")) % type %
-               addon.get_title() % addon.get_author());
-  } else {
+    text = str(boost::format("\"%s\"")
+               % langname);
+  }
+  else if(!addon.get_author().empty())
+  {
+    text = str(boost::format(_("%s \"%s\" by \"%s\""))
+               % type % addon.get_title() % addon.get_author());
+  }
+  else
+  {
     // Only addon type and name, no need for translation.
-    text = str(boost::format("%s \"%s\"") % type % addon.get_title());
+    text = str(boost::format("%s \"%s\"")
+               % type % addon.get_title());
   }
 
   return text;
@@ -85,24 +95,32 @@ std::string generate_menu_item_text(const Addon &addon) {
 
 } // namespace
 
-AddonMenu::AddonMenu(bool language_pack_mode, bool auto_install_langpack)
-    : m_addon_manager(*AddonManager::current()), m_installed_addons(),
-      m_repository_addons(), m_addons_enabled(),
-      m_language_pack_mode(language_pack_mode),
-      m_auto_install_langpack(auto_install_langpack) {
+AddonMenu::AddonMenu(bool language_pack_mode, bool auto_install_langpack) :
+  m_addon_manager(*AddonManager::current()),
+  m_installed_addons(),
+  m_repository_addons(),
+  m_addons_enabled(),
+  m_language_pack_mode(language_pack_mode),
+  m_auto_install_langpack(auto_install_langpack)
+{
   refresh();
-  if (auto_install_langpack) {
-    const std::string &language =
-        g_dictionary_manager->get_language().get_language();
-    if (language == "en")
+  if(auto_install_langpack)
+  {
+    const std::string& language = g_dictionary_manager->get_language().get_language();
+    if(language == "en")
       return;
     check_online();
   }
 }
 
-AddonMenu::~AddonMenu() { delete[] m_addons_enabled; }
+AddonMenu::~AddonMenu()
+{
+  delete[] m_addons_enabled;
+}
 
-void AddonMenu::refresh() {
+void
+AddonMenu::refresh()
+{
   m_installed_addons = m_addon_manager.get_installed_addons();
   m_repository_addons = m_addon_manager.get_repository_addons();
 
@@ -112,53 +130,66 @@ void AddonMenu::refresh() {
   rebuild_menu();
 }
 
-void AddonMenu::rebuild_menu() {
+void
+AddonMenu::rebuild_menu()
+{
   clear();
-  if (m_language_pack_mode) {
+  if(m_language_pack_mode)
+  {
     add_label(_("Language packs"));
-  } else {
+  }
+  else
+  {
     add_label(_("Add-ons"));
   }
   add_hl();
 
-  if (!m_language_pack_mode) {
+  if(!m_language_pack_mode)
+  {
     add_entry(MNID_LANGPACK_MODE, _("View Language Packs"));
-  } else {
+  }
+  else
+  {
     add_entry(MNID_LANGPACK_MODE, _("View Add-ons"));
   }
 
-  if (m_installed_addons.empty()) {
-    if (!m_repository_addons.empty()) {
-      if (m_language_pack_mode) {
+  if (m_installed_addons.empty())
+  {
+    if (!m_repository_addons.empty())
+    {
+      if(m_language_pack_mode)
+      {
         add_inactive(_("No Language packs installed"));
-      } else {
+      }
+      else
+      {
         add_inactive(_("No Add-ons installed"));
       }
-    } else {
-      if (m_language_pack_mode) {
+    }
+    else
+    {
+      if(m_language_pack_mode)
+      {
         add_inactive(_("No Language packs found"));
-      } else {
+      }
+      else
+      {
         add_inactive(_("No Add-ons found"));
       }
     }
-  } else {
+  }
+  else
+  {
     int idx = 0;
-    for (const auto &addon_id : m_installed_addons) {
-      const Addon &addon = m_addon_manager.get_installed_addon(addon_id);
+    for (const auto& addon_id : m_installed_addons)
+    {
+      const Addon& addon = m_addon_manager.get_installed_addon(addon_id);
       m_addons_enabled[idx] = addon.is_enabled();
-      std::string text = generate_menu_item_text(addon);
-      if (!m_language_pack_mode)
-        try {
-          const Addon &update_for_addon =
-              m_addon_manager.get_repository_addon(addon_id);
-          if (update_for_addon.get_md5() != addon.get_md5() &&
-              update_for_addon.get_version() >= addon.get_version()) {
-            text += " (* Update available *)";
-          }
-        } catch (const std::exception &err) {
-        }
-      if (addon_visible(addon))
-        add_entry(MAKE_INSTALLED_MENU_ID(idx), text);
+      if(addon_visible(addon))
+      {
+        std::string text = generate_menu_item_text(addon);
+        add_toggle(MAKE_INSTALLED_MENU_ID(idx), text, m_addons_enabled + idx);
+      }
       idx += 1;
     }
   }
@@ -168,175 +199,190 @@ void AddonMenu::rebuild_menu() {
   {
     bool have_new_stuff = false;
     int idx = 0;
-    for (const auto &addon_id : m_repository_addons) {
-      const Addon &addon = m_addon_manager.get_repository_addon(addon_id);
-      try {
+    for (const auto& addon_id : m_repository_addons)
+    {
+      const Addon& addon = m_addon_manager.get_repository_addon(addon_id);
+
+      try
+      {
         // addon is already installed, so check if they are the same
-        Addon &installed_addon = m_addon_manager.get_installed_addon(addon_id);
+        Addon& installed_addon = m_addon_manager.get_installed_addon(addon_id);
         if (installed_addon.get_md5() == addon.get_md5() ||
-            installed_addon.get_version() > addon.get_version()) {
-          log_debug << "ignoring already installed add-on "
-                    << installed_addon.get_id() << std::endl;
-        } else {
-          log_debug << installed_addon.get_id()
-                    << " is installed, but updated: '"
-                    << installed_addon.get_md5() << "' vs '" << addon.get_md5()
-                    << "'  '" << installed_addon.get_version() << "' vs '"
-                    << addon.get_version() << "'" << std::endl;
-          if (addon_visible(addon) && m_language_pack_mode) {
+            installed_addon.get_version() > addon.get_version())
+        {
+          log_debug << "ignoring already installed add-on " << installed_addon.get_id() << std::endl;
+        }
+        else
+        {
+          log_debug << installed_addon.get_id() << " is installed, but updated: '"
+                    << installed_addon.get_md5() << "' vs '" << addon.get_md5() << "'  '"
+                    << installed_addon.get_version() << "' vs '" << addon.get_version() << "'"
+                    << std::endl;
+          if(addon_visible(addon))
+          {
             std::string text = generate_menu_item_text(addon);
-            add_entry(MAKE_REPOSITORY_MENU_ID(idx),
-                      str(boost::format(_("Install %s *NEW*")) % text));
+            add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s *NEW*") ) % text));
             have_new_stuff = true;
           }
         }
-      } catch (const std::exception &err) {
+      }
+      catch(const std::exception& err)
+      {
         // addon is not installed
-        if (addon_visible(addon)) {
+        if(addon_visible(addon))
+        {
           std::string text = generate_menu_item_text(addon);
-          add_entry(MAKE_REPOSITORY_MENU_ID(idx),
-                    str(boost::format(_("Install %s")) % text));
+          add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s") ) % text));
           have_new_stuff = true;
         }
       }
       idx += 1;
     }
 
-    if (!have_new_stuff && m_addon_manager.has_been_updated()) {
-      if (m_language_pack_mode) {
-      } else {
+    if (!have_new_stuff && m_addon_manager.has_been_updated())
+    {
+      if(m_language_pack_mode)
+      {
+        add_inactive(_("No new Language packs found"));
+      }
+      else
+      {
         add_inactive(_("No new Add-ons found"));
       }
     }
   }
 
-  if (!m_addon_manager.has_online_support()) {
+  if (!m_addon_manager.has_online_support())
+  {
     add_inactive(_("Check Online (disabled)"));
-    if (!m_language_pack_mode) {
-      add_inactive(_("Update all Add-Ons"));
-    }
-  } else {
+  }
+  else
+  {
     add_entry(MNID_CHECK_ONLINE, _("Check Online"));
-    if (!m_language_pack_mode)
-      add_entry(MNID_UPDATE_ADDONS, _("Update Add-Ons"));
   }
 
   add_hl();
   add_back(_("Back"));
 }
 
-void AddonMenu::menu_action(MenuItem *item) {
+void
+AddonMenu::menu_action(MenuItem* item)
+{
   if (item->id == MNID_CHECK_ONLINE) // check if "Check Online" was chosen
   {
     check_online();
-  } else if (item->id == MNID_UPDATE_ADDONS) {
-    for (auto &addon : m_installed_addons) {
-      Addon &a = m_addon_manager.get_installed_addon(addon);
-      try {
-        Addon &possibleUpdate = m_addon_manager.get_repository_addon(addon);
-        if (possibleUpdate.get_version() >= a.get_version() &&
-            possibleUpdate.get_md5() != a.get_md5()) {
-          // Install the update
-          this->install_addon(possibleUpdate, true);
-        }
-      } catch (const std::exception &err) {
-        // Ignore: Add-On was not found in repository
-      }
-    }
-  } else if (item->id == MNID_LANGPACK_MODE) {
+  }
+  else if(item->id == MNID_LANGPACK_MODE)
+  {
     m_language_pack_mode = !m_language_pack_mode;
     rebuild_menu();
     on_window_resize();
     return;
-  } else if (MNID_ADDON_LIST_START <= item->id) {
-    if (IS_INSTALLED_MENU_ID(item->id)) {
+  }
+  else if (MNID_ADDON_LIST_START <= item->id)
+  {
+    if (IS_INSTALLED_MENU_ID(item->id))
+    {
       int idx = UNPACK_INSTALLED_MENU_ID(item->id);
-      // Only load Gallery for real add-ons
-      if (0 <= idx && idx < static_cast<int>(m_installed_addons.size()) &&
-          !m_language_pack_mode) {
-        std::unique_ptr<Menu> g(new AddonGallery(m_installed_addons[idx]));
-        MenuManager::instance().push_menu(std::move(g));
-      } else if (0 <= idx &&
-                 idx < static_cast<int>(m_installed_addons.size()) &&
-                 m_language_pack_mode) {
-        const Addon &addon =
-            m_addon_manager.get_installed_addon(m_installed_addons[idx]);
-        install_addon(addon);
-      }
-    } else if (IS_REPOSITORY_MENU_ID(item->id)) {
-
-      int idx = UNPACK_REPOSITORY_MENU_ID(item->id);
-      if (0 <= idx && idx < static_cast<int>(m_repository_addons.size()) &&
-          !m_language_pack_mode) {
-        std::unique_ptr<Menu> g(new AddonGallery(m_repository_addons[idx]));
-        MenuManager::instance().push_menu(std::move(g));
-      } else if (0 <= idx &&
-                 idx < static_cast<int>(m_repository_addons.size())) {
-        install_addon(
-            m_addon_manager.get_repository_addon(m_repository_addons[idx]));
+      if (0 <= idx && idx < static_cast<int>(m_installed_addons.size()))
+      {
+        const Addon& addon = m_addon_manager.get_installed_addon(m_installed_addons[idx]);
+        toggle_addon(addon);
       }
     }
-  } else {
+    else if (IS_REPOSITORY_MENU_ID(item->id))
+    {
+      int idx = UNPACK_REPOSITORY_MENU_ID(item->id);
+      if (0 <= idx && idx < static_cast<int>(m_repository_addons.size()))
+      {
+        const Addon& addon = m_addon_manager.get_repository_addon(m_repository_addons[idx]);
+        install_addon(addon);
+      }
+    }
+  }
+  else
+  {
     log_warning << "Unknown menu item clicked: " << item->id << std::endl;
   }
 }
 
-bool AddonMenu::addon_visible(const Addon &addon) const {
+bool
+AddonMenu::addon_visible(const Addon& addon) const
+{
   bool is_langpack = (addon.get_type() == Addon::LANGUAGEPACK);
-  return (m_language_pack_mode && is_langpack) ||
-         (!m_language_pack_mode && !is_langpack);
+  return (m_language_pack_mode && is_langpack) || (!m_language_pack_mode && !is_langpack);
 }
 
-void AddonMenu::check_online() {
-  try {
+void
+AddonMenu::check_online()
+{
+  try
+  {
     TransferStatusPtr status = m_addon_manager.request_check_online();
-    status->then([this](bool success) {
-      if (success) {
-        if (m_auto_install_langpack) {
-          const std::string &langpack_id =
-              "langpack-" + g_dictionary_manager->get_language().get_language();
+    status->then([this](bool success)
+    {
+      if (success)
+      {
+        if(m_auto_install_langpack)
+        {
+          const std::string& langpack_id = "langpack-" + g_dictionary_manager->get_language().get_language();
           install_addon(m_addon_manager.get_repository_addon(langpack_id));
-        } else {
+        }
+        else
+        {
           refresh();
         }
-      } else {
-        if (m_auto_install_langpack) {
+      }
+      else
+      {
+        if(m_auto_install_langpack)
+        {
           MenuManager::instance().set_dialog({});
           MenuManager::instance().clear_menu_stack();
         }
       }
     });
-    std::unique_ptr<DownloadDialog> dialog(
-        new DownloadDialog(status, false, m_auto_install_langpack));
+    std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, m_auto_install_langpack));
     dialog->set_title(_("Downloading Add-On Repository Index"));
     MenuManager::instance().set_dialog(std::move(dialog));
-  } catch (std::exception &e) {
-    log_warning << "Check for available Add-ons failed: " << e.what()
-                << std::endl;
+  }
+  catch (std::exception& e)
+  {
+    log_warning << "Check for available Add-ons failed: " << e.what() << std::endl;
   }
 }
 
-void AddonMenu::install_addon(const Addon &addon, bool update) {
+void
+AddonMenu::install_addon(const Addon& addon)
+{
   auto addon_id = addon.get_id();
   TransferStatusPtr status = m_addon_manager.request_install_addon(addon_id);
-  std::unique_ptr<DownloadDialog> dialog(
-      new DownloadDialog(status, update, m_auto_install_langpack));
-  dialog->set_title(
-      str(boost::format(_(update ? "Updating %s" : "Downloading %s")) %
-          generate_menu_item_text(addon)));
-  status->then([this, addon_id, update](bool success) {
-    if (success) {
-      try {
+  std::unique_ptr<DownloadDialog> dialog(new DownloadDialog(status, false, m_auto_install_langpack));
+  dialog->set_title(str(boost::format( _("Downloading %s") ) % generate_menu_item_text(addon)));
+  status->then([this, addon_id](bool success)
+  {
+    if (success)
+    {
+      try
+      {
         m_addon_manager.enable_addon(addon_id);
-        if (m_auto_install_langpack || update) {
+        if(m_auto_install_langpack)
+        {
+          MenuManager::instance().set_dialog({});
+          MenuManager::instance().clear_menu_stack();
           return;
         }
-      } catch (const std::exception &err) {
+      }
+      catch(const std::exception& err)
+      {
         log_warning << "Enabling add-on failed: " << err.what() << std::endl;
       }
       refresh();
-    } else {
-      if (m_auto_install_langpack) {
+    }
+    else
+    {
+      if(m_auto_install_langpack)
+      {
         MenuManager::instance().set_dialog({});
         MenuManager::instance().clear_menu_stack();
       }
@@ -345,19 +391,25 @@ void AddonMenu::install_addon(const Addon &addon, bool update) {
   MenuManager::instance().set_dialog(std::move(dialog));
 }
 
-void AddonMenu::toggle_addon(const Addon &addon) {
-  if (addon.is_enabled()) {
+void
+AddonMenu::toggle_addon(const Addon& addon)
+{
+  if(addon.is_enabled())
+  {
     m_addon_manager.disable_addon(addon.get_id());
-  } else {
+  }
+  else
+  {
     m_addon_manager.enable_addon(addon.get_id());
   }
-  if (addon.get_type() == Addon::LANGUAGEPACK) {
+  if(addon.get_type() == Addon::LANGUAGEPACK)
+  {
     std::unique_ptr<Dialog> dialog(new Dialog);
-    dialog->set_text(
-        _("Please restart SuperTux\nfor these changes to take effect."));
+    dialog->set_text(_("Please restart SuperTux\nfor these changes to take effect."));
     dialog->add_cancel_button(_("OK"));
     MenuManager::instance().set_dialog(std::move(dialog));
   }
 }
+
 
 /* EOF */

--- a/src/supertux/menu/addon_menu.hpp
+++ b/src/supertux/menu/addon_menu.hpp
@@ -27,7 +27,6 @@ class AddonMenu : public Menu
 private:
   enum {
     MNID_CHECK_ONLINE,
-    MNID_UPDATE_ADDONS,
     MNID_NOTHING_NEW,
     MNID_LANGPACK_MODE,
     MNID_ADDON_LIST_START = 10
@@ -48,8 +47,7 @@ public:
   void refresh() override;
   void menu_action(MenuItem* item) override;
   void check_online();
-  void update_addons();
-  void install_addon(const Addon& addon, bool update = false);
+  void install_addon(const Addon& addon);
   void toggle_addon(const Addon& addon);
 
 private:

--- a/src/supertux/menu/addon_menu.hpp
+++ b/src/supertux/menu/addon_menu.hpp
@@ -27,6 +27,7 @@ class AddonMenu : public Menu
 private:
   enum {
     MNID_CHECK_ONLINE,
+    MNID_UPDATE_ADDONS,
     MNID_NOTHING_NEW,
     MNID_LANGPACK_MODE,
     MNID_ADDON_LIST_START = 10
@@ -47,7 +48,8 @@ public:
   void refresh() override;
   void menu_action(MenuItem* item) override;
   void check_online();
-  void install_addon(const Addon& addon);
+  void update_addons();
+  void install_addon(const Addon& addon, bool update = false);
   void toggle_addon(const Addon& addon);
 
 private:

--- a/src/supertux/menu/download_dialog.cpp
+++ b/src/supertux/menu/download_dialog.cpp
@@ -42,7 +42,7 @@ DownloadDialog::DownloadDialog(TransferStatusPtr status, bool auto_close, bool p
       else
       {
         std::unique_ptr<Dialog> dialog(new Dialog);
-        dialog->set_text(_("Error:\n") + m_status->error_msg);
+        dialog->set_text(_("Error:\n") + this->m_status->error_msg);
         dialog->add_button(_("Ok"));
         MenuManager::instance().set_dialog(std::move(dialog));
       }


### PR DESCRIPTION
Adds a button to update all (level/worldmap) add-ons at once, and introduces a nicer view for the Add-Ons. Add-Ons can present screenshots to the user.  Adds a difficulty and rating field for add-ons.
**Screenshot-Format**
The screenshots have to be placed in the add-ons screenshot directory. They are referenced from the `.nfo` file. For every screenshot there has to be a url, from where the screenshot can be downloaded, a reference to a local file _might_ be included if not the image is downloaded every time, the corresponding add-ons menu is opened.
Example extended nfo file:
```
(supertux-addoninfo
  (id "lolkat-levels")
  (version 2)
  (type "worldmap")
  (title "Lolkat's Levels")
  (author "Lolkat")
  (license "GPL 2+ / CC-by-sa 3.0")
  (url "https://raw.githubusercontent.com/SuperTux/addons/master/repository/lolkat-levels_v2.zip")
  (md5 "fbd906c41fcfee8fd58175ef1c64bcb7")
  (rating 4)
  (difficulty 5)
  (screenshots
    (screenshot
      (text "This is Tux")
      (url "http://hagemeier.ch.dd24316.kasserver.com/crystal-mine-01.png")
      (url-local "crystal.png")
    )
    (screenshot
      (text "This looks like Tux")
      (url "http://hagemeier.ch.dd24316.kasserver.com/rsz_crystal-mine-02.png")
    )
  )
 )
```
**Potential Problems / Discussion Topics**

- ~~No caching of images, if they add-ons do not provide a `url-local` field. **Make this obligatory?**~~ Images are cached if an addon with same md5-hash is installed or in the repository. Cache is cleaned up after every use of the addon-manager.
- Adds dynamically heigth menu items (for the images), this leads to O(n) computation of selected menu item instead of O(1), because of the small size of menu items this seems to be ok.

**Testing**
Please test using `--repository-url https://raw.githubusercontent.com/christ2go/addons/master/index-0_5.nfo`. The only worldmap with images is Lolkats-Levels, eventhough the images are from RustyBoxs Crystal Mine. Note, that supertux remembers the repository-url even if you leave the command line argument out.

References #254