### PR TITLE
Use green font for perfect level stats

### DIFF
--- a/src/supertux/colorscheme.cpp
+++ b/src/supertux/colorscheme.cpp
@@ -30,9 +30,11 @@ Color LevelIntro::s_header_color(1.f,1.f,0.6f);
 Color LevelIntro::s_author_color(1.f,1.f,1.f);
 Color LevelIntro::s_stat_hdr_color(0.2f,0.5f,1.f);
 Color LevelIntro::s_stat_color(1.f,1.f,1.f);
+Color LevelIntro::s_stat_perfect_color(0.4f,1.f,0.4f);
 
 Color Statistics::header_color(1.f,1.f,1.f);
 Color Statistics::text_color(1.f,1.f,0.6f);
+Color Statistics::perfect_color(0.4f,1.f,0.4f);
 
 Color ColorScheme::Menu::default_color(1.f,1.f,1.f);
 Color ColorScheme::Menu::active_color(0.4f,0.66f,1.f);

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -546,7 +546,7 @@ GameSession::drawstatus(DrawingContext& context)
 {
   // draw level stats while end_sequence is running
   if (m_end_sequence) {
-    m_level->m_stats.draw_endseq_panel(context, m_best_level_statistics, m_statistics_backdrop);
+    m_level->m_stats.draw_endseq_panel(context, m_best_level_statistics, m_statistics_backdrop, m_level->m_target_time);
   }
 }
 

--- a/src/supertux/levelintro.cpp
+++ b/src/supertux/levelintro.cpp
@@ -102,12 +102,13 @@ LevelIntro::update(float dt_sec, const Controller& controller)
 
 }
 
-void LevelIntro::draw_stats_line(DrawingContext& context, int& py, const std::string& name, const std::string& stat)
+void LevelIntro::draw_stats_line(DrawingContext& context, int& py, const std::string& name, const std::string& stat, bool isPerfect)
 {
   std::stringstream ss;
   ss << name << ": " << stat;
+  Color tcolor = isPerfect ? s_stat_perfect_color : s_stat_color;
   context.color().draw_center_text(Resources::normal_font, ss.str(), Vector(0, static_cast<float>(py)),
-                                   LAYER_FOREGROUND1, s_stat_color);
+                                   LAYER_FOREGROUND1, tcolor);
   py += static_cast<int>(Resources::normal_font->get_height());
 }
 
@@ -163,17 +164,22 @@ LevelIntro::draw(Compositor& compositor)
     py += static_cast<int>(Resources::normal_font->get_height());
 
     draw_stats_line(context, py, _("Coins"),
-                    Statistics::coins_to_string(m_best_level_statistics->m_coins, stats.m_total_coins));
+                    Statistics::coins_to_string(m_best_level_statistics->m_coins, stats.m_total_coins),
+                    m_best_level_statistics->m_coins >= stats.m_total_coins);
     draw_stats_line(context, py, _("Badguys killed"),
-                    Statistics::frags_to_string(m_best_level_statistics->m_badguys, stats.m_total_badguys));
+                    Statistics::frags_to_string(m_best_level_statistics->m_badguys, stats.m_total_badguys),
+                    m_best_level_statistics->m_badguys >= stats.m_total_badguys);
     draw_stats_line(context, py, _("Secrets"),
-                    Statistics::secrets_to_string(m_best_level_statistics->m_secrets, stats.m_total_secrets));
+                    Statistics::secrets_to_string(m_best_level_statistics->m_secrets, stats.m_total_secrets),
+                    m_best_level_statistics->m_secrets >= stats.m_total_secrets);
+
+    bool targetTimeBeaten = m_level.m_target_time == 0.0f || (m_best_level_statistics->get_time() != 0.0f && m_best_level_statistics->get_time() < m_level.m_target_time);
     draw_stats_line(context, py, _("Best time"),
-                    Statistics::time_to_string(m_best_level_statistics->get_time()));
+                    Statistics::time_to_string(m_best_level_statistics->get_time()), targetTimeBeaten);
 
     if (m_level.m_target_time != 0.0f) {
       draw_stats_line(context, py, _("Level target time"),
-                      Statistics::time_to_string(m_level.m_target_time));
+                      Statistics::time_to_string(m_level.m_target_time), targetTimeBeaten);
     }
   }
 }

