### PR TITLE
Firefly: make torch checkpoint glow

### DIFF
--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -20,12 +20,15 @@
 
 #include "audio/sound_manager.hpp"
 #include "math/random_generator.hpp"
+#include "math/vector.hpp"
 #include "object/player.hpp"
 #include "object/sprite_particle.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/object_factory.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
+
+static const Vector TORCH_LIGHT_OFFSET = Vector(0, 12); /** Offset of the light specific to the torch firefly sprite */
 
 Firefly::Firefly(const ReaderMapping& lisp) :
    MovingSprite(lisp, "images/objects/resetpoints/default-resetpoint.sprite", LAYER_TILES, COLGROUP_TOUCHABLE),
@@ -47,7 +50,7 @@ Firefly::Firefly(const ReaderMapping& lisp) :
   bbox.set_size(sprite->get_current_hitbox_width(), sprite->get_current_hitbox_height());
 
   if (sprite_name.find("torch", 0) != std::string::npos) {
-    m_sprite_light = SpriteManager::current()->create("images/objects/torch/flame_light.sprite");
+    m_sprite_light = SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite");
     m_sprite_light->set_blend(Blend(GL_SRC_ALPHA, GL_ONE));
   }
 
@@ -74,7 +77,7 @@ Firefly::draw(DrawingContext& context)
         sprite->get_action() == "ringing")) {
     context.push_target();
     context.set_target(DrawingContext::LIGHTMAP);
-    m_sprite_light->draw(context, get_pos(), 0);
+    m_sprite_light->draw(context, bbox.get_middle() - TORCH_LIGHT_OFFSET, 0);
     context.pop_target();
   }
 }

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -28,6 +28,7 @@
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
 
+static const Color TORCH_LIGHT_COLOR = Color(0.87, 0.64, 0.12); /** Color of the light specific to the torch firefly sprite */
 static const Vector TORCH_LIGHT_OFFSET = Vector(0, 12); /** Offset of the light specific to the torch firefly sprite */
 
 Firefly::Firefly(const ReaderMapping& lisp) :
@@ -52,6 +53,7 @@ Firefly::Firefly(const ReaderMapping& lisp) :
   if (sprite_name.find("torch", 0) != std::string::npos) {
     m_sprite_light = SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite");
     m_sprite_light->set_blend(Blend(GL_SRC_ALPHA, GL_ONE));
+    m_sprite_light->set_color(TORCH_LIGHT_COLOR);
   }
 
   reactivate();

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -29,6 +29,7 @@
 
 Firefly::Firefly(const ReaderMapping& lisp) :
    MovingSprite(lisp, "images/objects/resetpoints/default-resetpoint.sprite", LAYER_TILES, COLGROUP_TOUCHABLE),
+   m_sprite_light(),
    activated(false),
    initial_position(get_pos())
 {
@@ -44,6 +45,12 @@ Firefly::Firefly(const ReaderMapping& lisp) :
   //Replace sprite
   sprite = SpriteManager::current()->create( sprite_name );
   bbox.set_size(sprite->get_current_hitbox_width(), sprite->get_current_hitbox_height());
+
+  if (sprite_name.find("torch", 0) != std::string::npos) {
+    m_sprite_light = SpriteManager::current()->create("images/objects/torch/flame_light.sprite");
+    m_sprite_light->set_blend(Blend(GL_SRC_ALPHA, GL_ONE));
+  }
+
   reactivate();
 
   //Load sound
@@ -56,6 +63,20 @@ Firefly::Firefly(const ReaderMapping& lisp) :
     else {
       SoundManager::current()->preload("sounds/savebell2.wav");
     }
+}
+
+void
+Firefly::draw(DrawingContext& context)
+{
+  MovingSprite::draw(context);
+
+  if (sprite_name.find("torch", 0) != std::string::npos && (activated ||
+        sprite->get_action() == "ringing")) {
+    context.push_target();
+    context.set_target(DrawingContext::LIGHTMAP);
+    m_sprite_light->draw(context, get_pos(), 0);
+    context.pop_target();
+  }
 }
 
 void

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_OBJECT_FIREFLY_HPP
 
 #include "object/moving_sprite.hpp"
+#include "sprite/sprite_ptr.hpp"
 
 /**
  * A Firefly: When tux touches it, it begins buzzing and you will respawn at this
@@ -28,6 +29,8 @@ class Firefly : public MovingSprite
 public:
   Firefly(const ReaderMapping& lisp);
 
+  void draw(DrawingContext& context);
+
   HitResponse collision(GameObject& other, const CollisionHit& hit);
   std::string get_class() const {
     return "firefly";
@@ -37,6 +40,7 @@ public:
   }
 
 private:
+  SpritePtr m_sprite_light;
   bool activated;
   Vector initial_position; /**< position as in level file. This is where Tux will have to respawn, as the level is reset every time */
   void reactivate();


### PR DESCRIPTION
Since this is a torch, it should be glowing. The glow is only enabled for
checkpoints using the torch sprite (it checks for "torch" in the file name of
the sprite).

~~**To discuss:** Should we keep using the huge light sprite from the Torch object?~~

Closes SuperTux/supertux#545 ("Ghost Forest Torch Checkpoint Should Give Out
Light")
  