### PR TITLE
WalkingCandle fixes

### DIFF
--- a/data/images/engine/editor/objects.stoi
+++ b/data/images/engine/editor/objects.stoi
@@ -118,6 +118,9 @@
     (class "totem")
     (icon "images/creatures/totem/walking1.png"))
   (object
+    (class "walking_candle")
+    (icon "images/creatures/mr_candle/mr-candle-left-1.png"))
+  (object
     (class "walkingleaf")
     (icon "images/creatures/walkingleaf/left-0.png"))
   (object

--- a/src/badguy/walking_candle.hpp
+++ b/src/badguy/walking_candle.hpp
@@ -39,7 +39,7 @@ public:
   ObjectSettings get_settings();
   virtual void after_editor_set();
   std::string get_class() const {
-    return "mrcandle";
+    return "walking_candle";
   }
   std::string get_display_name() const {
     return _("Mr. Candle");


### PR DESCRIPTION
Two fixes for WalkingCandle related to the editor:

> WalkingCandle::get_class: use name matching with object factory
>
> Replace "mrcandle" class name with the "walking_candle" name used in the object
> factory. When writing the levels, the editor will use the name returned by this
> function. However, this does not match the level parser/object factory code.
> Hence, the level editor didn't write properly levels containing this badguy.

> Editor Objects: add WalkingCandle

Fixes SuperTux/supertux#782 ("Walking Candle missing from editor")

Reported-by: @165your4