### PR TITLE
Show power up count

### DIFF
--- a/src/supertux/player_status_hud.cpp
+++ b/src/supertux/player_status_hud.cpp
@@ -30,7 +30,9 @@ PlayerStatusHUD::PlayerStatusHUD(PlayerStatus& player_status) :
   m_player_status(player_status),
   displayed_coins(DISPLAYED_COINS_UNSET),
   displayed_coins_frame(0),
-  coin_surface(Surface::from_file("images/engine/hud/coins-0.png"))
+  coin_surface(Surface::from_file("images/engine/hud/coins-0.png")),
+  fire_surface(Surface::from_file("images/objects/bullets/fire_bullet-0.png")),
+  ice_surface(Surface::from_file("images/objects/bullets/ice_bullet.png"))
 {
 }
 
@@ -84,6 +86,73 @@ PlayerStatusHUD::draw(DrawingContext& context)
                             ALIGN_LEFT,
                             LAYER_HUD,
                             PlayerStatusHUD::text_color);
+
+  std::string ammo_text;
+
+  if (m_player_status.bonus == FIRE_BONUS) {
+
+    ammo_text = std::to_string(m_player_status.max_fire_bullets);
+
+    if (fire_surface) {
+      context.color().draw_surface(fire_surface,
+                                   Vector(static_cast<float>(context.get_width())
+                                              - BORDER_X
+                                              - static_cast<float>(fire_surface->get_width())
+                                              - Resources::fixed_font->get_text_width(ammo_text),
+                                          BORDER_Y
+                                              + 1.0f
+                                              + (Resources::fixed_font->get_text_height(coins_text) + 5)
+                                              + (Resources::fixed_font->get_text_height(ammo_text) + 5)
+                                              * static_cast<float>(player_id)),
+                                   LAYER_HUD);
+    }
+
+    context.color().draw_text(Resources::fixed_font,
+                              ammo_text,
+                              Vector(static_cast<float>(context.get_width())
+                                         - BORDER_X
+                                         - Resources::fixed_font->get_text_width(ammo_text),
+                                     BORDER_Y
+                                         + (Resources::fixed_font->get_text_height(coins_text) + 5.0f)
+                                         + (Resources::fixed_font->get_text_height(ammo_text) + 5.0f)
+                                         * static_cast<float>(player_id)),
+                              ALIGN_LEFT,
+                              LAYER_HUD,
+                              PlayerStatusHUD::text_color);
+  }
+
+  if (m_player_status.bonus == ICE_BONUS) {
+
+    ammo_text = std::to_string(m_player_status.max_ice_bullets);
+
+    if (ice_surface) {
+      context.color().draw_surface(ice_surface,
+                                   Vector(static_cast<float>(context.get_width())
+                                              - BORDER_X
+                                              - static_cast<float>(ice_surface->get_width())
+                                              - Resources::fixed_font->get_text_width(ammo_text),
+                                          BORDER_Y
+                                              + 1.0f
+                                              + (Resources::fixed_font->get_text_height(coins_text) + 5)
+                                              + (Resources::fixed_font->get_text_height(ammo_text) + 5)
+                                              * static_cast<float>(player_id)),
+                                   LAYER_HUD);
+    }
+
+    context.color().draw_text(Resources::fixed_font,
+                              ammo_text,
+                              Vector(static_cast<float>(context.get_width())
+                                         - BORDER_X
+                                         - Resources::fixed_font->get_text_width(ammo_text),
+                                     BORDER_Y
+                                         + (Resources::fixed_font->get_text_height(coins_text) + 5.0f)
+                                         + (Resources::fixed_font->get_text_height(ammo_text) + 5.0f)
+                                         * static_cast<float>(player_id)),
+                              ALIGN_LEFT,
+                              LAYER_HUD,
+                              PlayerStatusHUD::text_color);
+  }
+
 
   context.pop_transform();
 }

--- a/src/supertux/player_status_hud.hpp
+++ b/src/supertux/player_status_hud.hpp
@@ -48,6 +48,8 @@ private:
   int displayed_coins;
   int displayed_coins_frame;
   SurfacePtr coin_surface;
+  SurfacePtr fire_surface;
+  SurfacePtr ice_surface;
 
 private:
   PlayerStatusHUD(const PlayerStatusHUD&) = delete;

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -193,7 +193,7 @@ void
 ScreenManager::draw_fps(DrawingContext& context, FPS_Stats& fps_statistics)
 {
   // The fonts are not monospace, so the numbers need to be drawn separately
-  Vector pos(static_cast<float>(context.get_width()) - BORDER_X, BORDER_Y + 20);
+  Vector pos(static_cast<float>(context.get_width()) - BORDER_X, BORDER_Y + 40);
   context.color().draw_text(Resources::small_font, "FPS  min / avg / max",
     pos, ALIGN_RIGHT, LAYER_HUD);
   static const float w2 = Resources::small_font->get_text_width("999.9 /");


### PR DESCRIPTION
Enhancement from https://github.com/SuperTux/supertux/issues/987.

- adds a counter to show the fire or ice ammo count
- hidden when no bonus
- offset fps and player position by another 20 pixels

![issue-987](https://user-images.githubusercontent.com/19230462/50569546-b2b99000-0d24-11e9-991e-22d8423502af.png)

![powerups](https://user-images.githubusercontent.com/19230462/50570193-86aa0900-0d3c-11e9-85bf-bc1319ed665e.gif)