### PR TITLE
Add a few more add-on types

### DIFF
--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -51,7 +51,7 @@ Addon::Type addon_type_from_string(const std::string& type)
   }
   else
   {
-    return Addon::ADD-ON;
+    return Addon::ADDON;
   }
 }
 

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -45,9 +45,13 @@ Addon::Type addon_type_from_string(const std::string& type)
   {
     return Addon::LANGUAGEPACK;
   }
+  else if (type == "textures")
+  {
+    return Addon::TEXTURES;
+  }
   else
   {
-    throw std::runtime_error("not a valid Addon::Type: " + type);
+    return Addon::ADD-ON;
   }
 }
 

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -29,7 +29,7 @@ public:
   static std::unique_ptr<Addon> parse(const ReaderMapping& mapping);
   static std::unique_ptr<Addon> parse(const std::string& fname);
 
-  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK, TEXTURES, ADD-ON };
+  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK, TEXTURES, ADDON };
 
   enum Format {
     ORIGINAL = 0,

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -29,7 +29,7 @@ public:
   static std::unique_ptr<Addon> parse(const ReaderMapping& mapping);
   static std::unique_ptr<Addon> parse(const std::string& fname);
 
-  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK };
+  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK, TEXTURES, ADD-ON };
 
   enum Format {
     ORIGINAL = 0,

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -56,7 +56,7 @@ std::string addon_type_to_translated_string(Addon::Type type)
     case Addon::TEXTURES;
       return _("Textures");
       
-    case Addon::ADD-ON;
+    case Addon::ADDON;
       return _("Add-on");
 
     default:

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -53,10 +53,10 @@ std::string addon_type_to_translated_string(Addon::Type type)
     case Addon::LANGUAGEPACK:
       return "";
       
-    case Addon::TEXTURES;
+    case Addon::TEXTURES:
       return _("Textures");
       
-    case Addon::ADDON;
+    case Addon::ADDON:
       return _("Add-on");
 
     default:

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -52,6 +52,12 @@ std::string addon_type_to_translated_string(Addon::Type type)
 
     case Addon::LANGUAGEPACK:
       return "";
+      
+    case Addon::TEXTURES;
+      return _("Textures");
+      
+    case Addon::ADD-ON;
+      return _("Add-on");
 
     default:
       return _("Unknown");


### PR DESCRIPTION
This should add 2 things: 
1) The addon can now be type "Textures" 
2) If the addon is an invalid addon type, it should default to "Add-On"