### PR TITLE
Trampolines from bonus block no longer hurt Tux

### DIFF
--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -317,7 +317,7 @@ BonusBlock::try_open(Player* player)
 
     case Content::CUSTOM:
     {
-      Sector::get().add<SpecialRiser>(get_pos(), std::move(m_object));
+      Sector::get().add<SpecialRiser>(get_pos(), std::move(m_object), true);
       play_upgrade_sound = true;
       break;
     }
@@ -336,7 +336,7 @@ BonusBlock::try_open(Player* player)
     }
     case Content::TRAMPOLINE:
     {
-      Sector::get().add<SpecialRiser>(get_pos(), std::make_unique<Trampoline>(get_pos(), false));
+      Sector::get().add<SpecialRiser>(get_pos(), std::make_unique<Trampoline>(get_pos(), false), true);
       play_upgrade_sound = true;
       break;
     }


### PR DESCRIPTION
Fix to accidently reverted bug.
No need to close any issue, since everything is closed anyway.