### PR TITLE
Install shader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,6 +784,7 @@ install(DIRECTORY
   ${CMAKE_CURRENT_SOURCE_DIR}/data/fonts
   ${CMAKE_CURRENT_SOURCE_DIR}/data/music
   ${CMAKE_CURRENT_SOURCE_DIR}/data/scripts
+  ${CMAKE_CURRENT_SOURCE_DIR}/data/shader
   ${CMAKE_CURRENT_SOURCE_DIR}/data/speech
   ${CMAKE_CURRENT_SOURCE_DIR}/data/sounds
   ${CMAKE_CURRENT_SOURCE_DIR}/data/locale


### PR DESCRIPTION
I currently get this error when running the nightly build:

```
flatpak run org.supertuxproject.SuperTux//master
[FATAL] /run/build/supertux/src/supertux/main.cpp:554 Unexpected exception: Couldn't open file 'shader/shader330.frag': 11
```