### PR TITLE
Smooth worldmap camera panning

### DIFF
--- a/src/worldmap/camera.hpp
+++ b/src/worldmap/camera.hpp
@@ -42,7 +42,9 @@ private:
   Vector m_camera_offset;
 
   /** variables to track panning to a spawn point */
-  Vector m_pan_pos;
+  Vector m_pan_startpos;
+  float m_pan_time_full;
+  float m_pan_time_remaining;
   bool m_panning;
 
 private:


### PR DESCRIPTION
The speed does no longer depend on the framerate.
The camera position is smoothly interpolated with a cosine function instead of linear interpolation.
The panning time is mostly direct proportional to the distance between start and end position.
If the distance is very high, this time is reduced to a maximum panning time.