### PR TITLE
Do not generate a text surface to measure text width

### DIFF
--- a/src/video/ttf_font.cpp
+++ b/src/video/ttf_font.cpp
@@ -62,25 +62,21 @@ TTFFont::get_text_width(const std::string& text) const
   {
     const std::string& line = iter.get();
 
-    // Since create_surface() takes a surface from the cache instead of
-    // generating it from scratch it should be faster than doing a whole
-    // layout.
-    if ((false))
-    {
+    // Since get_cached_surface_width() takes a surface from the cache
+    // instead of generating it from scratch,
+    // it should be faster than doing a whole layout.
+    int line_width = TTFSurfaceManager::current()->get_cached_surface_width(*this, line);
+    if (line_width < 0) {
+      // Not in cache
       int w = 0;
       int h = 0;
       int ret = TTF_SizeUTF8(m_font, line.c_str(), &w, &h);
-      if (ret < 0)
-      {
+      if (ret < 0) {
         std::cerr << "TTFFont::get_text_width(): " << TTF_GetError() << std::endl;
       }
-      max_width = std::max(max_width, static_cast<float>(w));
+      line_width = w;
     }
-    else
-    {
-      TTFSurfacePtr surface = TTFSurfaceManager::current()->create_surface(*this, line);
-      max_width = std::max(max_width, static_cast<float>(surface->get_width()));
-    }
+    max_width = std::max(max_width, static_cast<float>(line_width));
   }
 
   return max_width;

--- a/src/video/ttf_surface_manager.cpp
+++ b/src/video/ttf_surface_manager.cpp
@@ -69,6 +69,19 @@ TTFSurfaceManager::create_surface(const TTFFont& font, const std::string& text)
   }
 }
 
+int
+TTFSurfaceManager::get_cached_surface_width(const TTFFont& font,
+  const std::string& text)
+{
+  auto key = Key(font.get_ttf_font(), text);
+  auto it = m_cache.find(key);
+  if (it == m_cache.end())
+    return -1;
+  auto& entry = m_cache[key];
+  entry.last_access = g_game_time;
+  return entry.ttf_surface->get_width();
+}
+
 void
 TTFSurfaceManager::cache_cleanup_step()
 {

--- a/src/video/ttf_surface_manager.hpp
+++ b/src/video/ttf_surface_manager.hpp
@@ -36,6 +36,9 @@ public:
 
   TTFSurfacePtr create_surface(const TTFFont& font, const std::string& text);
 
+  // Returns -1 if there is no cached text surface
+  int get_cached_surface_width(const TTFFont& font, const std::string& text);
+
   void print_debug_info(std::ostream& out);
 
 private:


### PR DESCRIPTION
The changes were introduced in commit a7969f.
Now only cached surfaces' widths are used.

This makes e.g. loading the Options menu the first time significantly faster.

Note that I am not very familiar with the text rendering, so I do not know if this has bad side effects.