--- a/src/supertux/levelintro.hpp
+++ b/src/supertux/levelintro.hpp
@@ -35,6 +35,7 @@ private:
   static Color s_author_color;
   static Color s_stat_hdr_color;
   static Color s_stat_color;
+  static Color s_stat_perfect_color;
 
 public:
   LevelIntro(const Level& level, const Statistics* best_level_statistics, const PlayerStatus& player_status);
@@ -45,7 +46,7 @@ public:
   virtual void update(float dt_sec, const Controller& controller) override;
 
 private:
-  void draw_stats_line(DrawingContext& context, int& py, const std::string& name, const std::string& stat);
+  void draw_stats_line(DrawingContext& context, int& py, const std::string& name, const std::string& stat, bool isPerfect);
 
 private:
   const Level& m_level; /**< The level of which this is the intro screen */

--- a/src/supertux/statistics.cpp
+++ b/src/supertux/statistics.cpp
@@ -143,30 +143,42 @@ Statistics::draw_worldmap_info(DrawingContext& context, float target_time)
   std::string caption_buf;
   std::string stat_buf;
   float posy = WMAP_INFO_TOP_Y2;
+  Color tcolor;
 
   for (int stat_no = 0; stat_no < 5; stat_no++) {
+    tcolor = Statistics::header_color;
     switch (stat_no)
     {
       case 0:
         caption_buf = CAPTION_MAX_COINS;
         stat_buf = coins_to_string(m_coins, m_total_coins);
+        if (m_coins >= m_total_coins)
+          tcolor = Statistics::perfect_color;
         break;
       case 1:
         caption_buf = CAPTION_MAX_FRAGGING;
         stat_buf = frags_to_string(m_badguys, m_total_badguys);
+        if (m_badguys >= m_total_badguys)
+          tcolor = Statistics::perfect_color;
         break;
       case 2:
         caption_buf = CAPTION_MAX_SECRETS;
         stat_buf = secrets_to_string(m_secrets, m_total_secrets);
+        if (m_secrets >= m_total_secrets)
+          tcolor = Statistics::perfect_color;
         break;
       case 3:
         caption_buf = CAPTION_BEST_TIME;
         stat_buf = time_to_string(m_time);
+        if ((m_time < target_time) || (target_time == 0.0f))
+          tcolor = Statistics::perfect_color;
         break;
       case 4:
         if (target_time != 0.0f) { // display target time only if defined for level
           caption_buf = CAPTION_TARGET_TIME;
           stat_buf = time_to_string(target_time);
+          if ((m_time < target_time) || (target_time == 0.0f))
+            tcolor = Statistics::perfect_color;
         } else {
           caption_buf = "";
           stat_buf = "";
@@ -178,13 +190,13 @@ Statistics::draw_worldmap_info(DrawingContext& context, float target_time)
     }
 
     context.color().draw_text(Resources::small_font, caption_buf, Vector(WMAP_INFO_LEFT_X, posy), ALIGN_LEFT, LAYER_HUD, Statistics::header_color);
-    context.color().draw_text(Resources::small_font, stat_buf, Vector(WMAP_INFO_RIGHT_X, posy), ALIGN_RIGHT, LAYER_HUD, Statistics::header_color);
+    context.color().draw_text(Resources::small_font, stat_buf, Vector(WMAP_INFO_RIGHT_X, posy), ALIGN_RIGHT, LAYER_HUD, tcolor);
     posy += Resources::small_font->get_height() + 2;
   }
 }
 
 void
