### PR TITLE
Game Menu: Fix very long string

### DIFF
--- a/src/supertux/menu/game_menu.cpp
+++ b/src/supertux/menu/game_menu.cpp
@@ -52,10 +52,10 @@ GameMenu::GameMenu() :
   add_label(level.m_name);
   add_hl();
   add_entry(MNID_CONTINUE, _("Continue"));
-  add_entry(MNID_RESETLEVEL, _("Restart Level"));
+  add_entry(MNID_RESETLEVEL, _("Level Restart"));
 
   if (Sector::current()->get_player().get_status().can_reach_checkpoint()) {
-    add_entry(MNID_RESETLEVELCHECKPOINT, _("Restart Level from Checkpoint"));
+    add_entry(MNID_RESETLEVELCHECKPOINT, _("Checkpoint Restart"));
   }
 
   add_submenu(_("Options"), MenuStorage::INGAME_OPTIONS_MENU);

--- a/src/supertux/menu/game_menu.cpp
+++ b/src/supertux/menu/game_menu.cpp
@@ -52,10 +52,10 @@ GameMenu::GameMenu() :
   add_label(level.m_name);
   add_hl();
   add_entry(MNID_CONTINUE, _("Continue"));
-  add_entry(MNID_RESETLEVEL, _("Level Restart"));
+  add_entry(MNID_RESETLEVEL, _("Restart Level"));
 
   if (Sector::current()->get_player().get_status().can_reach_checkpoint()) {
-    add_entry(MNID_RESETLEVELCHECKPOINT, _("Checkpoint Restart"));
+    add_entry(MNID_RESETLEVELCHECKPOINT, _("Restart from Checkpoint"));
   }
 
   add_submenu(_("Options"), MenuStorage::INGAME_OPTIONS_MENU);


### PR DESCRIPTION
The string in the editor about the Checkpoint Restart is too long, so I have shortened it in this pull request.