### PR TITLE
Heed sRGB colourspace in the editor and when fading

### DIFF
--- a/src/gui/item_colorchannel.cpp
+++ b/src/gui/item_colorchannel.cpp
@@ -24,19 +24,25 @@
 
 namespace {
 
-std::string float_to_string(float v)
+std::string colour_value_to_string(float v, bool is_linear)
 {
+  if (!is_linear)
+    v = Color::remove_gamma(v);
+  v *= 100.0f;
   // not using std::to_string() as it padds the end with '0's
+  v = 0.01f * floorf(v * 100.0f + 0.5f);
   std::ostringstream os;
-  os << v;
+  os << v << " %";
   return os.str();
 }
 
 } // namespace
 
-ItemColorChannel::ItemColorChannel(float* input, Color channel, int id) :
-  MenuItem(float_to_string(*input), id),
+ItemColorChannel::ItemColorChannel(float* input, Color channel, int id,
+    bool is_linear) :
+  MenuItem(colour_value_to_string(*input, is_linear), id),
   m_number(input),
+  m_is_linear(is_linear),
   m_flickw(static_cast<int>(Resources::normal_font->get_text_width("_"))),
   m_channel(channel)
 {
@@ -135,18 +141,18 @@ ItemColorChannel::process_action(const MenuAction& action)
       break;
 
     case MenuAction::LEFT:
-      *m_number = truncf(*m_number * 10.0f) / 10.0f;
+      *m_number = roundf(*m_number * 10.0f) / 10.0f;
       *m_number -= 0.1f;
       *m_number = math::clamp(*m_number, 0.0f, 1.0f);
-      set_text(float_to_string(*m_number));
+      set_text(colour_value_to_string(*m_number, m_is_linear));
       break;
 
 
     case MenuAction::RIGHT:
-      *m_number = truncf(*m_number * 10.0f) / 10.0f;
+      *m_number = roundf(*m_number * 10.0f) / 10.0f;
       *m_number += 0.1f;
       *m_number = math::clamp(*m_number, 0.0f, 1.0f);
-      set_text(float_to_string(*m_number));
+      set_text(colour_value_to_string(*m_number, m_is_linear));
       break;
 
     default:

--- a/src/gui/item_colorchannel.hpp
+++ b/src/gui/item_colorchannel.hpp
@@ -24,7 +24,8 @@
 class ItemColorChannel final : public MenuItem
 {
 public:
-  ItemColorChannel(float* input_, Color channel_, int id_ = -1);
+  ItemColorChannel(float* input_, Color channel_, int id_ = -1,
+    bool is_linear = false);
 
   /** Draws the menu item. */
   virtual void draw(DrawingContext&, const Vector& pos, int menu_width, bool active) override;
@@ -50,6 +51,7 @@ private:
 
 private:
   float* m_number;
+  bool m_is_linear;
   int m_flickw;
   Color m_channel;
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -292,8 +292,8 @@ Menu::add_submenu(const std::string& text, int submenu, int id)
 }
 
 ItemColorChannel&
-Menu::add_color_channel(float* input, Color channel, int id) {
-  auto item = std::make_unique<ItemColorChannel>(input, channel, id);
+Menu::add_color_channel(float* input, Color channel, int id, bool is_linear) {
+  auto item = std::make_unique<ItemColorChannel>(input, channel, id, is_linear);
   auto item_ptr = item.get();
   add_item(std::move(item));
   return *item_ptr;

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -89,7 +89,8 @@ public:
 
   ItemColor& add_color(const std::string& text, Color* color, int id = -1);
   ItemColorDisplay& add_color_display(Color* color, int id = -1);
-  ItemColorChannel& add_color_channel(float* input, Color channel, int id = -1);
+  ItemColorChannel& add_color_channel(float* input, Color channel, int id = -1,
+    bool is_linear = false);
 
   void process_input(const Controller& controller);
 

--- a/src/gui/menu_color.cpp
+++ b/src/gui/menu_color.cpp
@@ -27,7 +27,7 @@ ColorMenu::ColorMenu(Color* color_) :
   add_color_channel( &(color->red), Color::RED);
   add_color_channel( &(color->green), Color::GREEN);
   add_color_channel( &(color->blue), Color::BLUE);
-  add_color_channel( &(color->alpha), Color::BLACK);
+  add_color_channel( &(color->alpha), Color::BLACK, -1, true);
   add_color_display(color);
 
   add_hl();

--- a/src/object/display_effect.cpp
+++ b/src/object/display_effect.cpp
@@ -109,6 +109,9 @@ DisplayEffect::draw(DrawingContext& context)
           alpha = 0.0f; // NOLINT
           assert(false);
       }
+
+      // Same as in fadetoblack.cpp
+      alpha = Color::remove_gamma(alpha);
     }
     context.color().draw_filled_rect(Rectf(0, 0,
                                            static_cast<float>(context.get_width()),

--- a/src/supertux/fadetoblack.cpp
+++ b/src/supertux/fadetoblack.cpp
@@ -39,11 +39,14 @@ void
 FadeToBlack::draw(DrawingContext& context)
 {
   Color col = m_color;
-  if (m_direction == FADEOUT) {
-    col.alpha = m_accum_time / m_fade_time;
-  } else {
-    col.alpha = 1.0f - m_accum_time / m_fade_time;
-  }
+  col.alpha = m_accum_time / m_fade_time;
+  if (m_direction != FADEOUT)
+    col.alpha = 1.0f - col.alpha;
+
+  // The colours are mixed directly in sRGB space, so change alpha for a more
+  // linear fading (it may only work correctly with black)
+  col.alpha = Color::remove_gamma(col.alpha);
+
   context.color().draw_filled_rect(Rectf(0, 0,
                                          static_cast<float>(context.get_width()),
                                          static_cast<float>(context.get_height())),

--- a/src/video/color.hpp
+++ b/src/video/color.hpp
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <math.h>
 
 #include <SDL_image.h>
 
@@ -49,6 +50,15 @@ public:
                  static_cast<float>(b) / 255.0f,
                  static_cast<float>(a) / 255.0f);
   }
+
+  static Color from_linear(float r, float g, float b, float a = 1.0f)
+  {
+    return Color(add_gamma(r), add_gamma(g), add_gamma(b), a);
+  }
+
+  // Helper functions to approximately transform to/from sRGB colours
+  static float add_gamma(float x) { return powf(x, 1.0f / 2.2f); }
+  static float remove_gamma(float x) { return powf(x, 2.2f); }
 
 public:
   Color();


### PR DESCRIPTION
Fading is now linear. Here are screenshots showing the darkness when the fading is halfway finished (tested by temporarily setting alpha always to 0.5) and a white-black chessboard pattern. The images only look correctly when they are shown in 1:1 resolution (no scaling by the browser).
Before:
![before](https://user-images.githubusercontent.com/3192173/67143828-c01e1780-f26f-11e9-8342-7594752184b8.png)
After:
![after](https://user-images.githubusercontent.com/3192173/67143830-c57b6200-f26f-11e9-85d1-880b0299b9d8.png)

I've also changed the level editor colour settings so that the user sees the linear number and not sRGB values.

Related issue: #1097