### PR TITLE
Link to boost targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,7 +767,7 @@ if(WIN32)
 else()
   add_executable(supertux2 src/main.cpp)
 endif(WIN32)
-target_link_libraries(supertux2 supertux2_lib)
+target_link_libraries(supertux2 supertux2_lib Boost::filesystem Boost::locale)
 set_target_properties(supertux2_lib PROPERTIES OUTPUT_NAME supertux2_lib)
 set_target_properties(supertux2_lib PROPERTIES COMPILE_FLAGS "${SUPERTUX2_EXTRA_WARNING_FLAGS}")
 


### PR DESCRIPTION
On my Linux distribution I've got undefined reference to boost filesystem and boost locale. This is probably due to the new boost version that exports their own CMake files.

But this patch should work since FindBoost in CMake also adds "Boost::filesystem" and "Boost::locale" targets.