### PR TITLE
Make skydive always use explosion animation

### DIFF
--- a/src/badguy/skydive.cpp
+++ b/src/badguy/skydive.cpp
@@ -118,6 +118,12 @@ SkyDive::active_update(float dt_sec)
 }
 
 void
+SkyDive::kill_fall()
+{
+  explode();
+}
+
+void
 SkyDive::explode()
 {
   if (!is_valid())
@@ -126,7 +132,7 @@ SkyDive::explode()
   auto& explosion = Sector::get().add<Explosion>(get_anchor_pos(m_col.m_bbox, ANCHOR_BOTTOM));
 
   explosion.hurts(true);
-  explosion.pushes(false);
+  explosion.pushes(true);
 
   remove_me();
 }

--- a/src/badguy/skydive.hpp
+++ b/src/badguy/skydive.hpp
@@ -24,6 +24,8 @@ class SkyDive final : public BadGuy, public Portable
 {
 public:
   SkyDive(const ReaderMapping& reader);
+  
+  virtual void kill_fall() override;
 
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
@@ -33,7 +35,7 @@ public:
   virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
   virtual void ungrab(MovingObject& object, Direction dir) override;
   virtual std::string get_class() const override { return "skydive"; }
-  virtual std::string get_display_name() const override { return _("Sky dive"); }
+  virtual std::string get_display_name() const override { return _("Skydive"); }
 
 private:
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;


### PR DESCRIPTION
There are some diff problems, and one unrelated change allowing skydive explosions to push entities.  Anyway, this makes the skydive never use the "fall" animation, fixing #1152.