### PR TITLE
Moved Object name property parsing to GameObject class

### DIFF
--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -71,7 +71,6 @@ Dispenser::Dispenser(const ReaderMapping& reader) :
 
   type_str = get_type_string();
 
-  reader.get("name", name, "");
   reader.get("limit-dispensed-badguys", limit_dispensed_badguys, false);
   reader.get("max-concurrent-badguys", max_concurrent_badguys, 0);
 

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -52,7 +52,6 @@ WillOWisp::WillOWisp(const ReaderMapping& reader) :
 {
   reader.get("sector", target_sector, "main");
   reader.get("spawnpoint", target_spawnpoint, "main");
-  reader.get("name", name, "");
   reader.get("flyspeed", flyspeed, FLYSPEED);
   reader.get("track-range", track_range, TRACK_RANGE);
   reader.get("vanish-range", vanish_range, VANISH_RANGE);

--- a/src/object/ambient_sound.cpp
+++ b/src/object/ambient_sound.cpp
@@ -29,6 +29,7 @@
 #include "video/drawing_context.hpp"
 
 AmbientSound::AmbientSound(const ReaderMapping& lisp) :
+  MovingObject(lisp),
   ExposedObject<AmbientSound, scripting::AmbientSound>(this),
   sample(),
   sound_source(),
@@ -45,7 +46,6 @@ AmbientSound::AmbientSound(const ReaderMapping& lisp) :
   group = COLGROUP_DISABLED;
 
   float w, h;
-  lisp.get("name" , name, "");
   lisp.get("x", bbox.p1.x, 0);
   lisp.get("y", bbox.p1.y, 0);
   lisp.get("width" , w, 32);

--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -51,6 +51,7 @@ Background::Background() :
 }
 
 Background::Background(const ReaderMapping& reader) :
+  GameObject(reader),
   ExposedObject<Background, scripting::Background>(this),
   alignment(NO_ALIGNMENT),
   layer(LAYER_BACKGROUND0),
@@ -74,8 +75,6 @@ Background::Background(const ReaderMapping& reader) :
   has_pos_x = reader.get("x", px);
   has_pos_y = reader.get("y", py);
   this->pos = Vector(px,py);
-
-  reader.get("name", name, "");
 
   speed = 1.0;
   speed_y = 1.0;

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -31,8 +31,6 @@ Candle::Candle(const ReaderMapping& lisp)
     candle_light_1(SpriteManager::current()->create("images/objects/candle/candle-light-1.sprite")),
     candle_light_2(SpriteManager::current()->create("images/objects/candle/candle-light-2.sprite"))
 {
-
-  lisp.get("name", name, "");
   lisp.get("burning", burning, true);
   lisp.get("flicker", flicker, true);
   std::vector<float> vColor;

--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -37,6 +37,7 @@ Gradient::Gradient() :
 }
 
 Gradient::Gradient(const ReaderMapping& reader) :
+  GameObject(reader),
   ExposedObject<Gradient, scripting::Gradient>(this),
   layer(LAYER_BACKGROUND0),
   gradient_top(),
@@ -47,7 +48,6 @@ Gradient::Gradient(const ReaderMapping& reader) :
   layer = reader_get_layer (reader, /* default = */ LAYER_BACKGROUND0);
   std::vector<float> bkgd_top_color, bkgd_bottom_color;
   std::string direction;
