### PR TITLE
Add an optional gain parameter to SoundManager::play

### DIFF
--- a/src/audio/sound_manager.cpp
+++ b/src/audio/sound_manager.cpp
@@ -184,13 +184,19 @@ SoundManager::preload(const std::string& filename)
 }
 
 void
-SoundManager::play(const std::string& filename, const Vector& pos)
+SoundManager::play(const std::string& filename, const Vector& pos,
+  const float gain)
 {
   if (!m_sound_enabled)
     return;
 
+  // Test gain for invalid values; it must not exceed 1 because in the end
+  // the value is set to min(sound_gain * sound_volume, 1)
+  assert(gain >= 0.0f && gain <= 1.0f);
+
   try {
     std::unique_ptr<OpenALSoundSource> source(intern_create_sound_source(filename));
+    source->set_gain(gain);
 
     if (pos.x < 0 || pos.y < 0) {
       source->set_relative(true);

--- a/src/audio/sound_manager.hpp
+++ b/src/audio/sound_manager.hpp
@@ -57,8 +57,14 @@ public:
       This function never throws exceptions, but might return a DummySoundSource */
   std::unique_ptr<SoundSource> create_sound_source(const std::string& filename);
 
-  /** Convenience function to simply play a sound at a given position. */
-  void play(const std::string& name, const Vector& pos = Vector(-1, -1));
+  /** Convenience functions to simply play a sound at a given position. */
+  void play(const std::string& name, const Vector& pos = Vector(-1, -1),
+    const float gain = 0.5f);
+  void play(const std::string& name, const float gain)
+  {
+    play(name, Vector(-1, -1), gain);
+  }
+
 
   /** Adds the source to the list of managed sources (= the source gets deleted
       when it finished playing) */

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -34,7 +34,7 @@ Bomb::Bomb(const Vector& pos, Direction dir_, const std::string& custom_sprite /
 
   ticking->set_position(get_pos());
   ticking->set_looping(true);
-  ticking->set_gain(2.0);
+  ticking->set_gain(1.0f);
   ticking->set_reference_distance(32);
   ticking->play();
 }

--- a/src/badguy/dart.cpp
+++ b/src/badguy/dart.cpp
@@ -73,7 +73,7 @@ Dart::activate()
   sound_source = SoundManager::current()->create_sound_source(DART_SOUND);
   sound_source->set_position(get_pos());
   sound_source->set_looping(true);
-  sound_source->set_gain(1.0);
+  sound_source->set_gain(0.5f);
   sound_source->set_reference_distance(32);
   sound_source->play();
 }

--- a/src/badguy/flame.cpp
+++ b/src/badguy/flame.cpp
@@ -85,7 +85,7 @@ Flame::activate()
   sound_source = SoundManager::current()->create_sound_source(FLAME_SOUND);
   sound_source->set_position(get_pos());
   sound_source->set_looping(true);
-  sound_source->set_gain(2.0);
+  sound_source->set_gain(1.0f);
   sound_source->set_reference_distance(32);
   sound_source->play();
 }

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -124,7 +124,7 @@ GoldBomb::collision_squished(GameObject& object)
     ticking = SoundManager::current()->create_sound_source("sounds/fizz.wav");
     ticking->set_position(get_pos());
     ticking->set_looping(true);
-    ticking->set_gain(2.0);
+    ticking->set_gain(1.0f);
     ticking->set_reference_distance(32);
     ticking->play();
   }

--- a/src/badguy/treewillowisp.cpp
+++ b/src/badguy/treewillowisp.cpp
@@ -56,7 +56,7 @@ TreeWillOWisp::activate()
   sound_source = SoundManager::current()->create_sound_source(TREEWILLOSOUND);
   sound_source->set_position(get_pos());
   sound_source->set_looping(true);
-  sound_source->set_gain(2.0);
+  sound_source->set_gain(1.0f);
   sound_source->set_reference_distance(32);
   sound_source->play();
 }

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -160,7 +160,7 @@ WillOWisp::activate()
   m_sound_source = SoundManager::current()->create_sound_source(SOUNDFILE);
   m_sound_source->set_position(get_pos());
   m_sound_source->set_looping(true);
-  m_sound_source->set_gain(2.0);
+  m_sound_source->set_gain(1.0f);
   m_sound_source->set_reference_distance(32);
   m_sound_source->play();
 }

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -63,7 +63,10 @@ Explosion::explode()
   set_action(hurt ? "default" : "pop", 1);
   m_sprite->set_animation_loops(1); //TODO: this is necessary because set_action will not set "loops" when "action" is the default action
   m_sprite->set_angle(graphicsRandom.randf(0, 360)); // a random rotation on the sprite to make explosions appear more random
-  SoundManager::current()->play(hurt ? "sounds/explosion.wav" : "sounds/firecracker.ogg", get_pos());
+  if (hurt)
+    SoundManager::current()->play("sounds/explosion.wav", get_pos(), 0.98f);
+  else
+    SoundManager::current()->play("sounds/firecracker.ogg", get_pos(), 0.7f);
 
   // spawn some particles
   int pnumber = push ? 8 : 100;

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -37,7 +37,7 @@ Config::Config() :
   show_player_pos(false),
   sound_enabled(true),
   music_enabled(true),
-  sound_volume(50),
+  sound_volume(100),
   music_volume(50),
   random_seed(0), // set by time(), by default (unless in config)
   enable_script_debugger(false),


### PR DESCRIPTION
I noticed that the openal sound gain is reduced to 1 if it is bigger, so to make explosions louder than jumping with the Sound Volume set to 100%, the gain of the jumping noise needs to be lowered.
To achieve this, I set the default gain to 0.5 and the default Sound Volume to 2 * Music Volume.
