### PR TITLE
Added support for multiple players configs in settings file (multiplayer branch PR)

### DIFF
--- a/src/control/joystick_config.cpp
+++ b/src/control/joystick_config.cpp
@@ -22,13 +22,14 @@
 #include "util/log.hpp"
 #include "util/reader_mapping.hpp"
 
-JoystickConfig::JoystickConfig() :
+JoystickConfig::JoystickConfig(int playernumber) :
   dead_zone(8000),
   jump_with_up_joy(false),
   use_game_controller(true),
   joy_button_map(),
   joy_axis_map(),
-  joy_hat_map()
+  joy_hat_map(),
+  playernum(playernumber)
 {
   // Default joystick button configuration
   bind_joybutton(0, 0, Controller::JUMP);
@@ -162,6 +163,14 @@ JoystickConfig::read(const ReaderMapping& joystick_lisp)
   joystick_lisp.get("jump-with-up", jump_with_up_joy);
   joystick_lisp.get("use-game-controller", use_game_controller);
 
+  if(!joystick_lisp.get("playernum", playernum)) {
+    if(playernum != 0){
+      // We only want the first player to use the old config that was made for
+      // only one player.
+      return;
+    }
+  }
+
   auto iter = joystick_lisp.get_iter();
   while(iter.next())
   {
@@ -218,6 +227,7 @@ JoystickConfig::write(Writer& writer)
   writer.write("dead-zone", dead_zone);
   writer.write("jump-with-up", jump_with_up_joy);
   writer.write("use-game-controller", use_game_controller);
+  writer.write("playernum", playernum);
 
   for(const auto& i : joy_button_map) {
     writer.start_list("map");

--- a/src/control/joystick_config.hpp
+++ b/src/control/joystick_config.hpp
@@ -41,8 +41,9 @@ public:
   AxisMap joy_axis_map;
   HatMap joy_hat_map;
 
+  int playernum;
 public:
-  JoystickConfig();
+  JoystickConfig(int playernumber = 0);
 
   void print_joystick_mappings() const;
 

--- a/src/control/keyboard_config.cpp
+++ b/src/control/keyboard_config.cpp
@@ -19,9 +19,10 @@
 #include "util/log.hpp"
 #include "util/reader_mapping.hpp"
 
-KeyboardConfig::KeyboardConfig() :
+KeyboardConfig::KeyboardConfig(int playernumber) :
   keymap(),
-  jump_with_up_kbd(false)
+  jump_with_up_kbd(false),
+  playernum(playernumber)
 {
   // initialize default keyboard map
   keymap[SDLK_LEFT]     = Controller::LEFT;
@@ -55,6 +56,13 @@ KeyboardConfig::read(const ReaderMapping& keymap_lisp)
   if (config_is_sdl2)
   {
     keymap_lisp.get("jump-with-up", jump_with_up_kbd);
+
+    // We only want the first player to use the old config that was made for
+    // only one player.
+    if(!keymap_lisp.get("playernum", playernum) &&
+       playernum != 0){
+      return;
+    }
 
     auto iter = keymap_lisp.get_iter();
     while(iter.next())
@@ -136,6 +144,7 @@ KeyboardConfig::write(Writer& writer)
   writer.write("sdl2", true);
 
   writer.write("jump-with-up", jump_with_up_kbd);
+  writer.write("playernum", playernum);
 
   for(const auto& i : keymap)
   {

--- a/src/control/keyboard_config.hpp
+++ b/src/control/keyboard_config.hpp
@@ -28,7 +28,7 @@ class ReaderMapping;
 class KeyboardConfig
 {
 public:
-  KeyboardConfig();
+  KeyboardConfig(int playernumber = 0);
 
   SDL_Keycode reversemap_key(Controller::Control c) const;
   void bind_key(SDL_Keycode key, Controller::Control c);
@@ -39,6 +39,7 @@ public:
   typedef std::map<SDL_Keycode, Controller::Control> KeyMap;
   KeyMap keymap;
   bool jump_with_up_kbd;
+  int playernum;
 };
 
 #endif

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -27,7 +27,7 @@
 #include "util/log.hpp"
 #include "supertux/globals.hpp"
 
-Config::Config() :
+Config::Config(int numberofplayers) :
   profile(1),
   fullscreen_size(0, 0),
   fullscreen_refresh_rate(0),
@@ -49,14 +49,20 @@ Config::Config() :
   tux_spawn_pos(),
   edit_level(),
   locale(),
-  keyboard_config(),
-  joystick_config(),
+  keyboard_configs(),
+  joystick_configs(),
   addons(),
   developer_mode(false),
   christmas_mode(false),
   transitions_enabled(true),
   repository_url()
 {
+  assert(numberofplayers > 0);
+
+  for(int i = 0; i < numberofplayers; ++i){
+    keyboard_configs.push_back(std::make_shared<KeyboardConfig>(i));
+    joystick_configs.push_back(std::make_shared<JoystickConfig>(i));
+  }
 }
 
 void
@@ -124,15 +130,35 @@ Config::load()
   if (config_lisp.get("control", config_control_lisp))
   {
     ReaderMapping keymap_lisp;
-    if (config_control_lisp.get("keymap", keymap_lisp))
-    {
-      keyboard_config.read(keymap_lisp);
+    
+    if(keyboard_configs.size() != joystick_configs.size()) {
+        log_warning << "Malformed Config file was tried to be loaded from! " 
+                    << "Defaults were loaded instead." << std::endl;
+        return;
+    }
+    
+    for(auto& keyboard_config : keyboard_configs) {
+      if (config_control_lisp.get("keymap", keymap_lisp))
+      {
+        keyboard_config.get()->read(keymap_lisp);
+      } 
+      else
+      {
+        break;
+      }
     }
 
     ReaderMapping joystick_lisp;
-    if (config_control_lisp.get("joystick", joystick_lisp))
-    {
-      joystick_config.read(joystick_lisp);
+    
+    for(auto& joystick_config : joystick_configs) {
+      if (config_control_lisp.get("joystick", joystick_lisp))
+      {
+        joystick_config.get()->read(joystick_lisp);
+      }
+      else
+      {
+        break;
+      }
     }
   }
 
@@ -205,13 +231,19 @@ Config::save()
 
   writer.start_list("control");
   {
-    writer.start_list("keymap");
-    keyboard_config.write(writer);
-    writer.end_list("keymap");
+    assert(keyboard_configs.size() == joystick_configs.size());
+  
+    for(auto& keyboard_config : keyboard_configs) {
+      writer.start_list("keymap");
+      keyboard_config->write(writer);
+      writer.end_list("keymap");
+    }
 
-    writer.start_list("joystick");
-    joystick_config.write(writer);
-    writer.end_list("joystick");
+    for(auto& joystick_config : joystick_configs) {
+      writer.start_list("joystick");
+      joystick_config->write(writer);
+      writer.end_list("joystick");
+    }
   }
   writer.end_list("control");
 

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -30,7 +30,7 @@
 class Config
 {
 public:
-  Config();
+  Config(int numberofplayers = 1);
 
   void load();
   void save();
@@ -79,8 +79,8 @@ public:
       means autodetect. */
   std::string locale;
 
-  KeyboardConfig keyboard_config;
-  JoystickConfig joystick_config;
+  std::vector<std::shared_ptr<KeyboardConfig>> keyboard_configs;
+  std::vector<std::shared_ptr<JoystickConfig>> joystick_configs;
 
   struct Addon
   {

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -374,7 +374,11 @@ Main::launch_game()
   ConsoleBuffer console_buffer;
 
   timelog("controller");
-  InputManager input_manager(g_config->keyboard_config, g_config->joystick_config);
+  
+  // TODO: Make InputManager parse more than one keyboard/joystick configs
+  // TODO: for supporting multiple players.
+  InputManager input_manager(*g_config->keyboard_configs[0].get(), 
+                            *g_config->joystick_configs[0].get());
 
   timelog("commandline");
 

--- a/src/supertux/menu/joystick_menu.cpp
+++ b/src/supertux/menu/joystick_menu.cpp
@@ -89,7 +89,8 @@ JoystickMenu::recreate_menu()
       add_inactive(_("It will be removed from the next release"));
       // l10n: Continuation of string "It will be removed from the next release"
       add_inactive(_("of SuperTux."));
-      add_toggle(MNID_JUMP_WITH_UP, _("Jump with Up"), &g_config->joystick_config.jump_with_up_joy);
+      add_toggle(MNID_JUMP_WITH_UP, _("Jump with Up"), 
+                        &g_config->joystick_configs[0].get()->jump_with_up_joy);
     }
     else
     {
@@ -154,9 +155,11 @@ JoystickMenu::refresh_menu_item(Controller::Control id)
     return;
   }
 
-  int button  = g_config->joystick_config.reversemap_joybutton(id);
-  int axis    = g_config->joystick_config.reversemap_joyaxis(id);
-  int hat_dir = g_config->joystick_config.reversemap_joyhat(id);
+  // TODO: Be able to handle multiple joystick configurations for different
+  // TODO: players.
+  int button  = g_config->joystick_configs[0].get()->reversemap_joybutton(id);
+  int axis    = g_config->joystick_configs[0].get()->reversemap_joyaxis(id);
+  int hat_dir = g_config->joystick_configs[0].get()->reversemap_joyhat(id);
 
   if (button != -1)
   {

--- a/src/supertux/menu/keyboard_menu.cpp
+++ b/src/supertux/menu/keyboard_menu.cpp
@@ -50,7 +50,8 @@ KeyboardMenu::KeyboardMenu(InputManager& input_manager) :
   add_inactive(_("It will be removed from the next release"));
   // l10n: Continuation of string "It will be removed from the next release"
   add_inactive(_("of SuperTux."));
-  add_toggle(Controller::CONTROLCOUNT, _("Jump with Up"), &g_config->keyboard_config.jump_with_up_kbd);
+  add_toggle(Controller::CONTROLCOUNT, _("Jump with Up"), 
+            &g_config->keyboard_configs[0].get()->jump_with_up_kbd);
   add_hl();
   add_back(_("Back"));
   refresh();
@@ -111,7 +112,9 @@ KeyboardMenu::menu_action(MenuItem* item)
 void
 KeyboardMenu::refresh()
 {
-  KeyboardConfig& kbd_cfg = g_config->keyboard_config;
+  // TODO: Make this menu parse more than one keyboard config
+  // TODO: for supporting multiple players.
+  KeyboardConfig& kbd_cfg = *g_config->keyboard_configs[0].get();
   ItemControlField* micf;
 
   micf = dynamic_cast<ItemControlField*>(&get_item_by_id((int) Controller::UP));


### PR DESCRIPTION
This commit adds support for storing multiple players configs in the settings file, while attempting to maintain backwards compatibility by automatically detecting if the config file does not have a "playernum" property and if so, assigns that keymap to the first player only. This PR however, does not adapt KeyboardMenu or JoystickMenu to support more than one player, as it just adapts them to get the first KeyboardConfig or JoystickConfig object from vectors of shared pointers of them.

This might need a bit of discussion before it gets merged, as issue #852 said prior.

Closes #852