### PR TITLE
Add script for stopping/fading out music

### DIFF
--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -235,6 +235,11 @@ void play_music(const std::string& filename)
   SoundManager::current()->play_music(filename);
 }
 
+void stop_music(float fadetime)
+{
+  SoundManager::current()->stop_music(fadetime);
+}
+
 void play_sound(const std::string& filename)
 {
   SoundManager::current()->play(filename);

--- a/src/scripting/functions.hpp
+++ b/src/scripting/functions.hpp
@@ -95,6 +95,9 @@ void debug_worldmap_ghost(bool enable);
 /** Changes music to musicfile */
 void play_music(const std::string& musicfile);
 
+/** Stops the music */
+void stop_music(float fadetime);
+
 /** Plays a soundfile */
 void play_sound(const std::string& soundfile);
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -5911,6 +5911,29 @@ static SQInteger play_music_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger stop_music_wrapper(HSQUIRRELVM vm)
+{
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    scripting::stop_music(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'stop_music'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger play_sound_wrapper(HSQUIRRELVM vm)
 {
   const SQChar* arg0;
@@ -7153,6 +7176,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'play_music'");
+  }
+
+  sq_pushstring(v, "stop_music", -1);
+  sq_newclosure(v, &stop_music_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tf");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'stop_music'");
   }
 
   sq_pushstring(v, "play_sound", -1);


### PR DESCRIPTION
Adds a script called "stop_music". This takes a float parameter, which is the fade time in seconds. E.g. "stop_music(2.0)" stops the current music with a fade-out time of 2 seconds.

This fixes part of #962. I haven't added a way to fade *in* music yet.

Video demo below:
[stop-music-demo.zip](https://github.com/SuperTux/supertux/files/3503615/stop-music-demo.zip)

One annoying thing - the script will accept "stop_music(2.0)" but not "stop_music(2)". Can I make it accept either a float or integer? Also, can I make it no parameter at all, to stop the music immediately? I'm not very familiar with squirrel.
