### PR TITLE
Added invincibility retaining code between doors

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -264,8 +264,7 @@ GameSession::draw(DrawingContext& context)
   if(game_pause)
     draw_pause(context);
 }
-
-
+                                                                                                                                                                                                                                                                                    
 void
 GameSession::on_window_resize()
 {
@@ -366,6 +365,11 @@ GameSession::update(float elapsed_time)
       currentsector->get_players()[0]->set_edit_mode(edit_mode);
     newsector = "";
     newspawnpoint = "";
+    // retain invincibility if the player has it
+    if(pastinvincibility) {
+      currentsector->get_players()[0]->invincible_timer.start(
+                                                        newinvincibilityperiod);
+    }
   }
 
   // Update the world state and all objects in the world
@@ -441,10 +445,13 @@ GameSession::finish(bool win)
 }
 
 void
-GameSession::respawn(const std::string& sector, const std::string& spawnpoint)
+GameSession::respawn(const std::string& sector, const std::string& spawnpoint,
+                     const bool invincibility, const int invincibilityperiod)
 {
   newsector = sector;
   newspawnpoint = spawnpoint;
+  pastinvincibility = invincibility;
+  newinvincibilityperiod = invincibilityperiod;
 }
 
 void

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -54,7 +54,8 @@ public:
 
   /// ends the current level
   void finish(bool win = true);
-  void respawn(const std::string& sectorname, const std::string& spawnpointname);
+  void respawn(const std::string& sectorname, const std::string& spawnpointname, 
+  const bool invincibility = false, const int invincibilityperiod = 0);
   void reset_level();
   void set_reset_point(const std::string& sectorname, const Vector& pos);
   std::string get_reset_point_sectorname() const
@@ -128,6 +129,10 @@ private:
   // the sector and spawnpoint we should spawn after this frame
   std::string newsector;
   std::string newspawnpoint;
+  
+  // Whether the player had invincibility before spawning in a new sector
+  bool pastinvincibility;
+  int newinvincibilityperiod;
 
   Statistics* best_level_statistics;
   Savegame& m_savegame;

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -152,7 +152,10 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
     {
       // if door is open and was touched by a player, teleport the player
       Player* player = dynamic_cast<Player*> (&other);
+      
       if (player) {
+        bool invincible = player->is_invincible();
+        int invincibilityperiod = player->invincible_timer.get_timeleft();
         state = CLOSING;
         sprite->set_action("closing", 1);
         if(!script.empty()) {
@@ -160,7 +163,8 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
         }
 
         if(!target_sector.empty()) {
-          GameSession::current()->respawn(target_sector, target_spawnpoint);
+          GameSession::current()->respawn(target_sector, target_spawnpoint,
+                                          invincible, invincibilityperiod);
           ScreenManager::current()->set_screen_fade(std::unique_ptr<ScreenFade>(new FadeIn(1)));
         }
       }


### PR DESCRIPTION
This pull request addresses issue number 770, where invincibility stars would immediately deactivate after entering a door, regardless of how much longer the star was supposed to go on for. This pull request makes the player retain the invincibility through doors.

Closes #770