### PR TITLE
Fix a -Wreturn-std-move-in-c++11 compiler warning

### DIFF
--- a/src/audio/sound_manager.cpp
+++ b/src/audio/sound_manager.cpp
@@ -138,7 +138,7 @@ SoundManager::intern_create_sound_source(const std::string& filename)
       auto stream_source = std::make_unique<StreamSoundSource>();
       stream_source->set_sound_file(std::move(file));
       stream_source->set_volume(static_cast<float>(m_sound_volume) / 100.0f);
-      return stream_source;
+      return std::move(stream_source);
     }
   }
 


### PR DESCRIPTION
Clang showed a warning about StreamSoundSource to me:
```
[…]/src/audio/sound_manager.cpp:141:14: warning: prior to the resolution of a defect report against ISO C++11, local variable 'stream_source' would have been copied despite being returned by name, due to its not matching the function return type ('unique_ptr<OpenALSoundSource, default_delete<OpenALSoundSource>>' vs 'unique_ptr<StreamSoundSource, default_delete<StreamSoundSource>>') [-Wreturn-std-move-in-c++11]
      return stream_source;
             ^~~~~~~~~~~~~
[…]/src/audio/sound_manager.cpp:141:14: note: call 'std::move' explicitly to avoid copying on older compilers
      return stream_source;
             ^~~~~~~~~~~~~
             std::move(stream_source)
1 warning generated.
```