### PR TITLE
Fix Iceblock Waking Animation

### DIFF
--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -124,7 +124,7 @@ HitResponse
 MrIceBlock::collision_player(Player& player, const CollisionHit& hit)
 {
   // handle kicks from left or right side
-  if (ice_state == ICESTATE_WAKING || ice_state == ICESTATE_FLAT && get_state() == STATE_ACTIVE) {
+  if ((ice_state == ICESTATE_WAKING || ice_state == ICESTATE_FLAT) && get_state() == STATE_ACTIVE) {
     if (hit.left) {
       m_dir = Direction::RIGHT;
       player.kick();

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -124,7 +124,7 @@ HitResponse
 MrIceBlock::collision_player(Player& player, const CollisionHit& hit)
 {
   // handle kicks from left or right side
-  if (ice_state == ICESTATE_FLAT && get_state() == STATE_ACTIVE) {
+  if (ice_state == ICESTATE_WAKING || ice_state == ICESTATE_FLAT && get_state() == STATE_ACTIVE) {
     if (hit.left) {
       m_dir = Direction::RIGHT;
       player.kick();


### PR DESCRIPTION
Iceblock is now kickable when waking and doesn't hurt the player.

Fixes #1005 