### PR TITLE
    Do not enable default keys in addition to player-defined keys

### DIFF
--- a/src/control/keyboard_config.cpp
+++ b/src/control/keyboard_config.cpp
@@ -52,35 +52,35 @@ KeyboardConfig::KeyboardConfig() :
 void
 KeyboardConfig::read(const ReaderMapping& keymap_mapping)
 {
+  // backwards compatibility:
   // keycode values changed between SDL1 and SDL2, so we skip old SDL1
   // based values and use the defaults instead on the first read of
   // the config file
   bool config_is_sdl2 = false;
   keymap_mapping.get("sdl2", config_is_sdl2);
-  if (config_is_sdl2)
+  if (!config_is_sdl2)
+    return;
+
+  keymap_mapping.get("jump-with-up", m_jump_with_up_kbd);
+
+  auto iter = keymap_mapping.get_iter();
+  while (iter.next())
   {
-    keymap_mapping.get("jump-with-up", m_jump_with_up_kbd);
+    if (iter.get_key() != "map")
+      continue;
+    int key = -1;
+    auto map = iter.as_mapping();
+    map.get("key", key);
 
-    auto iter = keymap_mapping.get_iter();
-    while (iter.next())
-    {
-      if (iter.get_key() == "map")
-      {
-        int key = -1;
-        auto map = iter.as_mapping();
-        map.get("key", key);
+    std::string control_text;
+    map.get("control", control_text);
 
-        std::string control_text;
-        map.get("control", control_text);
-
-        const boost::optional<Control> maybe_control = Control_from_string(control_text);
-        if (!maybe_control) {
-          log_info << "Invalid control '" << control_text << "' in keymap" << std::endl;
-        } else {
-          const Control control = *maybe_control;
-          m_keymap[static_cast<SDL_Keycode>(key)] = control;
-        }
-      }
+    const boost::optional<Control> maybe_control = Control_from_string(control_text);
+    if (maybe_control) {
+      const Control control = *maybe_control;
+      m_keymap[static_cast<SDL_Keycode>(key)] = control;
+    } else {
+      log_warning << "Invalid control '" << control_text << "' in keymap" << std::endl;
     }
   }
 }

--- a/src/control/keyboard_config.cpp
+++ b/src/control/keyboard_config.cpp
@@ -77,8 +77,7 @@ KeyboardConfig::read(const ReaderMapping& keymap_mapping)
 
     const boost::optional<Control> maybe_control = Control_from_string(control_text);
     if (maybe_control) {
-      const Control control = *maybe_control;
-      m_keymap[static_cast<SDL_Keycode>(key)] = control;
+      bind_key(static_cast<SDL_Keycode>(key), *maybe_control);
     } else {
       log_warning << "Invalid control '" << control_text << "' in keymap" << std::endl;
     }


### PR DESCRIPTION
I applied what christ2go commented at #592

When I have tested it, my keyboard configuration was reset at first but it worked after configuring it again.
I also tested if you can change important keys so that you cannot move through the menu. I could not break it, i.e. the safety mechanism in keyboard_manager.cpp probably works.
