### PR TITLE
WalkingBadguy: intelligent badguys turn around at harmful tiles 

### DIFF
--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -163,6 +163,17 @@ MrIceBlock::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
   return ABORT_MOVE;
 }
 
+void
+MrIceBlock::collision_tile(uint32_t tile_attributes)
+{
+  if ((tile_attributes & Tile::HURTS) && ice_state == ICESTATE_KICKED)
+  {
+    kill_fall();
+  } else {
+    WalkingBadguy::collision_tile(tile_attributes);
+  }
+}
+
 bool
 MrIceBlock::collision_squished(GameObject& object)
 {

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -31,6 +31,7 @@ public:
   void collision_solid(const CollisionHit& hit);
   HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit);
   HitResponse collision_player(Player& player, const CollisionHit& hit);
+  void collision_tile(uint32_t tile_attributes);
 
   void active_update(float elapsed_time);
 

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -227,6 +227,17 @@ Snail::collision_player(Player& player, const CollisionHit& hit)
   return BadGuy::collision_player(player, hit);
 }
 
+void
+Snail::collision_tile(uint32_t tile_attributes)
+{
+  if ((tile_attributes & Tile::HURTS) && state == STATE_KICKED)
+  {
+    kill_fall();
+  } else {
+    WalkingBadguy::collision_tile(tile_attributes);
+  }
+}
+
 bool
 Snail::collision_squished(GameObject& object)
 {

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -33,6 +33,7 @@ public:
   void collision_solid(const CollisionHit& hit);
   HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit);
   HitResponse collision_player(Player& player, const CollisionHit& hit);
+  void collision_tile(uint32_t tile_attributes);
   bool can_break() const;
 
   void active_update(float elapsed_time);

--- a/src/badguy/walking_badguy.cpp
+++ b/src/badguy/walking_badguy.cpp
@@ -191,6 +191,18 @@ WalkingBadguy::collision_badguy(BadGuy& , const CollisionHit& hit)
 }
 
 void
+WalkingBadguy::collision_tile(uint32_t tile_attributes)
+{
+  if ((tile_attributes & Tile::HURTS) && max_drop_height > -1 && on_ground())
+  {
+    // prevents the inteligent bad guys from running into deadly tiles
+    turn_around();
+  } else {
+    BadGuy::collision_tile(tile_attributes);
+  }
+}
+
+void
 WalkingBadguy::turn_around()
 {
   if(frozen)

--- a/src/badguy/walking_badguy.hpp
+++ b/src/badguy/walking_badguy.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_BADGUY_WALKING_BADGUY_HPP
 
 #include "badguy/badguy.hpp"
+#include "supertux/tile.hpp"
 
 class Timer;
 
@@ -51,6 +52,7 @@ public:
   void active_update(float elapsed_time, float target_velocity);
   void collision_solid(const CollisionHit& hit);
   HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit);
+  void collision_tile(uint32_t tile_attributes);
   void freeze();
   void unfreeze();
 


### PR DESCRIPTION
This changes prevents intelligent walking bad guys from running into spikes etc...
Fixes #851