### PR TITLE
Fix ground pounding bug

### DIFF
--- a/src/object/block.cpp
+++ b/src/object/block.cpp
@@ -86,7 +86,11 @@ Block::collision(GameObject& other, const CollisionHit& )
 {
   auto player = dynamic_cast<Player*> (&other);
   if (player) {
-    if (player->get_bbox().get_top() > m_col.m_bbox.get_bottom() - SHIFT_DELTA) {
+    bool x_coordinates_intersect =
+        player->get_bbox().get_right()  >= m_col.m_bbox.get_left() &&
+        player->get_bbox().get_left()   <= m_col.m_bbox.get_right();
+    if (player->get_bbox().get_top() > m_col.m_bbox.get_bottom() - SHIFT_DELTA &&
+        x_coordinates_intersect) {
       hit(*player);
     }
   }


### PR DESCRIPTION
Fixes #966.

The bug is easiest to reproduce by standing next to some bricks, holding down and right (or left) and pressing the jump button, as shown below:

![break-test-before-fix](https://user-images.githubusercontent.com/24422213/69068946-8583e680-0a8a-11ea-83e5-3efca5b6ac08.gif)

After the fix, the problem does not happen (see below):

![break-test-after-fix](https://user-images.githubusercontent.com/24422213/69069040-acdab380-0a8a-11ea-905c-84e5d4e87a40.gif)

I also tested with ground-pounding as per original bug description; this also seems to work fine now.