### PR TITLE
Fix music on big-endian platforms

### DIFF
--- a/src/audio/ogg_sound_file.cpp
+++ b/src/audio/ogg_sound_file.cpp
@@ -16,6 +16,8 @@
 
 #include "audio/ogg_sound_file.hpp"
 
+#include <config.h>
+
 #include <assert.h>
 #include <physfs.h>
 

--- a/src/audio/wav_sound_file.cpp
+++ b/src/audio/wav_sound_file.cpp
@@ -16,6 +16,8 @@
 
 #include "audio/wav_sound_file.hpp"
 
+#include <config.h>
+
 #include <string.h>
 #include <stdint.h>
 #include <assert.h>


### PR DESCRIPTION
ogg_sound_file.cpp forgot to #include <config.h>, so the definition
of WORDS_BIGENDIAN was missing, so it played noise instead of music.
wav_sound_file.cpp seems to get <config.h> from another header, but
add #include to be sure.