### PR TITLE
Save debug menu's "Show Controller" option in config

### DIFF
--- a/src/supertux/debug.cpp
+++ b/src/supertux/debug.cpp
@@ -24,7 +24,6 @@ Debug g_debug;
 Debug::Debug() :
   show_collision_rects(false),
   show_worldmap_path(false),
-  show_controller(false),
   draw_redundant_frames(false),
   m_use_bitmap_fonts(false),
   m_game_speed_multiplier(1.0f)

--- a/src/supertux/debug.hpp
+++ b/src/supertux/debug.hpp
@@ -35,8 +35,6 @@ public:
   /** Draw the path on the worldmap, including invisible paths */
   bool show_worldmap_path;
 
-  bool show_controller;
-
   // Draw frames even when visually nothing changes; this can be used to
   // vaguely measure the impact of code changes which should increase the FPS
   bool draw_redundant_frames;

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -35,6 +35,7 @@ Config::Config() :
   try_vsync(true),
   show_fps(false),
   show_player_pos(false),
+  show_controller(false),
   sound_enabled(true),
   music_enabled(true),
   sound_volume(100),
@@ -71,6 +72,7 @@ Config::load()
   config_mapping.get("profile", profile);
   config_mapping.get("show_fps", show_fps);
   config_mapping.get("show_player_pos", show_player_pos);
+  config_mapping.get("show_controller", show_controller);
   config_mapping.get("developer", developer_mode);
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
@@ -176,6 +178,7 @@ Config::save()
   writer.write("profile", profile);
   writer.write("show_fps", show_fps);
   writer.write("show_player_pos", show_player_pos);
+  writer.write("show_controller", show_controller);
   writer.write("developer", developer_mode);
   writer.write("confirmation_dialog", confirmation_dialog);
   writer.write("pause_on_focusloss", pause_on_focusloss);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -59,6 +59,7 @@ public:
   bool try_vsync;
   bool show_fps;
   bool show_player_pos;
+  bool show_controller;
   bool sound_enabled;
   bool music_enabled;
   int sound_volume;

--- a/src/supertux/menu/debug_menu.cpp
+++ b/src/supertux/menu/debug_menu.cpp
@@ -62,7 +62,7 @@ DebugMenu::DebugMenu() :
 
   add_toggle(-1, _("Show Collision Rects"), &g_debug.show_collision_rects);
   add_toggle(-1, _("Show Worldmap Path"), &g_debug.show_worldmap_path);
-  add_toggle(-1, _("Show Controller"), &g_debug.show_controller);
+  add_toggle(-1, _("Show Controller"), &g_config->show_controller);
   add_toggle(-1, _("Show Framerate"), &g_config->show_fps);
   add_toggle(-1, _("Draw Redundant Frames"), &g_debug.draw_redundant_frames);
   add_toggle(-1, _("Show Player Position"), &g_config->show_player_pos);
@@ -78,6 +78,7 @@ DebugMenu::DebugMenu() :
 void
 DebugMenu::menu_action(MenuItem& item)
 {
+  g_config->save();
 }
 
 /* EOF */

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -257,7 +257,7 @@ ScreenManager::draw(Compositor& compositor, FPS_Stats& fps_statistics)
   if (g_config->show_fps)
     draw_fps(context, fps_statistics);
 
-  if (g_debug.show_controller) {
+  if (g_config->show_controller) {
     m_controller_hud->draw(context);
   }
 


### PR DESCRIPTION
This commit moves the show_controller variable from the
Debug class to the Config class and adds a call to g_config->save()
in DebugMenu's menu_action member function so that changes are
written to the config file.

This addresses issue #1289.