### PR TITLE
Fix bug with falling coins (#942)

### DIFF
--- a/src/object/falling_coin.cpp
+++ b/src/object/falling_coin.cpp
@@ -41,7 +41,8 @@ void
 FallingCoin::update(float dt_sec)
 {
   pos += physic.get_movement(dt_sec);
-  if (pos.y > static_cast<float>(SCREEN_HEIGHT))
+  if (pos.y > static_cast<float>(SCREEN_HEIGHT) &&
+      physic.get_velocity_y() > 0.0f)
     remove_me();
 }
 


### PR DESCRIPTION
Fixes #942. Falling coins will now appear after dying post-checkpoint.

The problem was that the coins were spawning below the bottom of the screen, and therefore being removed immediately in the "update" method. I changed it so they will only be removed if they are also falling downwards (i.e. Y velocity is more than zero).