### PR TITLE
Fixed use after free in Downloader

### DIFF
--- a/src/addon/downloader.cpp
+++ b/src/addon/downloader.cpp
@@ -312,7 +312,8 @@ Downloader::update()
     {
       case CURLMSG_DONE:
         {
-          log_info << "Download completed with " << msg->data.result << std::endl;
+          CURLcode resultfromcurl = msg->data.result;
+          log_info << "Download completed with " << resultfromcurl << std::endl;
           curl_multi_remove_handle(m_multi_handle, msg->easy_handle);
 
           auto it = std::find_if(m_transfers.begin(), m_transfers.end(),
@@ -324,7 +325,7 @@ Downloader::update()
           status->error_msg = (*it)->get_error_buffer();
           m_transfers.erase(it);
 
-          if (msg->data.result == CURLE_OK)
+          if (resultfromcurl == CURLE_OK)
           {
             bool success = true;
             for(auto& callback : status->callbacks)
@@ -343,7 +344,7 @@ Downloader::update()
           }
           else
           {
-            log_warning << "Error: " << curl_easy_strerror(msg->data.result) << std::endl;
+            log_warning << "Error: " << curl_easy_strerror(resultfromcurl) << std::endl;
             for(auto& callback : status->callbacks)
             {
               try


### PR DESCRIPTION
This Pull Request fixes a use after free bug reported by address sanitizer in the Downloader class(Issue #672). The bug was caused due to the Downloader class destroying the entire message sent by cURL, including the result code, before it used the result code for detecting if there were any errors in the download operation. Since the result code was destroyed at that point with the entire message, it caused asan to throw a use after free error whenever it was used for checking if download errors existed.


Closes #672 