### PR TITLE
scripting::Player: expose a get_coins() function 

### DIFF
--- a/src/scripting/player.cpp
+++ b/src/scripting/player.cpp
@@ -47,6 +47,12 @@ Player::add_coins(int count)
   m_parent->add_coins(count);
 }
 
+int
+Player::get_coins() const
+{
+  return m_parent->get_coins();
+}
+
 void
 Player::make_invincible()
 {

--- a/src/scripting/player.hpp
+++ b/src/scripting/player.hpp
@@ -56,6 +56,10 @@ public:
    */
   void add_coins(int count);
   /**
+   * Returns the number of coins the player currently has.
+   */
+  int get_coins() const;
+  /**
    * Make tux invincible for a short amount of time
    */
   void make_invincible();

--- a/src/scripting/player.hpp
+++ b/src/scripting/player.hpp
@@ -53,6 +53,10 @@ public:
   bool set_bonus(const std::string& bonus);
   /**
    * Give tux more coins
+   *
+   * If count is a negative amount of coins, that number of coins will be taken
+   * from the player (until the number of coins the player has is 0, when it
+   * will stop changing).
    */
   void add_coins(int count);
   /**

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -1768,6 +1768,36 @@ static SQInteger Player_add_coins_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Player_get_coins_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, 0)) || !data) {
+    sq_throwerror(vm, _SC("'get_coins' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == NULL) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    int return_value = _this->get_coins();
+
+    sq_pushinteger(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_coins'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Player_make_invincible_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -6836,6 +6866,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ti");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'add_coins'");
+  }
+
+  sq_pushstring(v, "get_coins", -1);
+  sq_newclosure(v, &Player_get_coins_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_coins'");
   }
 
   sq_pushstring(v, "make_invincible", -1);


### PR DESCRIPTION
This allows checking how many coins currently has. This might be useful in a shop or store in the game, as it could be integrated in add-ons or even in the main game in the future.

Additionally, document adding negative amount of coins for the add_coins() function.

Reference: <https://forum.freegamedev.net/viewtopic.php?t=7801>