### PR TITLE
Fixed buffer overflow on game termination

### DIFF
--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -330,7 +330,8 @@ ScreenManager::handle_screen_switch()
 
       // move actions to a new vector since setup() might modify it
       auto actions = std::move(m_actions);
-
+      bool quit_action_triggered = false;
+      
       for(auto& action : actions)
       {
         switch (action.type)
@@ -353,21 +354,26 @@ ScreenManager::handle_screen_switch()
           case Action::QUIT_ACTION:
             m_screen_stack.clear();
             current_screen = nullptr;
+            quit_action_triggered = true;
             break;
         }
       }
 
-      if (current_screen != m_screen_stack.back().get())
+      if (!quit_action_triggered)
       {
-        if(current_screen != nullptr) {
-          current_screen->leave();
-        }
-
-        if (!m_screen_stack.empty())
+        if (current_screen != m_screen_stack.back().get())
         {
-          m_screen_stack.back()->setup();
-          m_speed = 1.0;
-          m_waiting_threads.wakeup();
+          if (current_screen != nullptr)
+          {
+            current_screen->leave();
+          }
+
+          if (!m_screen_stack.empty())
+          {
+            m_screen_stack.back()->setup();
+            m_speed = 1.0;
+            m_waiting_threads.wakeup();
+          }
         }
       }
     }


### PR DESCRIPTION
This pull request fixes a buffer overflow that occurred on game termination, as reported by Issue #671. This overflow was caused from the QUIT_ACTION clearing the entirety of the m_screen_stack stack. However, the code that dealt with the last screen in that screen stack was still being executed after that QUIT_ACTION code was executed, causing a buffer overflow from trying to get the back of an empty vector.

Closes #671 