### PR TITLE
Avoid stacked objects jittering

### DIFF
--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -116,6 +116,15 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
   if (is_grabbed()) {
     return ABORT_MOVE;
   }
+
+  // Don't fall further if we are on a rock which is on the ground.
+  // This is to avoid jittering.
+  auto rock = dynamic_cast<Rock*> (&other);
+  if (rock && rock->on_ground && hit.bottom) {
+    physic.set_velocity_y(0);
+    return CONTINUE;
+  }
+
   if (!on_ground) {
     if (hit.bottom && physic.get_velocity_y() > 200) {
       auto moving_object = dynamic_cast<MovingObject*> (&other);


### PR DESCRIPTION
Fixes #395. I tested this with a large column of stacked rocks (see videos below), and it looks like they still behave as expected - without jittering, of course.

I haven't tested using other stackable objects yet.

Before:

![stack-test-before](https://user-images.githubusercontent.com/24422213/69930744-7e98b180-1529-11ea-8233-9e6821013393.gif)

After:

![stack-test-after](https://user-images.githubusercontent.com/24422213/69930749-835d6580-1529-11ea-99de-37b596b0ee8a.gif)

If anyone tests this and finds it causes undesired behaviour, please let me know.