### PR TITLE
GUI: cycle through option lists with mouse click

### DIFF
--- a/src/gui/item_stringselect.cpp
+++ b/src/gui/item_stringselect.cpp
@@ -74,6 +74,7 @@ ItemStringSelect::process_action(const MenuAction& action) {
       MenuManager::instance().current_menu()->menu_action(this);
       break;
     case MENU_ACTION_RIGHT:
+    case MENU_ACTION_HIT:
       if( (*selected)+1 < int(list.size())) {
         (*selected)++;
       } else {


### PR DESCRIPTION
Options like display resolution can be changed only with left/right keys, this is not intuitive.