### PR TITLE
Renderer: Allow 4K viewports

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -40,8 +40,8 @@ static const float SQUISH_TIME = 2;
 static const float GEAR_TIME = 2;
 static const float BURN_TIME = 1;
 
-static const float X_OFFSCREEN_DISTANCE = 1280;
-static const float Y_OFFSCREEN_DISTANCE = 800;
+static const float X_OFFSCREEN_DISTANCE = 3840;
+static const float Y_OFFSCREEN_DISTANCE = 2160;
 
 BadGuy::BadGuy(const Vector& pos, const std::string& sprite_name_, int layer_,
                const std::string& light_sprite_name) :

--- a/src/video/gl/gl_renderer.cpp
+++ b/src/video/gl/gl_renderer.cpp
@@ -246,7 +246,7 @@ GLRenderer::apply_config()
                                                       target_size);
   }
 
-  Size max_size(1280, 800);
+  Size max_size(3840, 2160);
   Size min_size(640, 480);
 
   Vector scale;

--- a/src/video/sdl/sdl_renderer.cpp
+++ b/src/video/sdl/sdl_renderer.cpp
@@ -330,7 +330,7 @@ SDLRenderer::apply_viewport()
   }
 
   // calculate the viewport
-  Size max_size(1280, 800);
+  Size max_size(3840, 2160);
   Size min_size(640, 480);
 
   Size logical_size;


### PR DESCRIPTION
This is necessary in order to fully be able to use the available resolution on
modern screens. An effect of this might be that some levels end abruptly at the
top or bottom edges of the screen, since those were designed for much lower
resolutions. However, that seems not any worse to me than showing a black edge.

Additionally, the code for badguys has been updated so they are aware of this
change,