### PR TITLE
Add a generic addon type

### DIFF
--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -45,6 +45,10 @@ Addon::Type addon_type_from_string(const std::string& type)
   {
     return Addon::LANGUAGEPACK;
   }
+  else if (type == "addon")
+  {
+    return Addon::ADDON;
+  }
   else
   {
     throw std::runtime_error("not a valid Addon::Type: " + type);

--- a/src/addon/addon.hpp
+++ b/src/addon/addon.hpp
@@ -29,7 +29,7 @@ public:
   static std::unique_ptr<Addon> parse(const ReaderMapping& mapping);
   static std::unique_ptr<Addon> parse(const std::string& fname);
 
-  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK };
+  enum Type { WORLD, WORLDMAP, LEVELSET, LANGUAGEPACK, ADDON };
 
   enum Format {
     ORIGINAL = 0,

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -49,6 +49,9 @@ std::string addon_type_to_translated_string(Addon::Type type)
 
     case Addon::WORLD:
       return _("World");
+	  
+	case Addon::ADDON:
+      return _("Add-on");
 
     case Addon::LANGUAGEPACK:
       return "";


### PR DESCRIPTION
This PR adds a generic addon type that can be used when the user does not know what to label their addon with.  If their addon is a music pack, sound pack, graphic pack, or something else, they can simply label it as "addon".