### PR TITLE
Make fps measurements more accurate

### DIFF
--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -56,7 +56,8 @@ public:
   void set_screen_fade(std::unique_ptr<ScreenFade> fade);
 
 private:
-  void draw_fps(DrawingContext& context, float fps);
+  struct FPS_Stats;
+  void draw_fps(DrawingContext& context);
   void draw_player_pos(DrawingContext& context);
   void draw(Compositor& compositor);
   void update_gamelogic(float dt_sec);
@@ -88,8 +89,6 @@ private:
 
   std::vector<Action> m_actions;
 
-  /// measured fps
-  float m_fps;
   std::unique_ptr<ScreenFade> m_screen_fade;
   std::vector<std::unique_ptr<Screen> > m_screen_stack;
 };


### PR DESCRIPTION
After exceeding 0.5 s, the excess milliseconds are no longer discarded
	(the FPS shown were sometimes higher than the real FPS, especially when they were low)
minimum and maximum FPS are shown;
	these can be more interesting than average FPS when the game stutters
std::chrono is used instead of SDL_GetTicks for microsecond precision

![2019-05-09-113905_1920x1080_scrot](https://user-images.githubusercontent.com/3192173/57444116-b8cdf900-724f-11e9-87ac-83f34d8f5baf.png)
![2019-05-09-113952_1920x1080_scrot](https://user-images.githubusercontent.com/3192173/57444120-bb305300-724f-11e9-981c-304747bf05ea.png)
