### PR TITLE
Ignore error when checking if a path exists

### DIFF
--- a/src/util/file_system.cpp
+++ b/src/util/file_system.cpp
@@ -39,8 +39,11 @@ namespace FileSystem {
 bool exists(const std::string& path)
 {
   fs::path location(path);
+  boost::system::error_code ec;
 
-  return fs::exists(location);
+  // If we get an error (such as "Permission denied"), then ignore it
+  // and pretend that the path doesn't exist.
+  return fs::exists(location, ec);
 }
 
 bool is_directory(const std::string& path)


### PR DESCRIPTION
This prevents a fatal error when SuperTux wants to check for its
source directory, but doesn't have permission.  The error looks like,

    [FATAL] /home/kernigh/park/supertux/src/supertux/main.cpp:604
    Unexpected exception: boost::filesystem::status: Permission denied:
    "/home/kernigh/park/supertux/data/credits.stxt"

In this example, I did `chmod -x park/supertux`, but the error can
also happen when someone runs an installed SuperTux as a different
user or on a different machine.  The error should not be fatal, so
find_datadir() in main.cpp may try the installed data files.