### PR TITLE
Fixed Travis CI problems caused by PR #845

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -68,6 +68,8 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   reset_pos(),
   newsector(),
   newspawnpoint(),
+  pastinvincibility(false),
+  newinvincibilityperiod(0),
   best_level_statistics(statistics),
   m_savegame(savegame),
   play_time(0),


### PR DESCRIPTION
In Pull Request #845, I accidentally forgot to initialize the new variables I created in the constructor, which cause Travis to error out on all subsequent builds. This PR addresses that problem.