### PR TITLE
Move simple methods from physics.cpp to physics.hpp

### DIFF
--- a/src/supertux/physic.cpp
+++ b/src/supertux/physic.cpp
@@ -35,18 +35,6 @@ Physic::reset()
 }
 
 void
-Physic::set_velocity_x(float nvx)
-{
-  vx = nvx;
-}
-
-void
-Physic::set_velocity_y(float nvy)
-{
-  vy = nvy;
-}
-
-void
 Physic::set_velocity(float nvx, float nvy)
 {
   vx = nvx;
@@ -60,87 +48,11 @@ Physic::set_velocity(const Vector& vector)
   vy = vector.y;
 }
 
-void Physic::inverse_velocity_x()
-{
-  vx = -vx;
-}
-
-void Physic::inverse_velocity_y()
-{
-  vy = -vy;
-}
-
-float
-Physic::get_velocity_x() const
-{
-  return vx;
-}
-
-float
-Physic::get_velocity_y() const
-{
-  return vy;
-}
-
-Vector
-Physic::get_velocity() const
-{
-  return Vector(vx, vy);
-}
-
-void
-Physic::set_acceleration_x(float nax)
-{
-  ax = nax;
-}
-
-void
-Physic::set_acceleration_y(float nay)
-{
-  ay = nay;
-}
-
 void
 Physic::set_acceleration(float nax, float nay)
 {
   ax = nax;
   ay = nay;
-}
-
-float
-Physic::get_acceleration_x() const
-{
-  return ax;
-}
-
-float
-Physic::get_acceleration_y() const
-{
-  return ay;
-}
-
-Vector
-Physic::get_acceleration() const
-{
-  return Vector(ax, ay);
-}
-
-void
-Physic::enable_gravity(bool enable_gravity_)
-{
-  gravity_enabled_flag = enable_gravity_;
-}
-
-bool
-Physic::gravity_enabled() const
-{
-  return gravity_enabled_flag;
-}
-
-void
-Physic::set_gravity_modifier(float gravity_modifier_)
-{
-  gravity_modifier = gravity_modifier_;
 }
 
 Vector

--- a/src/supertux/physic.hpp
+++ b/src/supertux/physic.hpp
@@ -18,7 +18,7 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_PHYSIC_HPP
 #define HEADER_SUPERTUX_SUPERTUX_PHYSIC_HPP
 
-class Vector;
+#include "math/vector.hpp"
 
 /// Physics engine.
 /** This is a very simplistic physics engine handling accelerated and constant
@@ -33,39 +33,39 @@ public:
   void reset();
 
   /// Sets velocity to a fixed value.
-  void set_velocity(float vx, float vy);
+  void set_velocity(float nvx, float nvy);
   void set_velocity(const Vector& vector);
 
-  void set_velocity_x(float vx);
-  void set_velocity_y(float vy);
+  void set_velocity_x(float nvx) { vx = nvx; }
+  void set_velocity_y(float nvy) { vy = nvy; }
 
   /// Velocity inversion.
-  void inverse_velocity_x();
-  void inverse_velocity_y();
+  void inverse_velocity_x() { vx = -vx; }
+  void inverse_velocity_y() { vy = -vy; }
 
-  Vector get_velocity() const;
-  float get_velocity_x() const;
-  float get_velocity_y() const;
+  Vector get_velocity() const { return Vector(vx, vy); }
+  float get_velocity_x() const { return vx; }
+  float get_velocity_y() const { return vy; }
 
   /// Set acceleration.
   /** Sets acceleration applied to the object. (Note that gravity is
    * eventually added to the vertical acceleration)
    */
-  void set_acceleration(float ax, float ay);
+  void set_acceleration(float nax, float nay);
 
-  void set_acceleration_x(float ax);
-  void set_acceleration_y(float ay);
+  void set_acceleration_x(float nax) { ax = nax; }
+  void set_acceleration_y(float nay) { ay = nay; }
 
-  Vector get_acceleration() const;
-  float get_acceleration_x() const;
-  float get_acceleration_y() const;
+  Vector get_acceleration() const { return Vector(ax, ay); }
+  float get_acceleration_x() const { return ax; }
+  float get_acceleration_y() const { return ay; }
 
   /// Enables or disables handling of gravity.
-  void enable_gravity(bool gravity_enabled);
-  bool gravity_enabled() const;
+  void enable_gravity(bool enable) { gravity_enabled_flag = enable; }
+  bool gravity_enabled() const { return gravity_enabled_flag; }
 
   /** Set gravity modifier factor to apply to object when enabled */
-  void set_gravity_modifier(float gravity);
+  void set_gravity_modifier(float modifier) { gravity_modifier = modifier; }
 
   Vector get_movement(float dt_sec);
 


### PR DESCRIPTION
This makes the code shorter and allows the compiler to inline the functions, as mentioned e.g. at https://en.cppreference.com/w/cpp/language/class.