### PR TITLE
Explosion: Make push strength and number of particles configurable

### DIFF
--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -96,7 +96,8 @@ Bomb::explode()
 
   if (is_valid()) {
     remove_me();
-    Sector::get().add<Explosion>(m_col.m_bbox.get_middle());
+    Sector::get().add<Explosion>(m_col.m_bbox.get_middle(),
+      EXPLOSION_STRENGTH_DEFAULT);
   }
 
   run_dead_script();

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -166,7 +166,8 @@ GoldBomb::kill_fall()
 
   if (is_valid()) {
     remove_me();
-    Sector::get().add<Explosion>(m_col.m_bbox.get_middle());
+    Sector::get().add<Explosion>(m_col.m_bbox.get_middle(),
+      EXPLOSION_STRENGTH_DEFAULT);
     Sector::get().add<CoinExplode>(get_pos() + Vector (0, -40));
   }
 

--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -149,7 +149,8 @@ Haywire::kill_fall()
   }
   if (is_valid()) {
     remove_me();
-    Sector::get().add<Explosion>(m_col.m_bbox.get_middle());
+    Sector::get().add<Explosion>(m_col.m_bbox.get_middle(),
+      EXPLOSION_STRENGTH_DEFAULT);
   }
 
   run_dead_script();

--- a/src/badguy/mrbomb.cpp
+++ b/src/badguy/mrbomb.cpp
@@ -102,7 +102,8 @@ MrBomb::kill_fall()
 {
   if (is_valid()) {
     remove_me();
-    Sector::get().add<Explosion>(m_col.m_bbox.get_middle());
+    Sector::get().add<Explosion>(m_col.m_bbox.get_middle(),
+      EXPLOSION_STRENGTH_DEFAULT);
   }
 
   run_dead_script();

--- a/src/badguy/short_fuse.cpp
+++ b/src/badguy/short_fuse.cpp
@@ -48,9 +48,9 @@ ShortFuse::explode()
   if (!is_valid())
     return;
 
-  auto& explosion = Sector::get().add<Explosion>(get_bbox().get_middle());
+  auto& explosion = Sector::get().add<Explosion>(get_bbox().get_middle(),
+    EXPLOSION_STRENGTH_NEAR, 8);
   explosion.hurts(false);
-  explosion.pushes(true);
 
   run_dead_script();
   remove_me();

--- a/src/badguy/skydive.cpp
+++ b/src/badguy/skydive.cpp
@@ -126,10 +126,10 @@ SkyDive::explode()
   if (!is_valid())
     return;
 
-  auto& explosion = Sector::get().add<Explosion>(get_anchor_pos(m_col.m_bbox, ANCHOR_BOTTOM));
+  auto& explosion = Sector::get().add<Explosion>(
+    get_anchor_pos(m_col.m_bbox, ANCHOR_BOTTOM), EXPLOSION_STRENGTH_NEAR);
 
   explosion.hurts(true);
-  explosion.pushes(true);
 
   remove_me();
 }

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -26,10 +26,12 @@
 #include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
-Explosion::Explosion(const Vector& pos) :
+Explosion::Explosion(const Vector& pos, float p_push_strength,
+    int p_num_particles) :
   MovingSprite(pos, "images/objects/explosion/explosion.sprite", LAYER_OBJECTS+40, COLGROUP_MOVING),
   hurt(true),
-  push(true),
+  push_strength(p_push_strength),
+  num_particles(p_num_particles),
   state(STATE_WAITING),
   lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite"))
 {
@@ -43,7 +45,8 @@ Explosion::Explosion(const Vector& pos) :
 Explosion::Explosion(const ReaderMapping& reader) :
   MovingSprite(reader, "images/objects/explosion/explosion.sprite", LAYER_OBJECTS+40, COLGROUP_MOVING),
   hurt(true),
-  push(false),
+  push_strength(-1),
+  num_particles(100),
   state(STATE_WAITING),
   lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite"))
 {
@@ -67,14 +70,15 @@ Explosion::explode()
     SoundManager::current()->play("sounds/explosion.wav", get_pos(), 0.98f);
   else
     SoundManager::current()->play("sounds/firecracker.ogg", get_pos(), 0.7f);
+  bool does_push = push_strength > 0;
 
   // spawn some particles
-  int pnumber = push ? 8 : 100;
   Vector accel = Vector(0, Sector::get().get_gravity()*100);
   Sector::get().add<Particles>(
-    m_col.m_bbox.get_middle(), -360, 360, 450, 900, accel , pnumber, Color(.4f, .4f, .4f), 3, .8f, LAYER_OBJECTS-1);
+    m_col.m_bbox.get_middle(), -360, 360, 450, 900, accel, num_particles,
+    Color(.4f, .4f, .4f), 3, .8f, LAYER_OBJECTS-1);
 
-  if (push) {
+  if (does_push) {
     Vector center = m_col.m_bbox.get_middle ();
     auto near_objects = Sector::get().get_nearby_objects (center, 128.0 * 32.0);
 
@@ -90,9 +94,10 @@ Explosion::explode()
 
       /* The force decreases with the distance squared. In the distance of one
        * tile (32 pixels) you will have a speed increase of 150 pixels/s. */
-      float force = 150.0f * 100.0f * 100.0f / (distance * distance);
-	  // If we somehow get a force of over 200, keep it at 200 because unexpected behaviour could result otherwise.
-	  if (force > 200.0f)
+      float force = push_strength / (distance * distance);
+      // If we somehow get a force of over 200, keep it at 200 because
+      // unexpected behaviour could result otherwise.
+      if (force > 200.0f)
         force = 200.0;
 
       Vector add_speed = direction.unit () * force;

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -19,12 +19,15 @@
 
 #include "object/moving_sprite.hpp"
 
+#define EXPLOSION_STRENGTH_DEFAULT (1464.8f * 32.0f * 32.0f)
+#define EXPLOSION_STRENGTH_NEAR (150.0f * 32.0f * 32.0f)
+
 /** Just your average explosion - goes boom, hurts Tux */
 class Explosion final : public MovingSprite
 {
 public:
   /** Create new Explosion centered(!) at @c pos */
-  Explosion(const Vector& pos);
+  Explosion(const Vector& pos, float push_strength, int num_particles=100);
   Explosion(const ReaderMapping& reader);
 
   virtual void update(float dt_sec) override;
@@ -34,9 +37,6 @@ public:
 
   bool hurts() const { return hurt; }
   void hurts (bool val) { hurt = val; }
-
-  bool pushes() const { return push; }
-  void pushes (bool val) { push = val; }
 
 private:
   /** plays sound, starts animation */
@@ -50,7 +50,8 @@ private:
 
 private:
   bool hurt;
-  bool push;
+  float push_strength;
+  int num_particles;
   State state;
   SpritePtr lightsprite;
 


### PR DESCRIPTION
I did not set a default value for the `push_strength` parameter because I think that it should be set individually for each explosion.