### PR TITLE
Remove unused using namespace std.

### DIFF
--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -32,8 +32,6 @@
 #include <sstream>
 #include <stdexcept>
 
-using namespace std;
-
 Level* Level::_current = 0;
 
 Level::Level() :


### PR DESCRIPTION
Using `using namespace std` is horrible, and nothing in the file even depends on it so kill it with fire.