### PR TITLE
Fix bug introduced by text array

### DIFF
--- a/src/object/text_array_object.hpp
+++ b/src/object/text_array_object.hpp
@@ -28,6 +28,8 @@
 #include "object/text_object.hpp"
 #include "object/text_array_item.hpp"
 
+typedef size_t ta_index;
+
 /**
  * A text array object intended for narration
  */

--- a/src/scripting/text_array.cpp
+++ b/src/scripting/text_array.cpp
@@ -50,7 +50,7 @@ void TextArray::set_fade_time(float fadetime)
   m_parent->set_fade_time(fadetime);
 }
 
-void TextArray::set_text_index(ta_index index_)
+void TextArray::set_text_index(int index_)
 {
   m_parent->set_text_index(index_);
 }

--- a/src/scripting/text_array.hpp
+++ b/src/scripting/text_array.hpp
@@ -23,7 +23,6 @@
 class TextArrayObject;
 #endif
 
-typedef size_t ta_index;
 
 namespace scripting {
 
@@ -54,7 +53,7 @@ public:
   void clear();
   void add_text(const std::string& text);
   void add_text_duration(const std::string& text, float duration);
-  void set_text_index(ta_index index_);
+  void set_text_index(int index_);
   void set_keep_visible(bool keep_visible_);
   void set_fade_transition(bool fade_transition);
   void set_fade_time(float fadetime);
@@ -85,4 +84,3 @@ public:
 #endif // HEADER_SUPERTUX_SCRIPTING_TEXT_ARRAY_HPP
 
 /* EOF */
-


### PR DESCRIPTION
Some changes in text array (without regenerating wrapper) had led to wrapper be non-generatable (custom typedefs, using `size_t`.