### PR TITLE
Firefly: fix preloading of fire sound

### DIFF
--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -50,7 +50,7 @@ Firefly::Firefly(const ReaderMapping& lisp) :
     if( sprite_name.find("vbell", 0) != std::string::npos ) {
       SoundManager::current()->preload("sounds/savebell_low.wav");
     }
-    else if( sprite_name.find("torch, 0") != std::string::npos ) {
+    else if( sprite_name.find("torch", 0) != std::string::npos ) {
       SoundManager::current()->preload("sounds/fire.ogg");
     }
     else {


### PR DESCRIPTION
This seems to be a typo. It probably didn't matter, because it was just about
preloading the sound, not actually playing it.