### PR TITLE
Remove unused ctors.

### DIFF
--- a/src/badguy/bouncing_snowball.cpp
+++ b/src/badguy/bouncing_snowball.cpp
@@ -29,11 +29,6 @@ BouncingSnowball::BouncingSnowball(const ReaderMapping& reader)
 {
 }
 
-BouncingSnowball::BouncingSnowball(const Vector& pos, Direction d)
-  : BadGuy(pos, d, "images/creatures/bouncing_snowball/bouncing_snowball.sprite")
-{
-}
-
 void
 BouncingSnowball::initialize()
 {

--- a/src/badguy/bouncing_snowball.hpp
+++ b/src/badguy/bouncing_snowball.hpp
@@ -23,7 +23,6 @@ class BouncingSnowball : public BadGuy
 {
 public:
   BouncingSnowball(const ReaderMapping& reader);
-  BouncingSnowball(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/captainsnowball.cpp
+++ b/src/badguy/captainsnowball.cpp
@@ -33,15 +33,6 @@ CaptainSnowball::CaptainSnowball(const ReaderMapping& reader)
   physic.set_velocity_y(-400);
 }
 
-CaptainSnowball::CaptainSnowball(const Vector& pos, Direction d)
-  : WalkingBadguy(pos, d, "images/creatures/snowball/cpt-snowball.sprite", "left", "right")
-{
-  // Created during game eg. by dispencer. Board the enemy!
-  walk_speed = BOARDING_SPEED;
-  max_drop_height = -1;
-  physic.set_velocity_y(-400);
-}
-
 bool
 CaptainSnowball::might_climb(int width, int height) const
 {

--- a/src/badguy/captainsnowball.hpp
+++ b/src/badguy/captainsnowball.hpp
@@ -23,7 +23,6 @@ class CaptainSnowball : public WalkingBadguy
 {
 public:
   CaptainSnowball(const ReaderMapping& reader);
-  CaptainSnowball(const Vector& pos, Direction d);
 
   virtual void active_update(float elapsed_time);
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/crystallo.cpp
+++ b/src/badguy/crystallo.cpp
@@ -31,14 +31,6 @@ Crystallo::Crystallo(const ReaderMapping& reader) :
   reader.get("radius", radius, 100);
 }
 
-Crystallo::Crystallo(const Vector& pos, Direction d) :
-  WalkingBadguy(pos, d, "images/creatures/crystallo/crystallo.sprite", "left", "right"),
-  radius(100)
-{
-  walk_speed = 80;
-  max_drop_height = 16;
-}
-
 ObjectSettings
 Crystallo::get_settings() {
   ObjectSettings result = WalkingBadguy::get_settings();

--- a/src/badguy/crystallo.hpp
+++ b/src/badguy/crystallo.hpp
@@ -26,7 +26,6 @@ class Crystallo : public WalkingBadguy
 {
 public:
   Crystallo(const ReaderMapping& reader);
-  Crystallo(const Vector& pos, Direction d);
   ObjectSettings get_settings();
   std::string get_class() const {
     return "crystallo";

--- a/src/badguy/fish.cpp
+++ b/src/badguy/fish.cpp
@@ -31,14 +31,6 @@ Fish::Fish(const ReaderMapping& reader) :
   physic.enable_gravity(true);
 }
 
-Fish::Fish(const Vector& pos) :
-  BadGuy(pos, "images/creatures/fish/fish.sprite", LAYER_TILES-1),
-  waiting(),
-  stop_y(0)
-{
-  physic.enable_gravity(true);
-}
-
 void
 Fish::collision_solid(const CollisionHit& chit)
 {

--- a/src/badguy/fish.hpp
+++ b/src/badguy/fish.hpp
@@ -23,7 +23,6 @@ class Fish : public BadGuy
 {
 public:
   Fish(const ReaderMapping& );
-  Fish(const Vector& pos);
 
   void draw(DrawingContext& context);
 

--- a/src/badguy/flame.hpp
+++ b/src/badguy/flame.hpp
@@ -25,7 +25,6 @@ class Flame : public BadGuy
 {
 public:
   Flame(const ReaderMapping& reader);
-  Flame(const Flame& flame);
 
   void activate();
   void deactivate();

--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -35,14 +35,6 @@ FlyingSnowBall::FlyingSnowBall(const ReaderMapping& reader) :
   physic.enable_gravity(true);
 }
 
-FlyingSnowBall::FlyingSnowBall(const Vector& pos) :
-  BadGuy(pos, "images/creatures/flying_snowball/flying_snowball.sprite"),
-  normal_propeller_speed(),
-  puff_timer()
-{
-  physic.enable_gravity(true);
-}
-
 void
 FlyingSnowBall::initialize()
 {

--- a/src/badguy/flyingsnowball.hpp
+++ b/src/badguy/flyingsnowball.hpp
@@ -23,7 +23,6 @@ class FlyingSnowBall : public BadGuy
 {
 public:
   FlyingSnowBall(const ReaderMapping& reader);
-  FlyingSnowBall(const Vector& pos);
 
   void initialize();
   void activate();

--- a/src/badguy/ghostflame.hpp
+++ b/src/badguy/ghostflame.hpp
@@ -23,7 +23,6 @@ class Ghostflame : public Flame
 {
 public:
   Ghostflame(const ReaderMapping& reader);
-  Ghostflame(const Ghostflame& ghostflame);
 
   bool is_flammable() const;
   bool is_freezable() const;

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -25,7 +25,6 @@ class Haywire : public WalkingBadguy
 {
 public:
   Haywire(const ReaderMapping& reader);
-  Haywire(const Vector& pos, Direction d);
 
   void kill_fall();
   void ignite();

--- a/src/badguy/igel.cpp
+++ b/src/badguy/igel.cpp
@@ -36,14 +36,6 @@ Igel::Igel(const ReaderMapping& reader) :
   max_drop_height = 16;
 }
 
-Igel::Igel(const Vector& pos, Direction d) :
-  WalkingBadguy(pos, d, "images/creatures/igel/igel.sprite", "walking-left", "walking-right"),
-  turn_recover_timer()
-{
-  walk_speed = IGEL_SPEED;
-  max_drop_height = 16;
-}
-
 void
 Igel::be_normal()
 {

--- a/src/badguy/igel.hpp
+++ b/src/badguy/igel.hpp
@@ -26,7 +26,6 @@ class Igel : public WalkingBadguy
 {
 public:
   Igel(const ReaderMapping& reader);
-  Igel(const Vector& pos, Direction d);
 
   HitResponse collision_bullet(Bullet& bullet, const CollisionHit& hit);
 

--- a/src/badguy/kamikazesnowball.cpp
+++ b/src/badguy/kamikazesnowball.cpp
@@ -38,13 +38,6 @@ KamikazeSnowball::KamikazeSnowball(const ReaderMapping& reader) :
   set_action (dir == LEFT ? "left" : "right", /* loops = */ -1);
 }
 
-KamikazeSnowball::KamikazeSnowball(const Vector& pos, Direction d)
-  : BadGuy(pos, d, "images/creatures/snowball/kamikaze-snowball.sprite")
-{
-  SoundManager::current()->preload(SPLAT_SOUND);
-  set_action (dir == LEFT ? "left" : "right", /* loops = */ -1);
-}
-
 void
 KamikazeSnowball::initialize()
 {

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -23,7 +23,6 @@ class KamikazeSnowball : public BadGuy
 {
 public:
   KamikazeSnowball(const ReaderMapping& reader);
-  KamikazeSnowball(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -41,18 +41,6 @@ Mole::Mole(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/dartfire.wav");
 }
 
-Mole::Mole(const Vector& pos) :
-  BadGuy(pos, "images/creatures/mole/mole.sprite", LAYER_TILES-1),
-  state(PRE_THROWING),
-  timer(),
-  throw_timer()
-{
-  physic.enable_gravity(false);
-  SoundManager::current()->preload("sounds/fall.wav");
-  SoundManager::current()->preload("sounds/squish.wav");
-  SoundManager::current()->preload("sounds/dartfire.wav");
-}
-
 void
 Mole::activate()
 {

--- a/src/badguy/mole.hpp
+++ b/src/badguy/mole.hpp
@@ -23,7 +23,6 @@ class Mole : public BadGuy
 {
 public:
   Mole(const ReaderMapping& );
-  Mole(const Vector& pos);
 
   void kill_fall();
   HitResponse collision_badguy(BadGuy& , const CollisionHit& );

--- a/src/badguy/mrbomb.cpp
+++ b/src/badguy/mrbomb.cpp
@@ -47,17 +47,6 @@ MrBomb::MrBomb(const ReaderMapping& reader) :
   sprite = SpriteManager::current()->create( sprite_name );
 }
 
-/* MrBomb created by a dispenser always gets default sprite atm.*/
-MrBomb::MrBomb(const Vector& pos, Direction d) :
-  WalkingBadguy(pos, d, "images/creatures/mr_bomb/mr_bomb.sprite", "left", "right"),
-  grabbed()
-{
-  walk_speed = 80;
-  max_drop_height = 16;
-  grabbed = false;
-  SoundManager::current()->preload("sounds/explosion.wav");
-}
-
 HitResponse
 MrBomb::collision(GameObject& object, const CollisionHit& hit)
 {

--- a/src/badguy/mrbomb.hpp
+++ b/src/badguy/mrbomb.hpp
@@ -24,7 +24,6 @@ class MrBomb : public WalkingBadguy,
 {
 public:
   MrBomb(const ReaderMapping& reader);
-  MrBomb(const Vector& pos, Direction d);
 
   void kill_fall();
   void ignite();

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -45,20 +45,6 @@ MrIceBlock::MrIceBlock(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/kick.wav");
 }
 
-MrIceBlock::MrIceBlock(const Vector& pos, Direction d) :
-  WalkingBadguy(pos, d, "images/creatures/mr_iceblock/mr_iceblock.sprite", "left", "right"),
-  ice_state(ICESTATE_NORMAL),
-  nokick_timer(),
-  flat_timer(),
-  squishcount(0)
-{
-  walk_speed = 80;
-  max_drop_height = 600;
-  SoundManager::current()->preload("sounds/iceblock_bump.wav");
-  SoundManager::current()->preload("sounds/stomp.wav");
-  SoundManager::current()->preload("sounds/kick.wav");
-}
-
 void
 MrIceBlock::initialize()
 {

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -25,7 +25,6 @@ class MrIceBlock : public WalkingBadguy,
 {
 public:
   MrIceBlock(const ReaderMapping& reader);
-  MrIceBlock(const Vector& pos, Direction d);
 
   void initialize();
   HitResponse collision(GameObject& object, const CollisionHit& hit);

--- a/src/badguy/owl.cpp
+++ b/src/badguy/owl.cpp
@@ -40,14 +40,6 @@ Owl::Owl(const ReaderMapping& reader) :
   set_action (dir == LEFT ? "left" : "right", /* loops = */ -1);
 }
 
-Owl::Owl(const Vector& pos, Direction d) :
-  BadGuy(pos, d, "images/creatures/owl/owl.sprite", LAYER_OBJECTS + 1),
-  carried_obj_name("skydive"),
-  carried_object(NULL)
-{
-  set_action (dir == LEFT ? "left" : "right", /* loops = */ -1);
-}
-
 void
 Owl::save(Writer& writer) {
   BadGuy::save(writer);

--- a/src/badguy/owl.hpp
+++ b/src/badguy/owl.hpp
@@ -26,7 +26,6 @@ class Owl : public BadGuy
 {
 public:
   Owl(const ReaderMapping& reader);
-  Owl(const Vector& pos, Direction d);
   virtual void save(Writer& writer);
 
   void initialize();

--- a/src/badguy/skullyhop.cpp
+++ b/src/badguy/skullyhop.cpp
@@ -35,14 +35,6 @@ SkullyHop::SkullyHop(const ReaderMapping& reader) :
   SoundManager::current()->preload( SKULLYHOP_SOUND );
 }
 
-SkullyHop::SkullyHop(const Vector& pos, Direction d) :
-  BadGuy(pos, d, "images/creatures/skullyhop/skullyhop.sprite"),
-  recover_timer(),
-  state()
-{
-  SoundManager::current()->preload( SKULLYHOP_SOUND );
-}
-
 void
 SkullyHop::initialize()
 {

--- a/src/badguy/skullyhop.hpp
+++ b/src/badguy/skullyhop.hpp
@@ -26,7 +26,6 @@ class SkullyHop : public BadGuy
 {
 public:
   SkullyHop(const ReaderMapping& reader);
-  SkullyHop(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/skydive.cpp
+++ b/src/badguy/skydive.cpp
@@ -29,12 +29,6 @@ SkyDive::SkyDive(const ReaderMapping& reader) :
 {
 }
 
-SkyDive::SkyDive(const Vector& pos, Direction d) :
-  BadGuy(pos, d, "images/creatures/skydive/skydive.sprite"),
-  is_grabbed(false)
-{
-}
-
 void
 SkyDive::collision_solid(const CollisionHit& hit)
 {

--- a/src/badguy/skydive.hpp
+++ b/src/badguy/skydive.hpp
@@ -27,7 +27,6 @@ class SkyDive : public BadGuy, public Portable
 
   public:
     SkyDive(const ReaderMapping& reader);
-    SkyDive(const Vector& pos, Direction d);
 
     void collision_solid(const CollisionHit& hit);
     HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit);

--- a/src/badguy/smartball.cpp
+++ b/src/badguy/smartball.cpp
@@ -28,13 +28,6 @@ SmartBall::SmartBall(const ReaderMapping& reader)
   max_drop_height = 16;
 }
 
-SmartBall::SmartBall(const Vector& pos, Direction d)
-  : WalkingBadguy(pos, d, "images/creatures/snowball/smart-snowball.sprite", "left", "right")
-{
-  walk_speed = 80;
-  max_drop_height = 16;
-}
-
 bool
 SmartBall::collision_squished(GameObject& object)
 {

--- a/src/badguy/smartball.hpp
+++ b/src/badguy/smartball.hpp
@@ -26,7 +26,6 @@ class SmartBall : public WalkingBadguy
 {
 public:
   SmartBall(const ReaderMapping& reader);
-  SmartBall(const Vector& pos, Direction d);
 
   virtual std::string get_water_sprite() const {
     return "images/objects/water_drop/pink_drop.sprite";

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -42,19 +42,6 @@ Snail::Snail(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/kick.wav");
 }
 
-Snail::Snail(const Vector& pos, Direction d) :
-  WalkingBadguy(pos, d, "images/creatures/snail/snail.sprite", "left", "right"),
-  state(STATE_NORMAL),
-  kicked_delay_timer(),
-  squishcount(0)
-{
-  walk_speed = 80;
-  max_drop_height = 600;
-  SoundManager::current()->preload("sounds/iceblock_bump.wav");
-  SoundManager::current()->preload("sounds/stomp.wav");
-  SoundManager::current()->preload("sounds/kick.wav");
-}
-
 void
 Snail::initialize()
 {

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -28,7 +28,6 @@ class Snail : public WalkingBadguy,
 {
 public:
   Snail(const ReaderMapping& reader);
-  Snail(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/spidermite.cpp
+++ b/src/badguy/spidermite.cpp
@@ -31,14 +31,6 @@ SpiderMite::SpiderMite(const ReaderMapping& reader) :
   physic.enable_gravity(false);
 }
 
-SpiderMite::SpiderMite(const Vector& pos) :
-  BadGuy(pos, "images/creatures/spidermite/spidermite.sprite"),
-  mode(),
-  timer()
-{
-  physic.enable_gravity(false);
-}
-
 void
 SpiderMite::initialize()
 {

--- a/src/badguy/spidermite.hpp
+++ b/src/badguy/spidermite.hpp
@@ -23,7 +23,6 @@ class SpiderMite : public BadGuy
 {
 public:
   SpiderMite(const ReaderMapping& reader);
-  SpiderMite(const Vector& pos);
 
   void initialize();
   void active_update(float elapsed_time);

--- a/src/badguy/toad.cpp
+++ b/src/badguy/toad.cpp
@@ -36,14 +36,6 @@ Toad::Toad(const ReaderMapping& reader) :
   SoundManager::current()->preload(HOP_SOUND);
 }
 
-Toad::Toad(const Vector& pos, Direction d) :
-  BadGuy(pos, d, "images/creatures/toad/toad.sprite"),
-  recover_timer(),
-  state()
-{
-  SoundManager::current()->preload(HOP_SOUND);
-}
-
 void
 Toad::initialize()
 {

--- a/src/badguy/toad.hpp
+++ b/src/badguy/toad.hpp
@@ -26,7 +26,6 @@ class Toad : public BadGuy
 {
 public:
   Toad(const ReaderMapping& reader);
-  Toad(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);

--- a/src/badguy/walkingleaf.cpp
+++ b/src/badguy/walkingleaf.cpp
@@ -26,13 +26,6 @@ WalkingLeaf::WalkingLeaf(const ReaderMapping& reader) :
   max_drop_height = 16;
 }
 
-WalkingLeaf::WalkingLeaf(const Vector& pos, Direction d)
-  : WalkingBadguy(pos, d, "images/creatures/walkingleaf/walkingleaf.sprite", "left", "right")
-{
-  walk_speed = 60;
-  max_drop_height = 16;
-}
-
 bool
 WalkingLeaf::collision_squished(GameObject& object)
 {

--- a/src/badguy/walkingleaf.hpp
+++ b/src/badguy/walkingleaf.hpp
@@ -26,7 +26,6 @@ class WalkingLeaf : public WalkingBadguy
 {
 public:
   WalkingLeaf(const ReaderMapping& reader);
-  WalkingLeaf(const Vector& pos, Direction d);
 
   bool is_freezable() const;
   std::string get_class() const {

--- a/src/badguy/zeekling.cpp
+++ b/src/badguy/zeekling.cpp
@@ -36,18 +36,6 @@ Zeekling::Zeekling(const ReaderMapping& reader) :
   physic.enable_gravity(false);
 }
 
-Zeekling::Zeekling(const Vector& pos, Direction d) :
-  BadGuy(pos, d, "images/creatures/zeekling/zeekling.sprite"),
-  speed(gameRandom.rand(130, 171)),
-  diveRecoverTimer(),
-  state(FLYING),
-  last_player(0),
-  last_player_pos(),
-  last_self_pos()
-{
-  physic.enable_gravity(false);
-}
-
 void
 Zeekling::initialize()
 {

--- a/src/badguy/zeekling.hpp
+++ b/src/badguy/zeekling.hpp
@@ -24,7 +24,6 @@ class Zeekling : public BadGuy
 {
 public:
   Zeekling(const ReaderMapping& reader);
-  Zeekling(const Vector& pos, Direction d);
 
   void initialize();
   void collision_solid(const CollisionHit& hit);


### PR DESCRIPTION
It would be nice if we could switch to using only one of Pos+Dir or ReaderMapping.


As mentioned above as part of the commit message, having both of those ctors for some of the badguys seems strange. It would be a lot nicer if only one of those would be required for all the badguys, that would also make dispensers dispensing different badguys a lot easier, rather than requiring a bunch of new ctors (since not even all badguys have those pos+dir ctors).