### PR TITLE
Fixed problem with narrow levels

### DIFF
--- a/src/object/vertical_stripes.cpp
+++ b/src/object/vertical_stripes.cpp
@@ -1,0 +1,69 @@
+//  SuperTux
+//  Copyright (C) 2020 Grzegorz Przybylski <zwatotem@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "object/vertical_stripes.hpp"
+
+#include "editor/editor.hpp"
+#include "math/rect.hpp"
+#include "math/rectf.hpp"
+#include "supertux/sector.hpp"
+#include "video/drawing_context.hpp"
+#include "video/surface.hpp"
+
+VerticalStripes::VerticalStripes() :
+  m_visible(false),
+  m_layer(LAYER_FOREGROUND1 + 10),
+  m_left_stripe(0,0,0,0),
+  m_right_stripe(0,0,0,0)
+{
+}
+
+VerticalStripes::~VerticalStripes()
+{
+}
+
+void
+VerticalStripes::update(float dt_sec)
+{
+  m_visible = !Editor::is_active();
+}
+
+void
+VerticalStripes::draw(DrawingContext& context)
+{
+  float screen_width = static_cast<float>(context.get_width());
+  float level_width = Sector::get().get_width();
+  if (m_visible && level_width < screen_width)
+  {
+    // Drawing two black stripes at each side of a screen
+    float screen_height = static_cast<float>(context.get_height());
+    float level_height = Sector::get().get_height();
+
+    Canvas& canvas = context.get_canvas(DrawingTarget::COLORMAP);
+
+    float screen_left = (level_width - screen_width) / 2;
+    float screen_right = level_width - screen_left;
+    // Level can still be scrolled vertically!
+    float rect_top = -screen_height;
+    float rect_bottom = level_height + screen_height;
+    Rectf left_stripe = Rectf(screen_left, rect_top, 0, rect_bottom);
+    Rectf right_stripe = Rectf(level_width, rect_top, screen_right, rect_bottom);
+    canvas.draw_filled_rect(left_stripe, Color(0,0,0), m_layer);
+    canvas.draw_filled_rect(right_stripe, Color(0,0,0), m_layer);
+  }
+}
+
+/* EOF */

--- a/src/object/vertical_stripes.hpp
+++ b/src/object/vertical_stripes.hpp
@@ -1,0 +1,49 @@
+//  SuperTux
+//  Copyright (C) 2020 Grzegorz Przybylski <zwatotem@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_OBJECT_VERTICAL_STRIPES_HPP
+#define HEADER_SUPERTUX_OBJECT_VERTICAL_STRIPES_HPP
+
+#include "math/rect.hpp"
+#include "math/rectf.hpp"
+
+#include "supertux/game_object.hpp"
+
+class VerticalStripes final : public GameObject
+{
+public:
+	VerticalStripes();
+	virtual ~VerticalStripes();
+
+  virtual bool is_singleton() const { return true; }
+  virtual bool is_saveable() const { return false; }
+  virtual void update(float dt_sec) override;
+ 	virtual void draw(DrawingContext& context) override;
+
+private:
+  bool m_visible;
+  int m_layer;
+  Rectf m_left_stripe;
+  Rectf m_right_stripe;
+
+private:
+  VerticalStripes(const VerticalStripes&) = delete;
+  VerticalStripes& operator=(const VerticalStripes&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/object/vertical_stripes.hpp
+++ b/src/object/vertical_stripes.hpp
@@ -28,8 +28,8 @@ public:
 	VerticalStripes();
 	virtual ~VerticalStripes();
 
-  virtual bool is_singleton() const { return true; }
-  virtual bool is_saveable() const { return false; }
+  virtual bool is_singleton() const override { return true; }
+  virtual bool is_saveable() const override { return false; }
   virtual void update(float dt_sec) override;
  	virtual void draw(DrawingContext& context) override;
 

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -41,6 +41,7 @@
 #include "object/text_array_object.hpp"
 #include "object/text_object.hpp"
 #include "object/tilemap.hpp"
+#include "object/vertical_stripes.hpp"
 #include "physfs/ifile_stream.hpp"
 #include "scripting/sector.hpp"
 #include "squirrel/squirrel_environment.hpp"
@@ -139,6 +140,10 @@ Sector::finish_construction(bool editable)
 
   if (!get_object_by_type<MusicObject>()) {
     add<MusicObject>();
+  }
+
+  if (!get_object_by_type<VerticalStripes>()) {
+    add<VerticalStripes>();
   }
 
   flush_game_objects();


### PR DESCRIPTION
Levels narrower than display used to be displayed on whole screen. 
Now The part out of level limits is a black stripe.
Fixes #1270