### PR TITLE
Fix unisolid collision, when Level is flipped

### DIFF
--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -696,8 +696,7 @@ Sector::collision_tilemap(collision::Constraints* constraints,
         if(tile->is_unisolid ()) {
           Vector relative_movement = movement
             - solids->get_movement(/* actual = */ true);
-          // if vertically flipped invert relative x movement
-          if (!tile->is_solid (tile_bbox, object.get_bbox(), relative_movement))
+          if (!tile->is_solid (tile_bbox, object.get_bbox(), relative_movement, solids->get_drawing_effect() & VERTICAL_FLIP))
             continue;
         } /* if (tile->is_unisolid ()) */
 
@@ -740,7 +739,7 @@ Sector::collision_tile_attributes(const Rectf& dest, const Vector& mov) const
         const auto& tile = solids->get_tile(x, y);
         if(!tile)
           continue;
-        if ( tile->is_collisionful( solids->get_tile_bbox(x, y), dest, mov) ) {
+        if ( tile->is_collisionful( solids->get_tile_bbox(x, y), dest, mov, solids->get_drawing_effect() & VERTICAL_FLIP) ) {
           result |= tile->getAttributes();
         }
       }
@@ -748,7 +747,7 @@ Sector::collision_tile_attributes(const Rectf& dest, const Vector& mov) const
         const auto& tile = solids->get_tile(x, y);
         if(!tile)
           continue;
-        if ( tile->is_collisionful( solids->get_tile_bbox(x, y), dest, mov) ) {
+        if ( tile->is_collisionful( solids->get_tile_bbox(x, y), dest, mov, solids->get_drawing_effect() & VERTICAL_FLIP) ) {
           result |= (tile->getAttributes() & Tile::ICE);
         }
       }

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -352,7 +352,7 @@ Sector::update(float elapsed_time)
     float r = (1.0f - percent_done) * source_ambient_light.red + percent_done * target_ambient_light.red;
     float g = (1.0f - percent_done) * source_ambient_light.green + percent_done * target_ambient_light.green;
     float b = (1.0f - percent_done) * source_ambient_light.blue + percent_done * target_ambient_light.blue;
-    
+
     if(r > 1.0)
       r = 1.0;
     if(g > 1.0)
@@ -366,7 +366,7 @@ Sector::update(float elapsed_time)
       g = 0;
     if(b < 0)
       b = 0;
-    
+
     ambient_light = Color(r, g, b);
 
     if(ambient_light_fade_accum >= ambient_light_fade_duration)
@@ -696,7 +696,7 @@ Sector::collision_tilemap(collision::Constraints* constraints,
         if(tile->is_unisolid ()) {
           Vector relative_movement = movement
             - solids->get_movement(/* actual = */ true);
-
+          // if vertically flipped invert relative x movement
           if (!tile->is_solid (tile_bbox, object.get_bbox(), relative_movement))
             continue;
         } /* if (tile->is_unisolid ()) */

--- a/src/supertux/tile.cpp
+++ b/src/supertux/tile.cpp
@@ -178,7 +178,10 @@ bool Tile::check_movement_unisolid (const Vector& movement) const
   if (!this->is_slope())
   {
     int dir = this->getData() & Tile::UNI_DIR_MASK;
-
+    if(VERTICAL_FLIP)
+    {
+      dir = dir_vertical_flip(dir);
+    }
     return ((dir == Tile::UNI_DIR_NORTH) && (movement.y >= 0))  /* moving down */
         || ((dir == Tile::UNI_DIR_SOUTH) && (movement.y <= 0))  /* moving up */
         || ((dir == Tile::UNI_DIR_WEST ) && (movement.x >= 0))  /* moving right */
@@ -195,7 +198,7 @@ bool Tile::check_movement_unisolid (const Vector& movement) const
    */
   mv_x = (double) movement.x; //note switch to double for no good reason
   mv_y = (double) movement.y;
-
+  // TODO Apply vertical transformation
   slope_info = this->getData();
   switch (slope_info & AATriangle::DIRECTION_MASK)
   {
@@ -289,7 +292,10 @@ bool Tile::check_position_unisolid (const Rectf& obj_bbox,
   if (!this->is_slope())
   {
     int dir = this->getData() & Tile::UNI_DIR_MASK;
-
+    if(VERTICAL_FLIP)
+    {
+      dir = dir_vertical_flip(dir);
+    }
     return ((dir == Tile::UNI_DIR_NORTH) && ((obj_bbox.get_bottom() - SHIFT_DELTA) <= tile_bbox.get_top()   ))
         || ((dir == Tile::UNI_DIR_SOUTH) && ((obj_bbox.get_top()    + SHIFT_DELTA) >= tile_bbox.get_bottom()))
         || ((dir == Tile::UNI_DIR_WEST ) && ((obj_bbox.get_right()  - SHIFT_DELTA) <= tile_bbox.get_left()  ))
@@ -300,6 +306,8 @@ bool Tile::check_position_unisolid (const Rectf& obj_bbox,
    * describes the slope's surface. The line is defined by x, y, and m, the
    * gradient. */
   slope_info = this->getData();
+  if(VERTICAL_FLIP)
+    slope_info = AATriangle::vertical_flip(slope_info);
   switch (slope_info
       & (AATriangle::DIRECTION_MASK | AATriangle::DEFORM_MASK))
   {

--- a/src/supertux/tile.cpp
+++ b/src/supertux/tile.cpp
@@ -198,8 +198,9 @@ bool Tile::check_movement_unisolid (const Vector& movement) const
    */
   mv_x = (double) movement.x; //note switch to double for no good reason
   mv_y = (double) movement.y;
-  // TODO Apply vertical transformation
   slope_info = this->getData();
+  if(VERTICAL_FLIP)
+    slope_info = AATriangle::vertical_flip(slope_info);
   switch (slope_info & AATriangle::DIRECTION_MASK)
   {
     case AATriangle::SOUTHEAST: /*    . */

--- a/src/supertux/tile.cpp
+++ b/src/supertux/tile.cpp
@@ -166,7 +166,7 @@ Tile::print_debug(int id) const
  * in quotation marks because because the slope's gradient is taken.
  * Also, this uses the movement relative to the tilemaps own movement
  * (if any).  --octo */
-bool Tile::check_movement_unisolid (const Vector& movement) const
+bool Tile::check_movement_unisolid (const Vector& movement, bool vertical_flip) const
 {
   int slope_info;
   double mv_x;
@@ -178,7 +178,7 @@ bool Tile::check_movement_unisolid (const Vector& movement) const
   if (!this->is_slope())
   {
     int dir = this->getData() & Tile::UNI_DIR_MASK;
-    if(VERTICAL_FLIP)
+    if(vertical_flip)
     {
       dir = dir_vertical_flip(dir);
     }
@@ -199,7 +199,7 @@ bool Tile::check_movement_unisolid (const Vector& movement) const
   mv_x = (double) movement.x; //note switch to double for no good reason
   mv_y = (double) movement.y;
   slope_info = this->getData();
-  if(VERTICAL_FLIP)
+  if(vertical_flip)
     slope_info = AATriangle::vertical_flip(slope_info);
   switch (slope_info & AATriangle::DIRECTION_MASK)
   {
@@ -278,7 +278,7 @@ bool is_below_line (float l_x, float l_y, float m,
  * is non-solid. Otherwise, if the object is "above" (south slopes)
  * or "below" (north slopes), the tile will be solid. */
 bool Tile::check_position_unisolid (const Rectf& obj_bbox,
-                                    const Rectf& tile_bbox) const
+                                    const Rectf& tile_bbox, bool vertical_flip) const
 {
   int slope_info;
   float tile_x;
@@ -293,7 +293,7 @@ bool Tile::check_position_unisolid (const Rectf& obj_bbox,
   if (!this->is_slope())
   {
     int dir = this->getData() & Tile::UNI_DIR_MASK;
-    if(VERTICAL_FLIP)
+    if(vertical_flip)
     {
       dir = dir_vertical_flip(dir);
     }
@@ -307,7 +307,7 @@ bool Tile::check_position_unisolid (const Rectf& obj_bbox,
    * describes the slope's surface. The line is defined by x, y, and m, the
    * gradient. */
   slope_info = this->getData();
-  if(VERTICAL_FLIP)
+  if(vertical_flip)
     slope_info = AATriangle::vertical_flip(slope_info);
   switch (slope_info
       & (AATriangle::DIRECTION_MASK | AATriangle::DEFORM_MASK))
@@ -433,21 +433,21 @@ bool Tile::check_position_unisolid (const Rectf& obj_bbox,
   }
 } /* int check_position_unisolid */
 
-bool Tile::is_solid (const Rectf& tile_bbox, const Rectf& position, const Vector& movement) const
+bool Tile::is_solid (const Rectf& tile_bbox, const Rectf& position, const Vector& movement, bool vertical_flip) const
 {
   if (!(attributes & SOLID))
     return false;
 
-  return is_collisionful(tile_bbox, position, movement);
+  return is_collisionful(tile_bbox, position, movement, vertical_flip);
 } /* bool Tile::is_solid */
 
-bool Tile::is_collisionful(const Rectf& tile_bbox, const Rectf& position, const Vector& movement) const
+bool Tile::is_collisionful(const Rectf& tile_bbox, const Rectf& position, const Vector& movement, bool vertical_flip) const
 {
   if (!(attributes & UNISOLID))
     return true;
 
-  return check_movement_unisolid (movement) &&
-         check_position_unisolid (position, tile_bbox);
+  return check_movement_unisolid (movement, vertical_flip) &&
+         check_position_unisolid (position, tile_bbox, vertical_flip);
 } /* bool Tile::is_collisionful */
 
 /* vim: set sw=2 sts=2 et : */

--- a/src/supertux/tile.hpp
+++ b/src/supertux/tile.hpp
@@ -95,12 +95,16 @@ public:
   enum
   {
     UNI_DIR_NORTH = 0,
-    UNI_DIR_SOUTH = 1,
-    UNI_DIR_WEST  = 2,
-    UNI_DIR_EAST  = 3,
+    UNI_DIR_SOUTH = 2,
+    UNI_DIR_WEST  = 3,
+    UNI_DIR_EAST  = 1,
     UNI_DIR_MASK  = 3
   };
 
+  static UNI_DIR_MASK dir_vertical_flip(UNI_DIR_MASK mask)
+  {
+    return (mask+2)%3;
+  }
 private:
   std::vector<ImageSpec> imagespecs;
   std::vector<SurfacePtr>  images;

--- a/src/supertux/tile.hpp
+++ b/src/supertux/tile.hpp
@@ -95,15 +95,19 @@ public:
   enum
   {
     UNI_DIR_NORTH = 0,
-    UNI_DIR_SOUTH = 2,
-    UNI_DIR_WEST  = 3,
-    UNI_DIR_EAST  = 1,
+    UNI_DIR_SOUTH = 1,
+    UNI_DIR_WEST  = 2,
+    UNI_DIR_EAST  = 3,
     UNI_DIR_MASK  = 3
   };
 
-  static UNI_DIR_MASK dir_vertical_flip(UNI_DIR_MASK mask)
+  static int dir_vertical_flip(int dir)
   {
-    return (mask+2)%3;
+    if(dir == UNI_DIR_NORTH)
+      return UNI_DIR_SOUTH;
+    if(dir == UNI_DIR_SOUTH)
+      return UNI_DIR_NORTH;
+    return dir;
   }
 private:
   std::vector<ImageSpec> imagespecs;
@@ -154,7 +158,7 @@ public:
    * into account. Because creating the arguments for this function can be
    * expensive, you should handle trivial cases using the "is_solid()" and
    * "is_unisolid()" methods first. */
-  bool is_solid (const Rectf& tile_bbox, const Rectf& position, const Vector& movement) const;
+  bool is_solid (const Rectf& tile_bbox, const Rectf& position, const Vector& movement, bool vertical_flip = false) const;
 
   /** This version only checks the SOLID flag to determine the solidity of a
    * tile. This means it will always return "true" for unisolid tiles. To
@@ -168,7 +172,7 @@ public:
   /** Determines whether the tile's attributes are important to calculate the
    * collisions. The tile may be unisolid and therefore the collision with that
    * tile don't matter.*/
-  bool is_collisionful(const Rectf& tile_bbox, const Rectf& position, const Vector& movement) const;
+  bool is_collisionful(const Rectf& tile_bbox, const Rectf& position, const Vector& movement,bool vertical_flip) const;
 
   /** Checks the UNISOLID attribute. Returns "true" if set, "false" otherwise. */
   bool is_unisolid() const
@@ -193,12 +197,12 @@ private:
 
   /** Returns zero if a unisolid tile is non-solid due to the movement
    * direction, non-zero if the tile is solid due to direction. */
-  bool check_movement_unisolid (const Vector& movement) const;
+  bool check_movement_unisolid (const Vector& movement, bool vertical_flip) const;
 
   /** Returns zero if a unisolid tile is non-solid due to the position of the
    * tile and the object, non-zero if the tile is solid. */
   bool check_position_unisolid (const Rectf& obj_bbox,
-                                const Rectf& tile_bbox) const;
+                                const Rectf& tile_bbox, bool vertical_flip) const;
 
 private:
   Tile(const Tile&);


### PR DESCRIPTION
Currently, Flipping a level will lead to the unisolid directions be flipped too (thus a different side of the tile will be solid). 

Reported by @Alzter.