### PR TITLE
Rendering: Group horizontally adjacent frames together

### DIFF
--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -174,8 +174,7 @@ public:
 private:
   const TileSet* m_tileset;
 
-  typedef std::vector<uint32_t> Tiles;
-  Tiles m_tiles;
+  std::vector<uint32_t> m_tiles;
 
   /* read solid: In *general*, is this a solid layer? effective solid:
      is the layer *currently* solid? A generally solid layer may be


### PR DESCRIPTION
In Minetest, there's the [fast faces](https://github.com/minetest/minetest/blob/72feab081c336d2d71d300131d30e71694b485f3/src/client/mapblock_mesh.cpp#L897) method to reduce the polygon count. Neighbouring squares which use the same texture are joined together in one rectangle and the texture is rendered as tiles so that it repeats itself.
I think that maybe this could be done in Supertux, too. There're many tiles which can be grouped together:
![jpg file](https://user-images.githubusercontent.com/3192173/57570687-0e97d200-7405-11e9-8cd1-8c45f9126f60.jpg)
To render the tiles without stretching, changes in video/ are probably needed.