### PR TITLE
Fix Haiku build

### DIFF
--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -242,6 +242,7 @@ public:
   #pragma GCC diagnostic pop
 #endif
 
+#ifndef __HAIKU__
 #ifdef _WIN32
 	std::string olduserdir = FileSystem::join(physfs_userdir, PACKAGE_NAME);
 #else
@@ -282,6 +283,7 @@ public:
 	    log_info << "Moved old config dir " << olduserdir << " to " << userdir << std::endl;
 	  }
 	}
+#endif
 
     if (!FileSystem::is_directory(userdir))
     {


### PR DESCRIPTION
`PACKAGE_NAME` isn't defined for some reason on Haiku, so `olduserdir` resolves to `~/.`. Yikes! I just disabled the entire thing because I don't think the old config directory was ever on Haiku, anyway. I've only tested this on Haiku, as it's a pretty minor change.