### PR TITLE
Three simple Rock changes

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -897,6 +897,8 @@ Player::handle_input()
         moving_object->set_pos(dest_.p1());
         if (m_controller->hold(Control::UP)) {
           m_grabbed_object->ungrab(*this, Direction::UP);
+        } else if (m_controller->hold(Control::DOWN)) {
+          m_grabbed_object->ungrab(*this, Direction::DOWN);
         } else {
           m_grabbed_object->ungrab(*this, m_dir);
         }


### PR DESCRIPTION
throw to ground when ungrabbing while holding down
This allows Tux to place the Rock onto ground when he wants to do it. When I recently tried to place a rock onto another one, Tux threw it away although he moved slowly.
When Tux throws the Rock down and he has a powerup, he also begins to stomp, but that's not a problem.

slow down when hurting something 
When the Rock falls onto an enemy and kills it, it looses a bit velocity because it collided.

bounce a bit from walls
If the Rock is thrown against a wall it collides but the wall does not move, so the Rock needs to bounce back a bit.