### PR TITLE
BadGuy Squish Particle Effects & Enhance Particle Physics

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -486,8 +486,8 @@ BadGuy::kill_squished(GameObject& object)
     float green = graphicsRandom.randf(0.6f, 1.0f);
     float blue = graphicsRandom.randf(0.6f, 1.0f);
     sector->add_object(std::make_shared<Particles>(pos, -60, 60, 140, 140,
-                                                   Vector(0, 0), 45, Color(red, green, blue), 3, 0.5f,
-                                                   LAYER_FOREGROUND1+1, 600.0f, 200.0f)); 
+                                                   Vector(0, 0), 45, Color(red, green, blue), 20, 1.5f,
+                                                   LAYER_FOREGROUND1+1, 450.0f, 200.0f)); 
 
   }
 

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -482,8 +482,6 @@ BadGuy::kill_squished(GameObject& object)
     // particles code, as seen in fireworks.cpp
     Sector *sector = Sector::current();
     Vector pos = get_pos();
-    //pos += Vector(graphicsRandom.randf(static_cast<float>(SCREEN_WIDTH)),
-    //              graphicsRandom.randf(static_cast<float>(SCREEN_HEIGHT) / 2.0f));
     float red = graphicsRandom.randf(0.6f, 1.0f);
     float green = graphicsRandom.randf(0.6f, 1.0f);
     float blue = graphicsRandom.randf(0.6f, 1.0f);

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -67,6 +67,7 @@ BadGuy::BadGuy(const Vector& pos, Direction direction, const std::string& sprite
   is_active_flag(),
   state_timer(),
   on_ground_flag(false),
+  has_death_particles(true),
   floor_normal(),
   colgroup_active(COLGROUP_MOVING),
   parent_dispenser()
@@ -100,6 +101,7 @@ BadGuy::BadGuy(const ReaderMapping& reader, const std::string& sprite_name_, int
   is_active_flag(),
   state_timer(),
   on_ground_flag(false),
+  has_death_particles(true),
   floor_normal(),
   colgroup_active(COLGROUP_MOVING),
   parent_dispenser()
@@ -474,6 +476,21 @@ BadGuy::kill_squished(GameObject& object)
   auto player = dynamic_cast<Player*>(&object);
   if (player) {
     player->bounce(*this);
+  }
+
+  if (dead_script.empty() && has_death_particles) {
+    // particles code, as seen in fireworks.cpp
+    Sector *sector = Sector::current();
+    Vector pos = get_pos();
+    //pos += Vector(graphicsRandom.randf(static_cast<float>(SCREEN_WIDTH)),
+    //              graphicsRandom.randf(static_cast<float>(SCREEN_HEIGHT) / 2.0f));
+    float red = graphicsRandom.randf(0.6f, 1.0f);
+    float green = graphicsRandom.randf(0.6f, 1.0f);
+    float blue = graphicsRandom.randf(0.6f, 1.0f);
+    sector->add_object(std::make_shared<Particles>(pos, -60, 60, 140, 140,
+                                                   Vector(0, 0), 45, Color(red, green, blue), 3, 0.5f,
+                                                   LAYER_FOREGROUND1+1, 600.0f)); 
+
   }
 
   // start dead-script

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -489,7 +489,7 @@ BadGuy::kill_squished(GameObject& object)
     float blue = graphicsRandom.randf(0.6f, 1.0f);
     sector->add_object(std::make_shared<Particles>(pos, -60, 60, 140, 140,
                                                    Vector(0, 0), 45, Color(red, green, blue), 3, 0.5f,
-                                                   LAYER_FOREGROUND1+1, 600.0f)); 
+                                                   LAYER_FOREGROUND1+1, 600.0f, 200.0f)); 
 
   }
 

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -19,9 +19,14 @@
 
 #include "editor/object_option.hpp"
 #include "object/moving_sprite.hpp"
+#include "object/particles.hpp"
 #include "supertux/direction.hpp"
 #include "supertux/physic.hpp"
 #include "supertux/timer.hpp"
+
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
+
 
 class Dispenser;
 class Player;
@@ -291,6 +296,10 @@ private:
   /** true if we touched something solid from above and
       update_on_ground_flag was called last frame */
   bool on_ground_flag;
+
+  /** the defined Particle effect for this object.
+      Will need to  be defined in the constructor for each badguy */
+  bool has_death_particles;
 
   /** floor normal stored the last time when update_on_ground_flag was
       called and we touched something solid from above */

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -19,8 +19,10 @@
 #include <math.h>
 
 #include "audio/sound_manager.hpp"
+#include "math/random_generator.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
+#include "supertux/sector.hpp"
 
 namespace {
 const float KICKSPEED = 500;
@@ -210,7 +212,20 @@ MrIceBlock::collision_squished(GameObject& object)
       break;
   }
 
