### PR TITLE
Keep collisions enabled when Tux turns invisible

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1143,7 +1143,6 @@ void
 Player::set_visible(bool visible_)
 {
   m_visible = visible_;
-  set_group(visible_ ? COLGROUP_MOVING : COLGROUP_DISABLED);
 }
 
 bool


### PR DESCRIPTION
Fixes #1003. Below is a demo where I put a script trigger with "Tux.set_visible(false);" to the right of the coins. Note that Tux stays on the platform and can interact with the coins after turning invisible.

![invisible-demo](https://user-images.githubusercontent.com/24422213/67907851-3ca0e680-fbde-11e9-8287-9c55713fc8d0.gif)

To do this, I removed the line which moves Tux from "COLGROUP_MOVING" to "COLGROUP_DISABLED". I don't think this will have any adverse effects. Can anyone confirm?
