### PR TITLE
Don't fall through in a few cases.

### DIFF
--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -127,6 +127,7 @@ WillOWisp::active_update(float elapsed_time)
       if(sprite->animation_done()) {
         remove_me();
       }
+      break;
 
     case STATE_VANISHING: {
       Vector dir_ = dist.unit();

--- a/src/editor/input_gui.cpp
+++ b/src/editor/input_gui.cpp
@@ -351,7 +351,6 @@ EditorInputGui::event(SDL_Event& ev) {
     case SDL_MOUSEBUTTONUP:
       dragging = false;
       return false;
-      break;
 
     case SDL_MOUSEMOTION:
     {
@@ -399,7 +398,6 @@ EditorInputGui::event(SDL_Event& ev) {
       }
       return false;
     case SDL_MOUSEWHEEL:
-    {
       if (hovered_item != HI_NONE)
       {
         if (ev.wheel.y > 0) {
@@ -411,10 +409,9 @@ EditorInputGui::event(SDL_Event& ev) {
         using_scroll_wheel = true;
         wheel_scroll_amount = ev.wheel.y;
       }
-    }
+      return false;
     default:
       return false;
-      break;
   }
   return true;
 }


### PR DESCRIPTION
Pointed out by -Wimplicit-fallthrough.

Do note that in the willowisp case this changes the behaviour. But I think the previous behaviour was broken, since otherwise it would just have used the other label.