-  reader.get("name", name, "");
   if(reader.get("direction", direction))
   {
     if(direction == "horizontal")

--- a/src/object/invisible_wall.cpp
+++ b/src/object/invisible_wall.cpp
@@ -22,10 +22,10 @@
 #include "video/drawing_context.hpp"
 
 InvisibleWall::InvisibleWall(const ReaderMapping& lisp):
+  MovingObject(lisp),
   width(),
   height()
 {
-  lisp.get("name" , name, "");
   lisp.get("x", bbox.p1.x, 0);
   lisp.get("y", bbox.p1.y, 0);
   lisp.get("width", width, 32);

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -31,7 +31,6 @@ Lantern::Lantern(const ReaderMapping& reader) :
   lightcolor(1.0f, 1.0f, 1.0f),
   lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
 {
-  reader.get("name", name, "");
   //get color from lisp
   std::vector<float> vColor;
   if (reader.get("color", vColor)) {

--- a/src/object/level_time.cpp
+++ b/src/object/level_time.cpp
@@ -34,12 +34,12 @@
 static const float TIME_WARNING = 20;
 
 LevelTime::LevelTime(const ReaderMapping& reader) :
+  GameObject(reader),
   ExposedObject<LevelTime, scripting::LevelTime>(this),
   time_surface(Surface::create("images/engine/hud/time-0.png")),
   running(!Editor::is_active()),
   time_left()
 {
-  reader.get("name", name, "");
   reader.get("time", time_left, 0);
   if(time_left <= 0 && !Editor::is_active()) {
     log_warning << "No or invalid leveltime specified." << std::endl;

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -37,6 +37,7 @@ MovingSprite::MovingSprite(const Vector& pos, const std::string& sprite_name_,
 }
 
 MovingSprite::MovingSprite(const ReaderMapping& reader, const Vector& pos, int layer_, CollisionGroup collision_group) :
+  MovingObject(reader),
   sprite_name(),
   default_sprite_name(),
   sprite(),
@@ -53,6 +54,7 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const Vector& pos, int l
 }
 
 MovingSprite::MovingSprite(const ReaderMapping& reader, const std::string& sprite_name_, int layer_, CollisionGroup collision_group) :
+  MovingObject(reader),
   sprite_name(sprite_name_),
   default_sprite_name(sprite_name_),
   sprite(),
@@ -73,6 +75,7 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const std::string& sprit
 }
 
 MovingSprite::MovingSprite(const ReaderMapping& reader, int layer_, CollisionGroup collision_group) :
+  MovingObject(reader),
   sprite_name(),
   default_sprite_name(),
   sprite(),

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -38,7 +38,6 @@ Platform::Platform(const ReaderMapping& reader, const std::string& default_sprit
   last_player_contact(false)
 {
   bool running = true;
-  reader.get("name", name);
   reader.get("running", running);
   if ((name.empty()) && (!running)) {
     automatic = true;

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -52,7 +52,6 @@ Rock::Rock(const ReaderMapping& reader) :
   on_grab_script(),
   on_ungrab_script()
 {
-  reader.get("name", name, "");
   reader.get("on-grab-script", on_grab_script, "");
   reader.get("on-ungrab-script", on_ungrab_script, "");
   SoundManager::current()->preload(ROCK_SOUND);
@@ -69,7 +68,6 @@ Rock::Rock(const ReaderMapping& reader, const std::string& spritename) :
   on_grab_script(),
   on_ungrab_script()
 {
-  if(!reader.get("name", name)) name = "";
   if(!reader.get("on-grab-script", on_grab_script)) on_grab_script = "";
   if(!reader.get("on-ungrab-script", on_ungrab_script)) on_ungrab_script = "";
   SoundManager::current()->preload(ROCK_SOUND);

--- a/src/object/rusty_trampoline.cpp
+++ b/src/object/rusty_trampoline.cpp
@@ -37,7 +37,6 @@ RustyTrampoline::RustyTrampoline(const ReaderMapping& lisp) :
   Rock(lisp, "images/objects/rusty-trampoline/rusty-trampoline.sprite"),
   portable(true), counter(3)
 {
-  lisp.get("name", name, "");
   SoundManager::current()->preload(BOUNCE_SOUND);
 
   lisp.get("counter", counter);

--- a/src/object/scripted_object.cpp
+++ b/src/object/scripted_object.cpp
@@ -40,7 +40,6 @@ ScriptedObject::ScriptedObject(const ReaderMapping& lisp) :
   new_vel(),
   new_size()
 {
-  lisp.get("name", name, "");
   if(name.empty()) {
     name = "unnamed" + std::to_string(graphicsRandom.rand());
     log_warning << "Scripted object must have a name specified, setting to: " << name << std::endl;

--- a/src/object/thunderstorm.cpp
+++ b/src/object/thunderstorm.cpp
@@ -33,6 +33,7 @@ const float ELECTRIFY_TIME = 0.5f;
 }
 
 Thunderstorm::Thunderstorm(const ReaderMapping& reader) :
+  GameObject(reader),
   ExposedObject<Thunderstorm, scripting::Thunderstorm>(this),
   running(true),
   interval(10.0f),

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -62,6 +62,7 @@ TileMap::TileMap(const TileSet *new_tileset) :
 }
 
 TileMap::TileMap(const TileSet *tileset_, const ReaderMapping& reader) :
+  GameObject(reader),
   ExposedObject<TileMap, scripting::TileMap>(this),
   PathObject(),
   editor_active(true),
@@ -91,7 +92,6 @@ TileMap::TileMap(const TileSet *tileset_, const ReaderMapping& reader) :
 {
   assert(tileset);
 
-  reader.get("name",   name);
   reader.get("solid",  real_solid);
   reader.get("speed",  speed_x);
   reader.get("speed-y", speed_y, speed_x);

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -23,6 +23,7 @@
 #include "util/reader_mapping.hpp"
 
 Torch::Torch(const ReaderMapping& reader) :
+  MovingObject(reader),
   ExposedObject<Torch, scripting::Torch>(this),
   m_torch(),
   m_flame(SpriteManager::current()->create("images/objects/torch/flame.sprite")),
@@ -33,8 +34,6 @@ Torch::Torch(const ReaderMapping& reader) :
 {
   reader.get("x", bbox.p1.x);
   reader.get("y", bbox.p1.y);
-
-  reader.get("name", name, "");
 
   reader.get("sprite", sprite_name);
   reader.get("burning", m_burning, true);

--- a/src/object/trampoline.cpp
+++ b/src/object/trampoline.cpp
@@ -38,7 +38,6 @@ Trampoline::Trampoline(const ReaderMapping& lisp) :
   Rock(lisp, "images/objects/trampoline/trampoline.sprite"),
   portable(true)
 {
-  lisp.get("name", name, "");
   SoundManager::current()->preload(TRAMPOLINE_SOUND);
 
   //Check if this trampoline is not portable

--- a/src/object/wind.cpp
+++ b/src/object/wind.cpp
@@ -27,6 +27,7 @@
 #include "video/drawing_context.hpp"
 
 Wind::Wind(const ReaderMapping& reader) :
+  MovingObject(reader),
   ExposedObject<Wind, scripting::Wind>(this),
   blowing(),
   speed(),
@@ -35,7 +36,6 @@ Wind::Wind(const ReaderMapping& reader) :
   elapsed_time(0)
 {
   float w,h;
-  reader.get("name", name,"");
   reader.get("x", bbox.p1.x, 0);
   reader.get("y", bbox.p1.y, 0);
   reader.get("width", w, 32);

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -33,6 +33,12 @@ GameObject::GameObject(const GameObject& rhs) :
 {
 }
 
+GameObject::GameObject(const ReaderMapping& reader) :
+  GameObject()
+{
+  reader.get("name", name, "");
+}
+
 GameObject::~GameObject()
 {
   // call remove listeners (and remove them from the list)

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -22,6 +22,7 @@
 
 #include "editor/object_settings.hpp"
 #include "util/gettext.hpp"
+#include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
 
 class DrawingContext;
@@ -45,6 +46,7 @@ class GameObject
 public:
   GameObject();
   GameObject(const GameObject& rhs);
+  GameObject(const ReaderMapping& reader);
   virtual ~GameObject();
 
   /** This function is called once per frame and allows the object to update

--- a/src/supertux/moving_object.cpp
+++ b/src/supertux/moving_object.cpp
@@ -27,6 +27,15 @@ MovingObject::MovingObject() :
 {
 }
 
+MovingObject::MovingObject(const ReaderMapping& reader) :
+  GameObject(reader),
+  bbox(),
+  movement(),
+  group(COLGROUP_MOVING),
+  dest()
+{
+}
+
 MovingObject::~MovingObject()
 {
 }

--- a/src/supertux/moving_object.hpp
+++ b/src/supertux/moving_object.hpp
@@ -76,6 +76,7 @@ class MovingObject : public GameObject
 {
 public:
   MovingObject();
+  MovingObject(const ReaderMapping& reader);
   virtual ~MovingObject();
 
   /** this function is called when the object collided with something solid */


### PR DESCRIPTION
This Pull Request moves the object name property parsing code to the GameObject class for all direct and indirect subclasses of GameObject (except for ParticleSystem, where the name parsing code was not in the constructor), as requested in issue #862.

I was unable to fully test this code (other than compiling and playing a level in the game) as I was a little unsure how to exactly test it.

Closes #862 