### PR TITLE
Use preprocessor directives to disable unused code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         "-Wno-exit-time-destructors "
         "-Wno-global-constructors "
         "-Wno-duplicate-enum "
+        "-Wno-unreachable-code "
       )
     endif()
   endif(WARNINGS)

--- a/src/editor/undo_manager.cpp
+++ b/src/editor/undo_manager.cpp
@@ -57,7 +57,7 @@ UndoManager::try_snapshot(Level& level)
 void
 UndoManager::debug_print(const char* action)
 {
-  if ((false))
+  if (false)
   {
     std::cout << action << std::endl;
     std::cout << "undo_stack: ";

--- a/src/editor/undo_manager.cpp
+++ b/src/editor/undo_manager.cpp
@@ -57,22 +57,21 @@ UndoManager::try_snapshot(Level& level)
 void
 UndoManager::debug_print(const char* action)
 {
-  if (false)
-  {
-    std::cout << action << std::endl;
-    std::cout << "undo_stack: ";
-    for(size_t i = 0; i < m_undo_stack.size(); ++i) {
-      std::cout << static_cast<const void*>(m_undo_stack[i].data()) << " ";
-    }
-    std::cout << std::endl;
-
-    std::cout << "redo_stack: ";
-    for(size_t i = 0; i < m_redo_stack.size(); ++i) {
-      std::cout << static_cast<const void*>(m_redo_stack[i].data()) << " ";
-    }
-    std::cout << std::endl;
-    std::cout << std::endl;
+#if 0
+  std::cout << action << std::endl;
+  std::cout << "undo_stack: ";
+  for(size_t i = 0; i < m_undo_stack.size(); ++i) {
+    std::cout << static_cast<const void*>(m_undo_stack[i].data()) << " ";
   }
+  std::cout << std::endl;
+
+  std::cout << "redo_stack: ";
+  for(size_t i = 0; i < m_redo_stack.size(); ++i) {
+    std::cout << static_cast<const void*>(m_redo_stack[i].data()) << " ";
+  }
+  std::cout << std::endl;
+  std::cout << std::endl;
+#endif
 }
 
 void

--- a/src/video/gl/gl_texture.cpp
+++ b/src/video/gl/gl_texture.cpp
@@ -169,10 +169,9 @@ GLTexture::GLTexture(const SDL_Surface& image, const Sampler& sampler) :
                  GL_UNSIGNED_BYTE, convert->pixels);
 
     // no not use mipmaps
-    if ((false))
-    {
-      glGenerateMipmap(GL_TEXTURE_2D);
-    }
+#if 0
+    glGenerateMipmap(GL_TEXTURE_2D);
+#endif
 
     if (SDL_MUSTLOCK(convert.get())) {
       SDL_UnlockSurface(convert.get());

--- a/src/video/ttf_surface_manager.cpp
+++ b/src/video/ttf_surface_manager.cpp
@@ -53,14 +53,14 @@ TTFSurfaceManager::create_surface(const TTFFont& font, const std::string& text)
   }
   else
   {
-    if (false)
-    {
-      // Font debug output should go to 'std::cerr', not any of the
-      // log_* functions, as those are mirrored on the console which
-      // in turn will lead to the creation of more TTFSurface's and
-      // screw up the results.
-      print_debug_info(std::cerr);
-    }
+
+#if 0
+    // Font debug output should go to 'std::cerr', not any of the
+    // log_* functions, as those are mirrored on the console which
+    // in turn will lead to the creation of more TTFSurface's and
+    // screw up the results.
+    print_debug_info(std::cerr);
+#endif
 
     cache_cleanup_step();
 

--- a/src/video/ttf_surface_manager.cpp
+++ b/src/video/ttf_surface_manager.cpp
@@ -53,7 +53,7 @@ TTFSurfaceManager::create_surface(const TTFFont& font, const std::string& text)
   }
   else
   {
-    if ((false))
+    if (false)
     {
       // Font debug output should go to 'std::cerr', not any of the
       // log_* functions, as those are mirrored on the console which


### PR DESCRIPTION
I am not sure if there is some reason why unused C++ code was not disabled with preprocessor directives, and how the compiler flag change affects compilation with various compilers, so I opened this as draft PR.