### PR TITLE
Do not crash if the player takes a screenshot while the screenshot folder is readonly

### DIFF
--- a/src/video/sdl_surface.cpp
+++ b/src/video/sdl_surface.cpp
@@ -96,7 +96,15 @@ SDLSurface::save_png(const SDL_Surface& surface, const std::string& filename)
   // This does not lead to a double free when 'tmp == screen', as
   // SDL_PNGFormatAlpha() will increase the refcount of surface.
   SDLSurfacePtr tmp(SDL_PNGFormatAlpha(const_cast<SDL_Surface*>(&surface)));
-  int ret = SDL_SavePNG_RW(tmp.get(), get_writable_physfs_SDLRWops(filename), 1);
+  SDL_RWops* ops;
+  try {
+    ops = get_writable_physfs_SDLRWops(filename);
+  } catch (std::exception& e) {
+    log_warning << "Could not get SDLRWops for " << filename << ": " <<
+      e.what() << std::endl;
+    return false;
+  }
+  int ret = SDL_SavePNG_RW(tmp.get(), ops, 1);
   if (ret < 0)
   {
     log_warning << "Saving " << filename << " failed: " << SDL_GetError() << std::endl;


### PR DESCRIPTION
If I press <kbd>Print</kbd>, a screenshot already appears in my home directory, so I've taken the permission to write a screenshot from SuperTux:
`chmod -R -w ~/.local/share/supertux2/screenshots`
I think that an error message instead of a crash should appear if a screenshot cannot be saved.