### PR TITLE
Fixed glew on wayland.

### DIFF
--- a/src/video/gl/gl_renderer.cpp
+++ b/src/video/gl/gl_renderer.cpp
@@ -123,6 +123,13 @@ GLRenderer::GLRenderer() :
 #ifndef GL_VERSION_ES_CM_1_0
   #ifndef USE_GLBINDING
   GLenum err = glewInit();
+  #ifdef GLEW_ERROR_NO_GLX_DISPLAY
+  if (GLEW_ERROR_NO_GLX_DISPLAY == err)
+  {
+    log_info << "GLEW couldn't open GLX display" << std::endl;
+  }
+  else
+  #endif
   if (GLEW_OK != err)
   {
     std::ostringstream out;


### PR DESCRIPTION
Glew can't open glx display when it's running on wayland session and thus returns an error. But glXGetProcAddress is fully usable on wayland, so we can just ignore the "no glx display" error.

Note that GLEW_ERROR_NO_GLX_DISPLAY needs glew >= 2.1. Older versions assume that glx display is always available and will just crash.