### PR TITLE
Allow scrolling in the level editor using the mouse wheel

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -632,6 +632,13 @@ Editor::event(const SDL_Event& ev)
         }
       }
     }
+
+    // scroll with mouse wheel
+    if (ev.type == SDL_MOUSEWHEEL) {
+      float scroll_x = static_cast<float>(ev.wheel.x * -32);
+      float scroll_y = static_cast<float>(ev.wheel.y * -32);
+      scroll({scroll_x, scroll_y});
+    }
   }
   catch(const std::exception& err)
   {


### PR DESCRIPTION
Allows scrolling in the level editor using the mouse wheel. Fixes #1170.

I tested this with a regular mouse on Ubuntu 18, and it works well for me. I only tested scrolling vertically (I'm not sure how you would scroll horizontally with the mouse-wheel).

Demo below (zipped OGV file):

[scroll-demo.zip](https://github.com/SuperTux/supertux/files/3682433/scroll-demo.zip)

I would normally attach the GIF file, but it was 6 MB.

If anyone has a touch-pad, or can test on another O/S, please let me know if it works well for you.