### PR TITLE
Add option to delete levelsets

### DIFF
--- a/src/supertux/menu/confirm_dialog.cpp
+++ b/src/supertux/menu/confirm_dialog.cpp
@@ -1,0 +1,42 @@
+#include "supertux/menu/confirm_dialog.hpp"
+#include "gui/menu.hpp"
+#include "gui/menu_item.hpp"
+#include "gui/menu_manager.hpp"
+#include "supertux/menu/menu_storage.hpp"
+#include "util/gettext.hpp"
+
+ConfirmDialog::ConfirmDialog(const std::string& title, std::function<void(void)> callback):
+  m_title(title),
+  m_callback(callback)
+{
+  // Initialize the dialog 
+  add_label(_("Confirm dialog"));
+  add_label(title);
+  add_hl();
+  add_entry(1, _("Yes"));
+  add_entry(2, _("No"));
+}  
+
+ConfirmDialog::ConfirmDialog(const std::string& title, std::function<void(void)> callback, std::string& yes, std::string& no):
+  m_title(title),
+  m_callback(callback)
+{
+  // Initialize the dialog 
+  add_label(_("Confirm dialog"));
+  add_label(title);
+  add_hl();
+  add_entry(1, _(yes));
+  add_entry(2, _(no));
+}  
+void ConfirmDialog::menu_action(MenuItem* item)
+{
+  if(item->id == 1)
+  {
+    m_callback();
+    MenuManager::instance().pop_menu();
+  }else if(item->id == 2)
+  {
+    MenuManager::instance().pop_menu();
+  }
+  
+}

--- a/src/supertux/menu/confirm_dialog.hpp
+++ b/src/supertux/menu/confirm_dialog.hpp
@@ -1,0 +1,39 @@
+//  SuperTux
+//  Copyright (C) 2018 Christian Hagemeier <christian@hagemeier.ch>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_CONFIRM_DIALOG_HPP
+#define HEADER_SUPERTUX_SUPERTUX_MENU_CONFIRM_DIALOG_HPP
+
+#include "gui/menu.hpp"
+#include <functional>
+
+class ConfirmDialog : public Menu
+{
+private:
+  std::string m_title;
+  std::function<void(void)> m_callback;
+public:
+  ConfirmDialog(const std::string& title, std::function<void(void)> callback);
+  ConfirmDialog(const std::string& title, std::function<void(void)> callback, std::string& yes, std::string& no);
+  void menu_action(MenuItem* item) override;
+  
+private:
+  
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/menu/editor_levelset_menu.cpp
+++ b/src/supertux/menu/editor_levelset_menu.cpp
@@ -29,6 +29,7 @@
 #include "supertux/world.hpp"
 #include "util/file_system.hpp"
 #include "util/gettext.hpp"
+#include "supertux/menu/confirm_dialog.hpp"
 
 EditorLevelsetMenu::EditorLevelsetMenu():
   world(Editor::current()->get_world()),
@@ -67,6 +68,7 @@ EditorLevelsetMenu::initialize() {
   add_textfield(_("Description"), &(world->m_description));
   add_string_select(1, _("Type"), &levelset_type, {_("Worldmap"), _("Levelset")});
   add_hl();
+  add_entry(2,_("Delete this levelset"));
   add_back(_("OK"));
 }
 
@@ -78,6 +80,18 @@ EditorLevelsetMenu::menu_action(MenuItem* item)
   case 1:
     world->m_is_levelset = (levelset_type == 1);
     break;
+  case 2:
+  {
+      std::unique_ptr<Menu> cfd(new ConfirmDialog(_("Delete this levelset?"),[this]()-> void {    
+      // Delete the levelset 
+      world->remove();
+      // Pop the last two menus, so that the screen for the now deleted level will not be shown.
+      MenuManager::instance().pop_menu();
+      MenuManager::instance().pop_menu();
+}));
+    MenuManager::instance().push_menu(std::move(cfd));
+    break;
+  }
   default:
     break;
   }

--- a/src/supertux/menu/editor_levelset_select_menu.cpp
+++ b/src/supertux/menu/editor_levelset_select_menu.cpp
@@ -67,6 +67,10 @@ EditorLevelsetSelectMenu::EditorLevelsetSelectMenu() :
       {
         continue;
       }
+      if(world->is_removed())
+      {
+        continue;
+      }
       if(!world->is_levelset() && !world->is_worldmap())
       {
         log_warning << level_world << ": unknown World type" << std::endl;

--- a/src/supertux/world.hpp
+++ b/src/supertux/world.hpp
@@ -38,7 +38,6 @@ public:
   */
   static std::unique_ptr<World> load(const std::string& directory);
   static std::unique_ptr<World> create(const std::string& title, const std::string& desc);
-
 public:
   ~World();
 
@@ -46,7 +45,8 @@ public:
   std::string get_title() const;
 
   bool hide_from_contribs() const { return m_hide_from_contribs; }
-
+  bool is_removed() const { return m_removed; };
+  
   bool is_levelset() const { return m_is_levelset; }
   bool is_worldmap() const { return !m_is_levelset; }
 
@@ -54,12 +54,14 @@ public:
   std::string get_savegame_filename() const { return m_savegame_filename; }
 
   void save(bool retry = false);
+  void remove();
   void set_default_values();
 
 private:
   std::string m_basedir;
   std::string m_worldmap_filename;
   std::string m_savegame_filename;
+  bool m_removed;
 
 public:
   std::string m_title;


### PR DESCRIPTION
Allows levelsets to be deleted from the editor.

Implements a new menu type, the ConfirmDialog. 
ConfirmDialogs contain a query (e.g "Should this levelset be deleted") and a lambda function,
which is called when the query is confirmed. 

Deletes the levelset by recursively walking the directory and then deleting every single file.

TODO: Only delete user created levelsets (does anyone have a good idea, how this check could be done?).

Issue: Because the levelset menu can not be reloaded, the deleted levelset will still show up.  Don't know how to fix this with the current menu editor design.

Closes #735.