### PR TITLE
Fix build on big endian architectures

### DIFF
--- a/src/audio/wav_sound_file.cpp
+++ b/src/audio/wav_sound_file.cpp
@@ -150,7 +150,7 @@ WavSoundFile::read(void* buffer, size_t buffer_size)
     throw SoundError("read error while reading samples");
 
 #ifdef WORDS_BIGENDIAN
-  if (bits_per_sample != 16)
+  if (m_bits_per_sample != 16)
     return readsize;
   char *tmp = (char*)buffer;
 


### PR DESCRIPTION
In commit cb910e1 class attributes have been prefixed with m_.
This big endian case has been overlooked.