### PR TITLE
ScriptedObject: add possibility to use a hit script

### DIFF
--- a/src/object/scripted_object.hpp
+++ b/src/object/scripted_object.hpp
@@ -67,6 +67,7 @@ private:
   bool solid;
   bool physic_enabled;
   bool visible;
+  std::string hit_script;
   bool new_vel_set;
   Vector new_vel;
   Vector new_size;


### PR DESCRIPTION
This allows one to run a script upon colliding with the ScriptedObject. This is
useful e.g. for collectible objects, in order to have a script store the state
of the collectible.

Limitation: for now, this will only work with objects that are solid.