### PR TITLE
Snails can always be stomped

### DIFF
--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -247,10 +247,6 @@ Snail::collision_squished(GameObject& object)
     case STATE_KICKED:
     case STATE_NORMAL:
 
-      // Can't stomp in midair
-      if (!on_ground())
-        break;
-
       squishcount++;
       if (squishcount >= MAX_SNAIL_SQUISHES) {
         kill_fall();


### PR DESCRIPTION
This simply removes the flag that the snail must be on the ground to be stompable.  This seems to address #1069, but as it could cause unexpected behavior, I recommend someone else to test it as well.