### PR TITLE
Added downward throw for icecube

### DIFF
--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -274,7 +274,8 @@ MrIceBlock::grab(MovingObject& object, const Vector& pos, Direction dir_)
   set_colgroup_active(COLGROUP_DISABLED);
 }
 
-void MrIceBlock::ungrab(MovingObject &object, Direction dir_)
+void
+MrIceBlock::ungrab(MovingObject &object, Direction dir_)
 {
   if (dir_ == Direction::UP) {
     set_state(ICESTATE_FLAT, true);
@@ -285,8 +286,7 @@ void MrIceBlock::ungrab(MovingObject &object, Direction dir_)
       set_pos(get_pos() + mov);
       m_dir = dir_;
       set_state(ICESTATE_KICKED);
-    }
-    else
+    } else
       set_state(ICESTATE_FLAT);
   }
   else {
@@ -297,15 +297,16 @@ void MrIceBlock::ungrab(MovingObject &object, Direction dir_)
   Portable::ungrab(object, dir_);
 }
 
-bool MrIceBlock::is_portable() const 
+bool
+MrIceBlock::is_portable() const
 { 
   return ice_state == ICESTATE_FLAT; 
 }
 
-void MrIceBlock::ignite() 
-{
+void
+MrIceBlock::ignite() {
   set_state(ICESTATE_NORMAL);
   BadGuy::ignite();
- }
+}
 
 /* EOF */

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -274,7 +274,8 @@ MrIceBlock::grab(MovingObject& object, const Vector& pos, Direction dir_)
   set_colgroup_active(COLGROUP_DISABLED);
 }
 
-void MrIceBlock::ungrab(MovingObject &object, Direction dir_) {
+void MrIceBlock::ungrab(MovingObject &object, Direction dir_)
+{
   if (dir_ == Direction::UP) {
     set_state(ICESTATE_FLAT, true);
   }
@@ -296,11 +297,15 @@ void MrIceBlock::ungrab(MovingObject &object, Direction dir_) {
   Portable::ungrab(object, dir_);
 }
 
-  bool MrIceBlock::is_portable() const { return ice_state == ICESTATE_FLAT; }
+bool MrIceBlock::is_portable() const 
+{ 
+  return ice_state == ICESTATE_FLAT; 
+}
 
-  void MrIceBlock::ignite() {
-    set_state(ICESTATE_NORMAL);
-    BadGuy::ignite();
-  }
+void MrIceBlock::ignite() 
+{
+  set_state(ICESTATE_NORMAL);
+  BadGuy::ignite();
+ }
 
-  /* EOF */
+/* EOF */

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -275,7 +275,7 @@ MrIceBlock::grab(MovingObject& object, const Vector& pos, Direction dir_)
 }
 
 void
-MrIceBlock::ungrab(MovingObject &object, Direction dir_)
+MrIceBlock::ungrab(MovingObject& object, Direction dir_)
 {
   if (dir_ == Direction::UP) {
     set_state(ICESTATE_FLAT, true);
@@ -299,8 +299,8 @@ MrIceBlock::ungrab(MovingObject &object, Direction dir_)
 
 bool
 MrIceBlock::is_portable() const
-{ 
-  return ice_state == ICESTATE_FLAT; 
+{
+  return ice_state == ICESTATE_FLAT;
 }
 
 void


### PR DESCRIPTION
Releasing icecube while holding `down` key puts it on ground, or throws down, if released in the air. This solves #1285. Please check and review.