### PR TITLE
Debugging: Give each collision group an individual colour when drawing hitboxes

### DIFF
--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -61,11 +61,34 @@ CollisionSystem::remove(CollisionObject* object)
 void
 CollisionSystem::draw(DrawingContext& context)
 {
-  const Color color(1.0f, 0.0f, 0.0f, 0.75f);
-
+  const Color violet(0.5f, 0.0f, 1.0f, 0.75f);
+  const Color red(1.0f, 0.0f, 0.0f, 0.75f);
+  const Color red_bright(1.0f, 0.5f, 0.5f, 0.75f);
+  const Color cyan(0.0f, 1.0f, 1.0f, 0.75f);
+  const Color orange(1.0f, 0.5f, 0.0f, 0.75f);
+  const Color green_bright(0.7f, 1.0f, 0.7f, 0.75f);
   for (auto& object : m_objects) {
+    Color color;
+    switch (object->get_group()) {
+    case COLGROUP_MOVING_STATIC:
+      color = violet;
+      break;
+    case COLGROUP_MOVING:
+      color = red;
+      break;
+    case COLGROUP_MOVING_ONLY_STATIC:
+      color = red_bright;
+      break;
+    case COLGROUP_STATIC:
+      color = cyan;
+      break;
+    case COLGROUP_TOUCHABLE:
+      color = orange;
+      break;
+    default:
+      color = green_bright;
+    }
     const Rectf& rect = object->get_bbox();
-
     context.color().draw_filled_rect(rect, color, LAYER_FOREGROUND1 + 10);
   }
 }


### PR DESCRIPTION
![2019-10-11-151056_1920x1080_scrot](https://user-images.githubusercontent.com/3192173/66653913-5f705880-ec39-11e9-91d2-3776435cba38.png)