-  if (player) player->bounce(*this);
+  if (player)
+  {
+    player->bounce(*this); 
+    printf("Testing\n");
+    Sector *sector = Sector::current();
+    Vector pos = get_pos();
+    float red = graphicsRandom.randf(0.6f, 1.0f);
+    float green = graphicsRandom.randf(0.6f, 1.0f);
+    float blue = graphicsRandom.randf(0.6f, 1.0f);
+    sector->add_object(std::make_shared<Particles>(pos, -60, 60, 200, 200,
+                                                   Vector(0, 0), 45, Color(red, green, blue), 3, 5.0f,
+                                                   LAYER_FOREGROUND1+1, 600.0f, 200.0f)); 
+
+  }
   return true;
 }
 

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -215,15 +215,14 @@ MrIceBlock::collision_squished(GameObject& object)
   if (player)
   {
     player->bounce(*this); 
-    printf("Testing\n");
     Sector *sector = Sector::current();
     Vector pos = get_pos();
     float red = graphicsRandom.randf(0.6f, 1.0f);
     float green = graphicsRandom.randf(0.6f, 1.0f);
     float blue = graphicsRandom.randf(0.6f, 1.0f);
-    sector->add_object(std::make_shared<Particles>(pos, -60, 60, 200, 200,
-                                                   Vector(0, 0), 45, Color(red, green, blue), 3, 5.0f,
-                                                   LAYER_FOREGROUND1+1, 600.0f, 200.0f)); 
+    sector->add_object(std::make_shared<Particles>(pos, 0, 75, 200, 200,
+                                                   Vector(0, 0), 45, Color(red, green, blue), 20, 3.0f,
+                                                   LAYER_FOREGROUND1+1, 450.0f, 200.0f)); 
 
   }
   return true;

--- a/src/math/vector.hpp
+++ b/src/math/vector.hpp
@@ -116,6 +116,11 @@ public:
     return Vector(floorf(x), floorf(y));
   }
 
+  float magnitude()
+  {
+    return sqrt(x * x + y * y);
+  }
+
   // ... add the other operators as needed, I'm too lazy now ...
 
   float x, y; // leave this public, get/set methods just give me headaches

--- a/src/math/vector.hpp
+++ b/src/math/vector.hpp
@@ -116,11 +116,6 @@ public:
     return Vector(floorf(x), floorf(y));
   }
 
-  float magnitude()
-  {
-    return sqrt(x * x + y * y);
-  }
-
   // ... add the other operators as needed, I'm too lazy now ...
 
   float x, y; // leave this public, get/set methods just give me headaches

--- a/src/object/particles.cpp
+++ b/src/object/particles.cpp
@@ -148,9 +148,14 @@ Particles::update(float elapsed_time)
 void
 Particles::draw(DrawingContext& context)
 {
+  float particle_size = 1.0f / timer.get_timegone();
+  if(particle_size > size)
+  {
+    particle_size = size;
+  }
   // draw particles
   for(auto& particle : particles) {
-    context.color().draw_filled_rect(particle->pos, Vector(size,size), color, drawing_layer);
+    context.color().draw_filled_rect(particle->pos, Vector(particle_size, particle_size), color, drawing_layer);
   }
 }
 

--- a/src/object/particles.cpp
+++ b/src/object/particles.cpp
@@ -158,7 +158,7 @@ float
 Particles::angle(Vector &pos)
 {
   float dot_product = m_epicenter * pos;
-  float lengths = m_epicenter.magnitude() * pos.magnitude();
+  float lengths = m_epicenter.norm() * pos.norm();
   return (dot_product / lengths); 
 }
 

--- a/src/object/particles.hpp
+++ b/src/object/particles.hpp
@@ -34,11 +34,8 @@ public:
   Particles(const Vector& epicenter, int min_angle, int max_angle,
             const float min_initial_velocity, const float max_initial_velocity,
             const Vector& acceleration, int number, Color color,
-            int size, float life_time, int drawing_layer);
-  Particles(const Vector& epicenter, int min_angle, int max_angle,
-            const float min_initial_velocity, const float max_initial_velocity,
-            const Vector& acceleration, int number, Color color,
-            int size, float life_time, int drawing_layer, float gravity);
+            int size, float life_time, int drawing_layer, 
+            float gravity = 0.0f, float x_linear_accel = 0.0f);
   virtual bool is_saveable() const {
     return false;
   }
@@ -57,7 +54,11 @@ private:
     //     float angle;
   };
 
+  // doesn't return the angle, but returns the cos(theta) value
+  float angle(Vector &pos); // pass the particle position
+
 private:
+  Vector m_epicenter;
   Vector accel;
   Timer timer;
   bool live_forever;
@@ -65,8 +66,7 @@ private:
   Color color;
   float size;
   int drawing_layer;
-  float m_gravity;
-
+  float m_x_accel;
   std::vector<std::unique_ptr<Particle> > particles;
 };
 

--- a/src/object/particles.hpp
+++ b/src/object/particles.hpp
@@ -35,6 +35,10 @@ public:
             const float min_initial_velocity, const float max_initial_velocity,
             const Vector& acceleration, int number, Color color,
             int size, float life_time, int drawing_layer);
+  Particles(const Vector& epicenter, int min_angle, int max_angle,
+            const float min_initial_velocity, const float max_initial_velocity,
+            const Vector& acceleration, int number, Color color,
+            int size, float life_time, int drawing_layer, float gravity);
   virtual bool is_saveable() const {
     return false;
   }
@@ -61,6 +65,7 @@ private:
   Color color;
   float size;
   int drawing_layer;
+  float m_gravity;
 
   std::vector<std::unique_ptr<Particle> > particles;
 };


### PR DESCRIPTION
Right now, this does two things
- particles can now optionally have a "gravitational" effect, or an acceleration in the y direction to make them more interesting.
- Badguy's now emit particles when they're killed by a squish, to make it a little more interesting.

TODO:
- Maybe add a more complicated subclass of Particles, PhysicsParticles, which will allow for more complicated particle movement (think effecting x, y, at t^2 and t^3 rates)
~~- Perhaps add in a "z" value to give depth to the particles and increasee / decrease size accordingly.~~ Done without storing a "z" value, just decreased the size over time.
- Particles are usually pretty gray or white... change that?
- Add different particle effects for different badguys.