### PR TITLE
README: central Community section for getting in touch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing to SuperTux
 
-## Unsure? [Contact Us](https://supertux.org/contact.html)
-
 ## Bug reports
 
 - GitHub Issues in English only. IRC support might be possible in other languages,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,11 +155,3 @@ For more CMake options, look at end of the Linux/UNIX build section.
 6. Build the project.
 
 7. Now you can run SuperTux using the run_supertux.bat file
-
-
-Support
--------
-
-You can contact us at [supertux-devel@lists.lethargik.org](mailto:supertux-devel@lists.lethargik.org)
-and in the [#supertux](irc://chat.freenode.net/supertux) channel on
-the chat.freenode.net IRC server. Usually someone will be around to give you a hand.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/SuperTux/supertux.svg?branch=master)](https://travis-ci.org/SuperTux/supertux)
 [![AppVeyor Build Satus](https://ci.appveyor.com/api/projects/status/github/SuperTux/supertux?svg=true&branch=master)](https://ci.appveyor.com/project/supertux/supertux-9ml4d/branch/master)
 [![Github All Releases](https://img.shields.io/github/downloads/supertux/supertux/total.svg?maxAge=2592000)](https://github.com/SuperTux/supertux)
-[![#supertux on freenode](https://img.shields.io/badge/freenode-%23supertux-brightgreen.svg)](https://webchat.freenode.net/?channels=supertux)
 
 SuperTux is a jump'n'run game with strong inspiration from the
 Super Mario Bros. games for the various Nintendo platforms.
@@ -72,6 +71,29 @@ arrow keys or the mouse.
 In the worldmap, the arrow keys are used to navigate and Enter to
 enter the current level.
 
+## Community
+
+In case you need help, feel free to reach out using the following means:
+
+* **IRC:** [#supertux](ircs://chat.freenode.net/#supertux) on
+  [freenode](https://freenode.net) hosts most of the discussions between
+  developers. Also, real-time support can be provided here. If you don't know
+  how to use an IRC client, you access the channel using a web-based
+  [client](https://kiwiirc.com/client/chat.freenode.net:+6697/?nick=Guest?#supertux).
+  Please stay around after asking questions, otherwise you will be disconnected
+  and might miss potential answers.
+* **Matrix:** [#supertux:matrix.org](https://matrix.to/#/#supertux:matrix.org)
+  is bridged to our IRC room.
+* **[Forum](https://forum.freegamedev.net/viewforum.php?f=66):** The SuperTux
+  community is very active on the forum, the discussion ranges from feature
+  proposals to support questions. In particular, most community-contributed
+  add-ons are published there first, so this is worth checking.
+* **Mailing Lists:** The
+  [supertux-devel](http://lists.lethargik.org/listinfo.cgi/supertux-devel-lethargik.org)
+  mailing list is intended for development purposes. However, it is not very
+  active at the moment.
+* **Social Media:** Mostly on [Twitter](https://twitter.com/supertux_team) at
+  the moment.
 
 ## Development status
 
@@ -89,8 +111,3 @@ Forest World, but decided that in order to allow more access to the most recent
 version (in repositories etc.) we would have to release Milestone 2 without the
 Forest World included in the Story Mode. Constructive feedback with regards to
 the Forest World is welcome.
-
-Don't forget that you can get involved with the development at
-<https://github.com/supertux/supertux>,
-or get notified about the recent changes on Twitter
-[@supertux_team](https://twitter.com/supertux_team)


### PR DESCRIPTION
Replace the various links and statements describing how to get in touch with the
developers or the community by a central section in the README.

This is the second pull request in a series intended to improve the README for newcomers (see <https://github.com/SuperTux/supertux/pull/882#issue-203013153> for details).