### PR TITLE
Update target times for Icy Island levels [ci skip]

### DIFF
--- a/data/levels/world1/15 - Under the Ice.stl
+++ b/data/levels/world1/15 - Under the Ice.stl
@@ -3,7 +3,7 @@
   (name (_ "Under the Ice"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 60)
+  (target-time 75)
   (sector
     (name "main")
     (music "music/cave.music")

--- a/data/levels/world1/16 - Living in a Fridge.stl
+++ b/data/levels/world1/16 - Living in a Fridge.stl
@@ -3,7 +3,7 @@
   (name (_ "Living in a Fridge"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/cave.music")

--- a/data/levels/world1/17 - Or is it just me.stl
+++ b/data/levels/world1/17 - Or is it just me.stl
@@ -3,7 +3,7 @@
   (name (_ "'...or is it just me?'"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 60)
+  (target-time 90)
   (sector
     (name "main")
     (music "music/voc-dark.music")

--- a/data/levels/world1/18 - Ice in the Hole.stl
+++ b/data/levels/world1/18 - Ice in the Hole.stl
@@ -3,7 +3,7 @@
   (name (_ "Ice in the Hole"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/cave.music")

--- a/data/levels/world1/19 - Miyamoto Monument.stl
+++ b/data/levels/world1/19 - Miyamoto Monument.stl
@@ -3,7 +3,7 @@
   (name (_ "Miyamoto Monument"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/cave.music")

--- a/data/levels/world1/20 - End of the Tunnel.stl
+++ b/data/levels/world1/20 - End of the Tunnel.stl
@@ -3,7 +3,7 @@
   (name (_ "End of the Tunnel"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/cave.music")

--- a/data/levels/world1/21 - A Path in the Clouds.stl
+++ b/data/levels/world1/21 - A Path in the Clouds.stl
@@ -3,7 +3,7 @@
   (name (_ "A Path in the Clouds"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 60)
+  (target-time 75)
   (sector
     (name "main")
     (music "music/chipdisko.ogg")

--- a/data/levels/world1/23 - The Escape.stl
+++ b/data/levels/world1/23 - The Escape.stl
@@ -3,7 +3,7 @@
   (name (_ "The Escape"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 60)
+  (target-time 65)
   (sector
     (name "main")
     (music "music/chipdisko.ogg")

--- a/data/levels/world1/24 - The Shattered Bridge.stl
+++ b/data/levels/world1/24 - The Shattered Bridge.stl
@@ -3,7 +3,7 @@
   (name (_ "The Shattered Bridge"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/wisphunt.music")

--- a/data/levels/world1/25 - Arctic Ruins.stl
+++ b/data/levels/world1/25 - Arctic Ruins.stl
@@ -3,7 +3,7 @@
   (name (_ "Arctic Ruins"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 80)
   (sector
     (name "main")
     (music "music/wisphunt.music")

--- a/data/levels/world1/26 - The Castle of Nolok.stl
+++ b/data/levels/world1/26 - The Castle of Nolok.stl
@@ -3,7 +3,7 @@
   (name (_ "The Castle of Nolok"))
   (author "SuperTux Team")
   (license "GPL 2+ / CC-by-sa 3.0")
-  (target-time 70)
+  (target-time 90)
   (sector
     (name "main")
     (music "music/fortress.music")


### PR DESCRIPTION
The target times seemed harsher or much harsher than the others. They are not designed for hard-core speedrunners. This should make this more consistent with times in the rest of the worldmap and hopefully fairer, and at least make it possible for casual users.