### PR TITLE
Do not automatically hurt Tux when he cannot standup

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -868,7 +868,7 @@ Player::handle_input()
   if (m_controller->hold(Control::DOWN) && !m_stone) {
     do_duck();
   } else {
-    do_standup(m_controller->hold(Control::UP));
+    do_standup(false);
   }
 
   /* grabbing */

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -379,7 +379,7 @@ Player::update(float dt_sec)
 
       // if controls are currently deactivated, we take care of standing up ourselves
       if (m_deactivated)
-        do_standup();
+        do_standup(false);
     }
     if (m_player_status.bonus == AIR_BONUS)
       m_ability_time = static_cast<float>(m_player_status.max_air_time) * GLIDE_TIME_PER_FLOWER;
@@ -586,7 +586,7 @@ Player::do_cheer()
 {
   do_duck();
   do_backflip();
-  do_standup();
+  do_standup(false);
 }
 
 void
@@ -607,13 +607,11 @@ Player::do_duck() {
     m_duck = true;
     m_growing = false;
     m_unduck_hurt_timer.stop();
-  } else {
-    // FIXME: what now?
   }
 }
 
 void
-Player::do_standup() {
+Player::do_standup(bool force_standup) {
   if (!m_duck)
     return;
   if (!is_big())
@@ -626,7 +624,7 @@ Player::do_standup() {
   if (adjust_height(BIG_TUX_HEIGHT)) {
     m_duck = false;
     m_unduck_hurt_timer.stop();
-  } else {
+  } else if (force_standup) {
     // if timer is not already running, start it.
     if (m_unduck_hurt_timer.get_period() == 0) {
       m_unduck_hurt_timer.start(UNDUCK_HURT_TIME);
@@ -870,7 +868,7 @@ Player::handle_input()
   if (m_controller->hold(Control::DOWN) && !m_stone) {
     do_duck();
   } else {
-    do_standup();
+    do_standup(m_controller->hold(Control::UP));
   }
 
   /* grabbing */
@@ -1669,7 +1667,7 @@ Player::start_climbing(Climbable& climbable)
   m_physic.set_acceleration(0, 0);
   if (m_backflipping) {
     stop_backflipping();
-    do_standup();
+    do_standup(true);
   }
 }
 

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -108,7 +108,7 @@ public:
   void do_duck();
 
   /** stand back up if possible. */
-  void do_standup();
+  void do_standup(bool force_standup);
 
   /** do a backflip if possible. */
   void do_backflip();

--- a/src/scripting/player.cpp
+++ b/src/scripting/player.cpp
@@ -143,7 +143,8 @@ void
 Player::do_standup()
 {
   SCRIPT_GUARD_VOID;
-  object.do_standup();
+  // Force standup for backwards compatibility
+  object.do_standup(true);
 }
 
 void


### PR DESCRIPTION
The player can press Up to hurt Tux when he is stuck.
I remember that somebody created an issue for this topic but I couldn't find it.