-Statistics::draw_endseq_panel(DrawingContext& context, Statistics* best_stats, const SurfacePtr& backdrop)
+Statistics::draw_endseq_panel(DrawingContext& context, Statistics* best_stats, const SurfacePtr& backdrop, float target_time)
 {
   if (m_status != FINAL) return;
 
@@ -218,35 +230,70 @@ Statistics::draw_endseq_panel(DrawingContext& context, Statistics* best_stats, c
     context.color().draw_text(Resources::normal_font, _("Best"), Vector(col3_x, row1_y), ALIGN_LEFT, LAYER_HUD, Statistics::header_color);
 
   context.color().draw_text(Resources::normal_font, _("Coins"), Vector(col2_x - 16.0f, static_cast<float>(row3_y)), ALIGN_RIGHT, LAYER_HUD, Statistics::header_color);
-  context.color().draw_text(Resources::normal_font, coins_to_string(m_coins, m_total_coins), Vector(col2_x, static_cast<float>(row3_y)), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+
+  Color tcolor;
+  if (m_coins >= m_total_coins)
+    tcolor = Statistics::perfect_color;
+  else
+    tcolor = Statistics::text_color;
+  context.color().draw_text(Resources::normal_font, coins_to_string(m_coins, m_total_coins), Vector(col2_x, static_cast<float>(row3_y)), ALIGN_LEFT, LAYER_HUD, tcolor);
 
   if (best_stats) {
     int coins_best = (best_stats->m_coins > m_coins) ? best_stats->m_coins : m_coins;
     int total_coins_best = (best_stats->m_total_coins > m_total_coins) ? best_stats->m_total_coins : m_total_coins;
-    context.color().draw_text(Resources::normal_font, coins_to_string(coins_best, total_coins_best), Vector(col3_x, static_cast<float>(row3_y)), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+    if (coins_best >= total_coins_best)
+      tcolor = Statistics::perfect_color;
+    else
+      tcolor = Statistics::text_color;
+    context.color().draw_text(Resources::normal_font, coins_to_string(coins_best, total_coins_best), Vector(col3_x, static_cast<float>(row3_y)), ALIGN_LEFT, LAYER_HUD, tcolor);
   }
 
+  if (m_badguys >= m_total_badguys)
+    tcolor = Statistics::perfect_color;
+  else
+    tcolor = Statistics::text_color;
   context.color().draw_text(Resources::normal_font, _("Badguys"), Vector(col2_x - 16.0f, static_cast<float>(row4_y)), ALIGN_RIGHT, LAYER_HUD, Statistics::header_color);
-  context.color().draw_text(Resources::normal_font, frags_to_string(m_badguys, m_total_badguys), Vector(col2_x, static_cast<float>(row4_y)), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+  context.color().draw_text(Resources::normal_font, frags_to_string(m_badguys, m_total_badguys), Vector(col2_x, static_cast<float>(row4_y)), ALIGN_LEFT, LAYER_HUD, tcolor);
   if (best_stats) {
 	int badguys_best = (best_stats->m_badguys > m_badguys) ? best_stats->m_badguys : m_badguys;
 	int total_badguys_best = (best_stats->m_total_badguys > m_total_badguys) ? best_stats->m_total_badguys : m_total_badguys;
-	context.color().draw_text(Resources::normal_font, frags_to_string(badguys_best, total_badguys_best), Vector(col3_x, row4_y), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+        if (badguys_best >= total_badguys_best)
+          tcolor = Statistics::perfect_color;
+        else
+          tcolor = Statistics::text_color;
+	context.color().draw_text(Resources::normal_font, frags_to_string(badguys_best, total_badguys_best), Vector(col3_x, row4_y), ALIGN_LEFT, LAYER_HUD, tcolor);
   }
 
+  if (m_secrets >= m_total_secrets)
+    tcolor = Statistics::perfect_color;
+  else
+    tcolor = Statistics::text_color;
   context.color().draw_text(Resources::normal_font, _("Secrets"), Vector(col2_x-16, row5_y), ALIGN_RIGHT, LAYER_HUD, Statistics::header_color);
-  context.color().draw_text(Resources::normal_font, secrets_to_string(m_secrets, m_total_secrets), Vector(col2_x, row5_y), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+  context.color().draw_text(Resources::normal_font, secrets_to_string(m_secrets, m_total_secrets), Vector(col2_x, row5_y), ALIGN_LEFT, LAYER_HUD, tcolor);
   if (best_stats) {
     int secrets_best = (best_stats->m_secrets > m_secrets) ? best_stats->m_secrets : m_secrets;
     int total_secrets_best = (best_stats->m_total_secrets > m_total_secrets) ? best_stats->m_total_secrets : m_total_secrets;
-    context.color().draw_text(Resources::normal_font, secrets_to_string(secrets_best, total_secrets_best), Vector(col3_x, row5_y), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+    if (secrets_best >= total_secrets_best)
+      tcolor = Statistics::perfect_color;
+    else
+      tcolor = Statistics::text_color;
+    context.color().draw_text(Resources::normal_font, secrets_to_string(secrets_best, total_secrets_best), Vector(col3_x, row5_y), ALIGN_LEFT, LAYER_HUD, tcolor);
   }
 
+  tcolor = Statistics::text_color;
+  if (target_time == 0.0f || (m_time != 0.0f && m_time < target_time))
+    tcolor = Statistics::perfect_color;
+  else
+    tcolor = Statistics::text_color;
   context.color().draw_text(Resources::normal_font, _("Time"), Vector(col2_x - 16, row2_y), ALIGN_RIGHT, LAYER_HUD, Statistics::header_color);
-  context.color().draw_text(Resources::normal_font, time_to_string(m_time), Vector(col2_x, row2_y), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+  context.color().draw_text(Resources::normal_font, time_to_string(m_time), Vector(col2_x, row2_y), ALIGN_LEFT, LAYER_HUD, tcolor);
   if (best_stats) {
     float time_best = (best_stats->m_time < m_time && best_stats->m_time > 0.0f) ? best_stats->m_time : m_time;
-    context.color().draw_text(Resources::normal_font, time_to_string(time_best), Vector(col3_x, row2_y), ALIGN_LEFT, LAYER_HUD, Statistics::text_color);
+    if (target_time == 0.0f || (time_best != 0.0f && time_best < target_time))
+      tcolor = Statistics::perfect_color;
+    else
+      tcolor = Statistics::text_color;
+    context.color().draw_text(Resources::normal_font, time_to_string(time_best), Vector(col3_x, row2_y), ALIGN_LEFT, LAYER_HUD, tcolor);
   }
 }
 

--- a/src/supertux/statistics.hpp
+++ b/src/supertux/statistics.hpp
@@ -34,6 +34,7 @@ class Statistics final
 private:
   static Color header_color;
   static Color text_color;
+  static Color perfect_color;
 
 public:
   static std::string coins_to_string(int coins, int total_coins);
@@ -54,7 +55,7 @@ public:
   void unserialize_from_squirrel(SquirrelVM& vm);
 
   void draw_worldmap_info(DrawingContext& context, float target_time); /**< draw worldmap stat HUD */
-  void draw_endseq_panel(DrawingContext& context, Statistics* best_stats, const SurfacePtr& backdrop); /**< draw panel shown during level's end sequence */
+  void draw_endseq_panel(DrawingContext& context, Statistics* best_stats, const SurfacePtr& backdrop, float target_time); /**< draw panel shown during level's end sequence */
 
   void init(const Level& level);
   void finish(float time);


### PR DESCRIPTION
This PR will make change the font color to green for displayed level stats if they are “perfect”, e.g. the level target has been reached.
“Perfect” stats: All badguys killed / all coins collected / all secrets found / target time beaten.

This affects the following:
* Level intro screen
* Level outro screen
* Level stats in worldmap

The record time will become green if it is lower than the target time. If the level does not have a target time, it turns green when the level was beaten.

Examples:

* If you got 100/100 coins, the coins text will be green. If you got fewer coins, the text will be the default color.
* If you beat the level in 30 seconds, and there is a target time of 1 min, time text is green.
* If you beat the level in 4 hours, and there is no target time, time text is still green.

---

Rationale:
With this you can see which parts of the level you did perfectly at a glance. You don't need to read anymore, as soon you see green, you know it's perfect. Basically it's a small quality-of-life improvement.