### PR TITLE
Torch: expose to scripting interface

### DIFF
--- a/data/images/engine/editor/objects.stoi
+++ b/data/images/engine/editor/objects.stoi
@@ -229,9 +229,6 @@
     (class "trampoline")
     (icon "images/objects/trampoline/trampoline1-0.png"))
   (object
-    (class "torch")
-    (icon "images/objects/torch/torch1.png"))
-  (object
     (class "unstable_tile")
     (icon "images/objects/unstable_tile/snow-3.png"))
   (object
@@ -254,6 +251,9 @@
   (object
     (class "candle")
     (icon "images/objects/candle/candle-1.png"))
+  (object
+    (class "torch")
+    (icon "images/objects/torch/torch1.png"))
   (object
     (class "lantern")
     (icon "images/objects/lantern/lantern-1.png"))

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2014 Ingo Ruhnke <grumbel@gmail.com>
+//  Copyright (C) 2017 M. Teufel <mteufel@supertux.org>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -22,6 +23,7 @@
 #include "util/reader_mapping.hpp"
 
 Torch::Torch(const ReaderMapping& reader) :
+  ExposedObject<Torch, scripting::Torch>(this),
   m_torch(),
   m_flame(SpriteManager::current()->create("images/objects/torch/flame.sprite")),
   m_flame_glow(SpriteManager::current()->create("images/objects/torch/flame_glow.sprite")),
@@ -31,6 +33,8 @@ Torch::Torch(const ReaderMapping& reader) :
 {
   reader.get("x", bbox.p1.x);
   reader.get("y", bbox.p1.y);
+
+  reader.get("name", name, "");
 
   reader.get("sprite", sprite_name);
   reader.get("burning", m_burning, true);
@@ -94,6 +98,19 @@ ObjectSettings Torch::get_settings()
 void Torch::after_editor_set()
 {
   m_torch = SpriteManager::current()->create(sprite_name);
+}
+
+bool
+Torch::get_burning() const
+{
+  return m_burning;
+}
+
+void
+Torch::set_burning(bool burning_)
+{
+  if (this->m_burning == burning_) { return; }
+  this->m_burning = burning_;
 }
 
 /* EOF */

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2014 Ingo Ruhnke <grumbel@gmail.com>
+//  Copyright (C) 2017 M. Teufel <mteufel@supertux.org>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -19,12 +20,15 @@
 
 #include <memory>
 
+#include "scripting/exposed_object.hpp"
+#include "scripting/torch.hpp"
 #include "sprite/sprite_ptr.hpp"
 #include "supertux/moving_object.hpp"
 
 class ReaderMapping;
 
-class Torch : public MovingObject
+class Torch : public MovingObject,
+              public ExposedObject<Torch, scripting::Torch>
 {
 public:
   Torch(const ReaderMapping& reader);
@@ -33,6 +37,18 @@ public:
   void update(float) override;
 
   HitResponse collision(GameObject& other, const CollisionHit& ) override;
+
+  /**
+   * @name Scriptable Methods
+   * @{
+   */
+  bool get_burning() const; /**< returns true if torch is lighted */
+  void set_burning(bool burning_); /**< true: light torch, false: extinguish
+                                     torch */
+  /**
+   * @}
+   */
+
   std::string get_class() const override {
     return "torch";
   }

--- a/src/scripting/torch.cpp
+++ b/src/scripting/torch.cpp
@@ -1,0 +1,42 @@
+//  SuperTux
+//  Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+//  Copyright (C) 2017 M. Teufel <mteufel@supertux.org>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "object/torch.hpp"
+#include "scripting/torch.hpp"
+
+namespace scripting {
+
+Torch::Torch(::Torch* torch_)
+  : torch(torch_)
+{ }
+
+Torch::~Torch()
+{ }
+
+bool Torch::get_burning() const
+{
+  return torch->get_burning();
+}
+
+void Torch::set_burning(bool burning)
+{
+  torch->set_burning(burning);
+}
+
+}
+
+/* EOF */

--- a/src/scripting/torch.hpp
+++ b/src/scripting/torch.hpp
@@ -1,0 +1,51 @@
+//  SuperTux
+//  Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+//  Copyright (C) 2017 M. Teufel <mteufel@supertux.org>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SCRIPTING_TORCH_HPP
+#define HEADER_SUPERTUX_SCRIPTING_TORCH_HPP
+
+#ifndef SCRIPTING_API
+class Torch;
+#endif
+
+namespace scripting {
+
+class Torch
+{
+public:
+#ifndef SCRIPTING_API
+  Torch(::Torch* torch);
+  ~Torch();
+#endif
+
+  bool get_burning() const; /**< returns true if torch is lighted */
+  void set_burning(bool burning); /**< true: light torch, false: extinguish torch */
+
+#ifndef SCRIPTING_API
+  ::Torch* torch;
+
+private:
+  Torch(const Torch&);
+  Torch& operator=(const Torch&);
+#endif
+};
+
+}
+
+#endif
+
+/* EOF */

--- a/src/scripting/wrapper.hpp
+++ b/src/scripting/wrapper.hpp
@@ -44,6 +44,8 @@ class Thunderstorm;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::Thunderstorm* object, bool setup_releasehook = false);
 class TileMap;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::TileMap* object, bool setup_releasehook = false);
+class Torch;
+void create_squirrel_instance(HSQUIRRELVM v, scripting::Torch* object, bool setup_releasehook = false);
 class WillOWisp;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::WillOWisp* object, bool setup_releasehook = false);
 class Wind;

--- a/src/scripting/wrapper.interface.hpp
+++ b/src/scripting/wrapper.interface.hpp
@@ -19,6 +19,7 @@
 #include "scripting/text.hpp"
 #include "scripting/thunderstorm.hpp"
 #include "scripting/tilemap.hpp"
+#include "scripting/torch.hpp"
 #include "scripting/willowisp.hpp"
 #include "scripting/wind.hpp"
 


### PR DESCRIPTION
This exposes the Torch object to the in-game squirrel scripting interface. There
are two methods as of now:

- Torch::get_burning returns the state of the flame of the torch (true for
burning, false for extinguished)

- Torch::set_burning takes a bool to set the state of the torches flame (true to
set to burning, false to extinguish)