### PR TITLE
scripting::TileMap: add set_solid() function

### DIFF
--- a/src/scripting/tilemap.cpp
+++ b/src/scripting/tilemap.cpp
@@ -83,6 +83,11 @@ float TileMap::get_alpha() const
   return tilemap->get_alpha();
 }
 
+void TileMap::set_solid(bool solid)
+{
+  tilemap->set_solid(solid);
+}
+
 }
 
 /* EOF */

--- a/src/scripting/tilemap.hpp
+++ b/src/scripting/tilemap.hpp
@@ -74,6 +74,12 @@ public:
    */
   float get_alpha() const;
 
+  /**
+   * Switch tilemap's real solidity to the given bool. Note that effective
+   * solidity is also influenced by the alpha of the tilemap.
+   */
+  void set_solid(bool solid); /**< true: make tilemap solid, false: disable solidity */
+
 #ifndef SCRIPTING_API
   ::TileMap* tilemap;
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -4270,6 +4270,40 @@ static SQInteger TileMap_get_alpha_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger TileMap_set_solid_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, 0)) || !data) {
+    sq_throwerror(vm, _SC("'set_solid' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TileMap*> (data);
+
+  if (_this == NULL) {
+    return SQ_ERROR;
+  }
+
+  SQBool arg0;
+  if(SQ_FAILED(sq_getbool(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a bool"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_solid(arg0 == SQTrue);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_solid'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Torch_release_hook(SQUserPointer ptr, SQInteger )
 {
   auto _this = reinterpret_cast<scripting::Torch*> (ptr);
@@ -7450,6 +7484,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'get_alpha'");
+  }
+
+  sq_pushstring(v, "set_solid", -1);
+  sq_newclosure(v, &TileMap_set_solid_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tb");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_solid'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {


### PR DESCRIPTION
This allows changing the solidity of a tilemap on the fly without changing its
alpha value.

Not implementing a get_solid() function at this point, because we track to
values of solidity, the real (given) solidity and the effective solidity
(influenced by the tilemap's alpha value).

Reference: <https://forum.freegamedev.net/viewtopic.php?f=69&t=7849>