### PR TITLE
ScriptTrigger: add oneshot option

### DIFF
--- a/src/trigger/scripttrigger.cpp
+++ b/src/trigger/scripttrigger.cpp
@@ -31,7 +31,9 @@ ScriptTrigger::ScriptTrigger(const ReaderMapping& reader) :
   triggerevent(),
   script(),
   new_size(),
-  must_activate(false)
+  must_activate(false),
+  oneshot(false),
+  runcount(0)
 {
   reader.get("x", bbox.p1.x);
   reader.get("y", bbox.p1.y);
@@ -41,6 +43,7 @@ ScriptTrigger::ScriptTrigger(const ReaderMapping& reader) :
   bbox.set_size(w, h);
   reader.get("script", script);
   reader.get("button", must_activate);
+  reader.get("oneshot", oneshot);
   if(script.empty()) {
     log_warning << "No script set in script trigger" << std::endl;
   }
@@ -55,7 +58,9 @@ ScriptTrigger::ScriptTrigger(const Vector& pos, const std::string& script_) :
   triggerevent(EVENT_TOUCH),
   script(script_),
   new_size(),
-  must_activate()
+  must_activate(),
+  oneshot(false),
+  runcount(0)
 {
   bbox.set_pos(pos);
   bbox.set_size(32, 32);
@@ -75,6 +80,7 @@ ScriptTrigger::get_settings() {
   result.options.push_back( ObjectOption(MN_NUMFIELD, _("Height"), &new_size.y, "height"));
   result.options.push_back( ObjectOption(MN_SCRIPT, _("Script"), &script, "script"));
   result.options.push_back( ObjectOption(MN_TOGGLE, _("Button"), &must_activate, "button"));
+  result.options.push_back( ObjectOption(MN_TOGGLE, _("Oneshot"), &oneshot, "oneshot"));
   return result;
 }
 
@@ -94,7 +100,12 @@ ScriptTrigger::event(Player& , EventType type)
   if(type != triggerevent)
     return;
 
+  if (oneshot && runcount >= 1) {
+    return;
+  }
+
   Sector::current()->run_script(script, "ScriptTrigger");
+  runcount++;
 }
 
 void

--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -47,6 +47,8 @@ private:
   std::string script;
   Vector new_size;
   bool must_activate;
+  bool oneshot;
+  int runcount;
 };
 
 #endif


### PR DESCRIPTION
This allows the creation of a ScriptTrigger that only runs once. After running
for the first time, it is disabled.

Reference: <https://forum.freegamedev.net/viewtopic.php?f=67&t=6687&p=76020#p76017>
Suggested-by: @manuel-st