### PR TITLE
Enable deleting pneumatic and bicycle platforms in editor (#1018)

### DIFF
--- a/src/object/bicycle_platform.cpp
+++ b/src/object/bicycle_platform.cpp
@@ -73,6 +73,12 @@ BicyclePlatformChild::collision(GameObject& other, const CollisionHit& )
   return FORCE_MOVE;
 }
 
+void BicyclePlatformChild::editor_delete()
+{
+  // removing a child removes the whole platform
+  m_parent.editor_delete();
+}
+
 BicyclePlatform::BicyclePlatform(const ReaderMapping& reader) :
   GameObject(reader),
   m_center(),
@@ -157,10 +163,14 @@ BicyclePlatform::update(float dt_sec)
 void
 BicyclePlatform::editor_delete()
 {
+  // remove children
   for (auto& child : m_children)
   {
     child->remove_me();
   }
+
+  // remove self
+  remove_me();
 }
 
 void

--- a/src/object/bicycle_platform.hpp
+++ b/src/object/bicycle_platform.hpp
@@ -33,6 +33,8 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual bool is_saveable() const override { return false; }
 
+  virtual void editor_delete() override;
+
 private:
   BicyclePlatform& m_parent;
   float m_angle_offset;

--- a/src/object/pneumatic_platform.cpp
+++ b/src/object/pneumatic_platform.cpp
@@ -63,6 +63,12 @@ PneumaticPlatformChild::collision(GameObject& other, const CollisionHit& )
   return FORCE_MOVE;
 }
 
+void PneumaticPlatformChild::editor_delete()
+{
+  // removing a child removes the whole platform
+  m_parent.editor_delete();
+}
+
 PneumaticPlatform::PneumaticPlatform(const ReaderMapping& mapping) :
   GameObject(mapping),
   m_pos(),
@@ -121,9 +127,13 @@ PneumaticPlatform::update(float dt_sec)
 void
 PneumaticPlatform::editor_delete()
 {
+  // remove children
   for (auto& child : m_children) {
     child->remove_me();
   }
+
+  // remove self
+  remove_me();
 }
 
 ObjectSettings

--- a/src/object/pneumatic_platform.hpp
+++ b/src/object/pneumatic_platform.hpp
@@ -33,6 +33,8 @@ public:
   virtual void update(float dt_sec) override;
   virtual bool is_saveable() const override { return false; }
 
+  virtual void editor_delete() override;
+
 protected:
   PneumaticPlatform& m_parent;
   bool m_left;


### PR DESCRIPTION
Fixes #1018. The object is now actually removed from the level (not just from the
editor interface).

Removing any child of a pneumatic or bicycle platform will delete the
whole platform. (From the code it looks like it will not work if there
is just one child.)