### PR TITLE
Use the parameter instead of the uninitialized member.

### DIFF
--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -33,7 +33,7 @@
 #include "video/video_system.hpp"
 
 ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
-  ItemTextField("", input_, id)
+  ItemTextField("", input_, id_)
 {
 }
 


### PR DESCRIPTION
Fixes a -Wuninitialized warning.