### PR TITLE
Do not use a variable time step

### DIFF
--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -23,11 +23,10 @@
 #include "gui/item_toggle.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
-#include "supertux/game_session.hpp"
 #include "supertux/gameconfig.hpp"
+#include "supertux/game_session.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/menu/menu_storage.hpp"
-#include "supertux/screen_manager.hpp"
 #include "util/gettext.hpp"
 #include "util/log.hpp"
 #include "video/renderer.hpp"
@@ -56,7 +55,6 @@ enum OptionsMenuIDs {
   MNID_MAGNIFICATION,
   MNID_ASPECTRATIO,
   MNID_VSYNC,
-  MNID_FRAMERATE,
   MNID_SOUND,
   MNID_MUSIC,
   MNID_SOUND_VOLUME,
@@ -74,7 +72,6 @@ OptionsMenu::OptionsMenu(bool complete) :
   next_window_resolution(0),
   next_resolution(0),
   next_vsync(0),
-  next_framerate(0),
   next_sound_volume(0),
   next_music_volume(0),
   magnifications(),
@@ -82,7 +79,6 @@ OptionsMenu::OptionsMenu(bool complete) :
   window_resolutions(),
   resolutions(),
   vsyncs(),
-  framerates(),
   sound_volumes(),
   music_volumes()
 {
@@ -236,26 +232,6 @@ OptionsMenu::OptionsMenu(bool complete) :
     resolutions.push_back(fullscreen_size_str);
   }
 
-  framerates.push_back("30");
-  framerates.push_back("60");
-  framerates.push_back("75");
-  framerates.push_back("90");
-  framerates.push_back("120");
-  framerates.push_back("144");
-  framerates.push_back("240");
-  framerates.push_back("288");
-  framerates.push_back("500");
-  framerates.push_back("1000");
-  next_framerate = 1;
-  const int target_framerate = static_cast<int>(ScreenManager::current()->get_target_framerate());
-  for (size_t i = 0; i < framerates.size(); ++i)
-  {
-    if (std::to_string(target_framerate) == framerates[i])
-    {
-      next_framerate = static_cast<int>(i);
-    }
-  }
-
   { // vsync
     vsyncs.push_back("on");
     vsyncs.push_back("off");
@@ -380,12 +356,6 @@ OptionsMenu::OptionsMenu(bool complete) :
 
   MenuItem& vsync = add_string_select(MNID_VSYNC, _("VSync"), &next_vsync, vsyncs);
   vsync.set_help(_("Set the VSync mode"));
-
-  if (g_config->developer_mode) {
-    MenuItem& framerate = add_string_select(MNID_FRAMERATE, _("Framerate"), &next_framerate, framerates);
-    framerate.set_help(_("Change the maximum framerate of the game, "
-      "ignored when vsync is enabled"));
-  }
 
   MenuItem& aspect = add_string_select(MNID_ASPECTRATIO, _("Aspect Ratio"), &next_aspect_ratio, aspect_ratios);
   aspect.set_help(_("Adjust the aspect ratio"));
@@ -529,10 +499,6 @@ OptionsMenu::menu_action(MenuItem& item)
             g_config->fullscreen_refresh_rate = 0;
         }
       }
-      break;
-
-    case MNID_FRAMERATE:
-      ScreenManager::current()->set_target_framerate(std::stof(framerates[next_framerate]));
       break;
 
     case MNID_VSYNC:

--- a/src/supertux/menu/options_menu.hpp
+++ b/src/supertux/menu/options_menu.hpp
@@ -34,7 +34,6 @@ private:
   int next_window_resolution;
   int next_resolution;
   int next_vsync;
-  int next_framerate;
   int next_sound_volume;
   int next_music_volume;
 
@@ -43,7 +42,6 @@ private:
   std::vector<std::string> window_resolutions;
   std::vector<std::string> resolutions;
   std::vector<std::string> vsyncs;
-  std::vector<std::string> framerates;
   std::vector<std::string> sound_volumes;
   std::vector<std::string> music_volumes;
 

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -491,22 +491,20 @@ ScreenManager::run()
     g_real_time = static_cast<float>(ticks) / 1000.0f;
 
     float speed_multiplier = 1.0f / g_debug.get_game_speed_multiplier();
-    int steps = static_cast<int>(elapsed_ticks * speed_multiplier) / ms_per_step;
+    int steps = static_cast<int>(elapsed_ticks) / ms_per_step;
     // Do not calculate more than a few steps at once
     steps = std::min<int>(steps, 3);
     for (int i = 0; i < steps; ++i) {
       // Perform a logical game step; seconds_per_step is set to a fixed value
       // so that the game is deterministic
-      g_game_time += seconds_per_step;
+      float dtime = seconds_per_step;
+      if (speed_multiplier != 1.0f)
+        // speed_multiplier is a debug setting; usually dtime is fixed
+        dtime *= speed_multiplier;
+      g_game_time += dtime;
       process_events();
-      update_gamelogic(seconds_per_step);
+      update_gamelogic(dtime);
       elapsed_ticks -= ms_per_step;
-    }
-
-    // Avoid hang when the game speed is very low
-    if (speed_multiplier < 0.3f && steps == 0) {
-      process_events();
-      update_gamelogic(0.0f);
     }
 
     if (draw_frame) {

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -55,9 +55,9 @@ public:
 
 private:
   struct FPS_Stats;
-  void draw_fps(DrawingContext& context);
+  void draw_fps(DrawingContext& context, FPS_Stats& fps_statistics);
   void draw_player_pos(DrawingContext& context);
-  void draw(Compositor& compositor);
+  void draw(Compositor& compositor, FPS_Stats& fps_statistics);
   void update_gamelogic(float dt_sec);
   void process_events();
   void handle_screen_switch();

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -45,8 +45,6 @@ public:
   void run();
   void quit(std::unique_ptr<ScreenFade> fade = {});
   void set_speed(float speed);
-  void set_target_framerate(float framerate);
-  float get_target_framerate() const;
   float get_speed() const;
   bool has_pending_fadeout() const;
 
@@ -72,8 +70,6 @@ private:
   std::unique_ptr<ControllerHUD> m_controller_hud;
 
   float m_speed;
-  float m_target_framerate;
-
   struct Action
   {
     enum Type { PUSH_ACTION, POP_ACTION, QUIT_ACTION };


### PR DESCRIPTION
This makes the game deterministic again. If the frames are drawn too slow, the game slows down. To catch up a bit, it is allowed to process up to three steps at once; the player cannot give different keyboard input in each step when it happens.
With these changes the game generally looks a bit jittery, see https://gameprogrammingpatterns.com/game-loop.html#stuck-in-the-middle for an explanation.
Ideally, the extrapolation could be implemented in SuperTux.

I don't know if I made mistakes again, so please test it.
I especially did not test it on windows.