### PR TITLE
Make freetype required, libraqm optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,12 +397,17 @@ set_target_properties(tinygettext_lib PROPERTIES IMPORTED_LOCATION "${TINYGETTEX
 include_directories(SYSTEM ${TINYGETTEXT_PREFIX}/include)
 
 ## external/SDL_ttf with patches
-find_package(Freetype)
+find_package(Freetype REQUIRED)
 find_package(RAQM)
+if(RAQM_FOUND)
+  set(WITH_RAQM --with-raqm)
+else()
+  set(WITH_RAQM --without-raqm)
+endif()
 set(SDL_TTF_PREFIX ${CMAKE_BINARY_DIR}/SDL_ttf/)
 ExternalProject_Add(SDL_ttf
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/SDL_ttf/"
-  CONFIGURE_COMMAND env CC=${CMAKE_C_COMPILER} ${CMAKE_SOURCE_DIR}/external/SDL_ttf/configure --prefix=${SDL_TTF_PREFIX} --enable-static --disable-shared --with-raqm --with-freetype-prefix=${FREETYPE_DIR} --with-sdl-prefix=${SDL2_PREFIX}
+  CONFIGURE_COMMAND env CC=${CMAKE_C_COMPILER} ${CMAKE_SOURCE_DIR}/external/SDL_ttf/configure --prefix=${SDL_TTF_PREFIX} --enable-static --disable-shared ${WITH_RAQM} --with-freetype-prefix=${FREETYPE_DIR} --with-sdl-prefix=${SDL2_PREFIX}
   BUILD_COMMAND ${MAKE})
 add_library(SDL_ttf_lib STATIC IMPORTED)
 set_target_properties(SDL_ttf_lib PROPERTIES IMPORTED_LOCATION "${SDL_TTF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}SDL2_ttf${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -670,7 +675,9 @@ target_link_libraries(supertux2_lib PUBLIC ${SDL2_LIBRARIES})
 target_link_libraries(supertux2_lib PUBLIC ${SDL2IMAGE_LIBRARIES})
 target_link_libraries(supertux2_lib PUBLIC SDL_ttf_lib)
 target_link_libraries(supertux2_lib PUBLIC ${FREETYPE_LIBRARIES})
-target_link_libraries(supertux2_lib PUBLIC ${RAQM_LIBRARIES})
+if(RAQM_FOUND)
+  target_link_libraries(supertux2_lib PUBLIC ${RAQM_LIBRARIES})
+endif()
 
 target_link_libraries(supertux2_lib PUBLIC squirrel_lib)
 target_link_libraries(supertux2_lib PUBLIC sqstdlib_lib)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ distributions.
   - a shell and common POSIX command line tools
   - **Note:** To get these tools, you can install `build-essential` on Debian-based distros,
     `base-devel` on Arch-based distros and the Xcode Command Line tools on OS X.
-* [CMake](http://www.cmake.org/) 2.8 or later: most package managers ship this as `cmake`
+* [CMake](http://www.cmake.org/) 3.1 or later: most package managers ship this as `cmake`
 * OpenGL headers and libraries: OpenGL libraries and headers are
   specific to your graphics card. Make sure that you have hardware
   accelerated OpenGL drivers installed. Software renderers like Mesa
@@ -47,6 +47,9 @@ distributions.
 * [Boost](http://www.boost.org) smart_ptr and format headers, along with date_time and filesystem libraries
 * [cURL](http://curl.haxx.se/libcurl/): for Add-on downloads
 * [libogg and libvorbis](https://www.xiph.org/)
+* [FreeType](https://www.freetype.org/)
+* [libraqm](https://github.com/HOST-Oman/libraqm): optional, but needed
+  to display Arabic
 
 **Note I:** for any of the above listed libraries (OpenGL, SDL2, SDL2_image,
 OpenAL, GLEW/glbinding, Boost, cURL, libogg and libvorbis), you should


### PR DESCRIPTION
If libraqm was not found, then configure SDL_ttf --without-raqm and
don't link to libraqm.  This fixes a CMake error for linking to a
not-found library.  SuperTux built this way can't display Arabic but
can still display English.

Make Freetype REQUIRED, so not finding it is an error.  Update
INSTALL.md to list CMake 3.1, Freetype, and optional libraqm.