### PR TITLE
Added a "Restart from Checkpoint" button

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1482,7 +1482,7 @@ Player::kill(bool completely)
       return;
     }
 
-    if (m_player_status.coins >= 25 && !GameSession::current()->get_reset_point_sectorname().empty())
+    if (m_player_status.can_reach_checkpoint())
     {
       for (int i = 0; i < 5; i++)
       {
@@ -1491,7 +1491,7 @@ Player::kill(bool completely)
                                                       Vector(graphicsRandom.randf(5.0f), graphicsRandom.randf(-32.0f, 18.0f)),
                                                       graphicsRandom.randf(-100.0f, 100.0f));
       }
-      m_player_status.coins -= std::max(m_player_status.coins/10, 25);
+      m_player_status.take_checkpoint_coins();
     }
     else
     {

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -45,6 +45,7 @@
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics) :
   GameSessionRecorder(),
   reset_button(false),
+  reset_checkpoint_button(false),
   m_level(),
   m_old_level(),
   m_statistics_backdrop(Surface::from_file("images/engine/menu/score-backdrop.png")),
@@ -406,6 +407,10 @@ GameSession::update(float dt_sec, const Controller& controller)
     reset_button = false;
     reset_level();
     restart_level();
+  } else if(reset_checkpoint_button) {
+    reset_checkpoint_button = false;
+
+    get_current_sector().get_player().kill(true);
   }
 }
 

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -72,6 +72,7 @@ public:
   std::string get_working_directory() const;
   int restart_level(bool after_death = false);
   bool reset_button;
+  bool reset_checkpoint_button;
 
   void toggle_pause();
   void abort_level();

--- a/src/supertux/menu/game_menu.cpp
+++ b/src/supertux/menu/game_menu.cpp
@@ -24,6 +24,8 @@
 #include "supertux/globals.hpp"
 #include "supertux/level.hpp"
 #include "supertux/menu/menu_storage.hpp"
+#include "supertux/sector.hpp"
+#include "object/player.hpp"
 #include "util/gettext.hpp"
 
 static const std::string CONFIRMATION_PROMPT = _("Are you sure?");
@@ -33,6 +35,12 @@ GameMenu::GameMenu() :
     MenuManager::instance().clear_menu_stack();
     GameSession::current()->toggle_pause();
     GameSession::current()->reset_button = true;
+  }),
+  reset_checkpoint_callback( [] {
+    MenuManager::instance().clear_menu_stack();
+    GameSession::current()->toggle_pause();
+
+    GameSession::current()->reset_checkpoint_button = true;
   }),
   abort_callback ( [] {
     MenuManager::instance().clear_menu_stack();
@@ -45,6 +53,11 @@ GameMenu::GameMenu() :
   add_hl();
   add_entry(MNID_CONTINUE, _("Continue"));
   add_entry(MNID_RESETLEVEL, _("Restart Level"));
+
+  if (Sector::current()->get_player().get_status().can_reach_checkpoint()) {
+    add_entry(MNID_RESETLEVELCHECKPOINT, _("Restart Level from Checkpoint"));
+  }
+
   add_submenu(_("Options"), MenuStorage::INGAME_OPTIONS_MENU);
   add_hl();
   add_entry(MNID_ABORTLEVEL, _("Abort Level"));
@@ -68,6 +81,18 @@ GameMenu::menu_action(MenuItem& item)
       else
       {
         reset_callback();
+      }
+      break;
+
+    case MNID_RESETLEVELCHECKPOINT:
+      if (g_config->confirmation_dialog)
+      {
+        Dialog::show_confirmation(CONFIRMATION_PROMPT,
+                                  reset_checkpoint_callback);
+      }
+      else
+      {
+        reset_checkpoint_callback();
       }
       break;
 

--- a/src/supertux/menu/game_menu.hpp
+++ b/src/supertux/menu/game_menu.hpp
@@ -24,6 +24,7 @@
 enum GameMenuIDs {
   MNID_CONTINUE,
   MNID_RESETLEVEL,
+  MNID_RESETLEVELCHECKPOINT,
   MNID_ABORTLEVEL
 };
 
@@ -32,6 +33,8 @@ class GameMenu final : public Menu
 private:
   // stores callback for level reset
   std::function<void ()> reset_callback;
+  // stores callback for level reset from checkpoint
+  std::function<void ()> reset_checkpoint_callback;
   // stores callback for level abort
   std::function<void ()> abort_callback;
 public:

--- a/src/supertux/player_status.cpp
+++ b/src/supertux/player_status.cpp
@@ -17,7 +17,6 @@
 
 #include "supertux/player_status.hpp"
 
-#include <algorithm>
 #include <sstream>
 
 #include "audio/sound_manager.hpp"

--- a/src/supertux/player_status.cpp
+++ b/src/supertux/player_status.cpp
@@ -22,6 +22,7 @@
 
 #include "audio/sound_manager.hpp"
 #include "supertux/globals.hpp"
+#include "supertux/game_session.hpp"
 #include "util/log.hpp"
 #include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
@@ -58,6 +59,13 @@ int
 PlayerStatus::get_max_coins() const
 {
   return MAX_COINS;
+}
+
+bool
+PlayerStatus::can_reach_checkpoint() const
+{
+  return coins >= 25
+    && !GameSession::current()->get_reset_point_sectorname().empty();
 }
 
 void

--- a/src/supertux/player_status.hpp
+++ b/src/supertux/player_status.hpp
@@ -40,11 +40,13 @@ public:
   PlayerStatus();
   void reset();
   void add_coins(int count, bool play_sound = true);
+  void take_checkpoint_coins() { coins -= std::max(coins / 10, 25); }
 
   void write(Writer& writer);
   void read(const ReaderMapping& mapping);
 
   int get_max_coins() const;
+  bool can_reach_checkpoint() const;
   std::string get_bonus_prefix() const;/**Returns the prefix of the animations that should be displayed*/
   bool has_hat_sprite() const { return bonus > GROWUP_BONUS; }
 

--- a/src/supertux/player_status.hpp
+++ b/src/supertux/player_status.hpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <algorithm>
 
 class DrawingContext;
 class ReaderMapping;


### PR DESCRIPTION
Original PR: #885

I've changed it so that the kill function is executed, which plays the hurt sound (otherwise the player would silently loose the coins).