### PR TITLE
Allow setting the layer (z-pos) of candles, torches & spotlights

### DIFF
--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -36,6 +36,7 @@ Candle::Candle(const ReaderMapping& mapping) :
   mapping.get("flicker", flicker, true);
   std::vector<float> vColor;
   if (!mapping.get("color", vColor)) vColor = {1.0f, 1.0f, 1.0f};
+  mapping.get("layer", m_layer, 0);
 
   //change the light color if defined
   if (vColor.size() >= 3) {
@@ -74,8 +75,9 @@ Candle::get_settings()
   result.add_bool(_("Burning"), &burning, "burning", true);
   result.add_bool(_("Flicker"), &flicker, "flicker", true);
   result.add_color(_("Color"), &lightcolor, "color", Color::WHITE);
+  result.add_int(_("Layer"), &m_layer, "layer", 0);
 
-  result.reorder({"burning", "flicker", "name", "sprite", "color", "x", "y"});
+  result.reorder({"burning", "flicker", "name", "sprite", "color", "layer", "x", "y"});
 
   return result;
 }
@@ -92,10 +94,10 @@ Candle::draw(DrawingContext& context)
     // draw approx. 1 in 10 frames darker. Makes the candle flicker
     if (gameRandom.rand(10) != 0 || !flicker) {
       //context.color().draw_surface(candle_light_1, pos, layer);
-      candle_light_1->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+      candle_light_1->draw(context.light(), m_col.m_bbox.get_middle(), m_layer);
     } else {
       //context.color().draw_surface(candle_light_2, pos, layer);
-      candle_light_2->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+      candle_light_2->draw(context.light(), m_col.m_bbox.get_middle(), m_layer);
     }
   }
 }

--- a/src/object/spotlight.cpp
+++ b/src/object/spotlight.cpp
@@ -29,7 +29,8 @@ Spotlight::Spotlight(const ReaderMapping& mapping) :
   lightcone(SpriteManager::current()->create("images/objects/spotlight/lightcone.sprite")),
   color(1.0f, 1.0f, 1.0f),
   speed(50.0f),
-  counter_clockwise()
+  counter_clockwise(),
+  m_layer(0)
 {
   m_col.m_group = COLGROUP_DISABLED;
 

--- a/src/object/spotlight.cpp
+++ b/src/object/spotlight.cpp
@@ -45,6 +45,8 @@ Spotlight::Spotlight(const ReaderMapping& mapping) :
   if ( mapping.get( "color", vColor ) ){
     color = Color( vColor );
   }
+
+  mapping.get("layer", m_layer, 0);
 }
 
 Spotlight::~Spotlight()
@@ -60,8 +62,9 @@ Spotlight::get_settings()
   result.add_color(_("Color"), &color, "color", Color::WHITE);
   result.add_float(_("Speed"), &speed, "speed", 50.0f);
   result.add_bool(_("Counter-clockwise"), &counter_clockwise, "counter-clockwise", false);
+  result.add_int(_("Layer"), &m_layer, "layer", 0);
 
-  result.reorder({"angle", "color", "x", "y"});
+  result.reorder({"angle", "color", "layer", "x", "y"});
 
   return result;
 }
@@ -85,18 +88,18 @@ Spotlight::draw(DrawingContext& context)
   light->set_color(color);
   light->set_blend(Blend::ADD);
   light->set_angle(angle);
-  light->draw(context.light(), m_col.m_bbox.p1(), 0);
+  light->draw(context.light(), m_col.m_bbox.p1(), m_layer);
 
   //lightcone->set_angle(angle);
-  //lightcone->draw(context.color(), position, 0);
+  //lightcone->draw(context.color(), position, m_layer);
 
   lights->set_angle(angle);
-  lights->draw(context.color(), m_col.m_bbox.p1(), 0);
+  lights->draw(context.color(), m_col.m_bbox.p1(), m_layer);
 
   base->set_angle(angle);
-  base->draw(context.color(), m_col.m_bbox.p1(), 0);
+  base->draw(context.color(), m_col.m_bbox.p1(), m_layer);
 
-  center->draw(context.color(), m_col.m_bbox.p1(), 0);
+  center->draw(context.color(), m_col.m_bbox.p1(), m_layer);
 
   lightcone->set_angle(angle);
   lightcone->draw(context.color(), m_col.m_bbox.p1(), LAYER_FOREGROUND1 + 10);

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -55,6 +55,9 @@ private:
   /** If true, the spotlight will rotate counter-clockwise */
   bool counter_clockwise;
 
+  /** The layer (z-pos) of the spotlight. */
+  int m_layer;
+
 private:
   Spotlight(const Spotlight&) = delete;
   Spotlight& operator=(const Spotlight&) = delete;

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -37,6 +37,7 @@ Torch::Torch(const ReaderMapping& reader) :
 
   reader.get("sprite", sprite_name);
   reader.get("burning", m_burning, true);
+  reader.get("layer", m_layer, 0);
 
   m_torch = SpriteManager::current()->create(sprite_name);
   m_col.m_bbox.set_size(static_cast<float>(m_torch->get_width()),
@@ -51,16 +52,16 @@ Torch::draw(DrawingContext& context)
 {
   if (m_burning)
   {
-    m_flame->draw(context.color(), get_pos(), LAYER_TILES - 1);
+    m_flame->draw(context.color(), get_pos(), m_layer - 1);
 
-    m_flame_light->draw(context.light(), get_pos(), 0);
+    m_flame_light->draw(context.light(), get_pos(), m_layer);
   }
 
-  m_torch->draw(context.color(), get_pos(), LAYER_TILES - 1);
+  m_torch->draw(context.color(), get_pos(), m_layer - 1);
 
   if (m_burning)
   {
-    m_flame_glow->draw(context.color(), get_pos(), LAYER_TILES - 1);
+    m_flame_glow->draw(context.color(), get_pos(), m_layer - 1);
   }
 }
 
@@ -87,8 +88,9 @@ Torch::get_settings()
 
   result.add_bool(_("Burning"), &m_burning, "burning", true);
   result.add_sprite(_("Sprite"), &sprite_name, "sprite", std::string("images/objects/torch/torch1.sprite"));
+  result.add_int(_("Layer"), &m_layer, "layer", 0);
 
-  result.reorder({"sprite", "x", "y"});
+  result.reorder({"sprite", "layer", "x", "y"});
 
   return result;
 }

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -30,7 +30,8 @@ Torch::Torch(const ReaderMapping& reader) :
   m_flame_glow(SpriteManager::current()->create("images/objects/torch/flame_glow.sprite")),
   m_flame_light(SpriteManager::current()->create("images/objects/torch/flame_light.sprite")),
   m_burning(true),
-  sprite_name("images/objects/torch/torch1.sprite")
+  sprite_name("images/objects/torch/torch1.sprite"),
+  m_layer(0)
 {
   reader.get("x", m_col.m_bbox.get_left());
   reader.get("y", m_col.m_bbox.get_top());

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -57,6 +57,7 @@ private:
   SpritePtr m_flame_light;
   bool m_burning;
   std::string sprite_name;
+  int m_layer; /**< The layer (z-pos) of the torch */
 
 private:
   Torch(const Torch&) = delete;


### PR DESCRIPTION
Fixes #1011. You can set the layer of candles, torches and spotlight in the level editor now. Demo below (zipped .ogv, since the .gif was too large):

[set-torch-layer-demo.zip](https://github.com/SuperTux/supertux/files/4308191/set-torch-layer-demo.zip)

Here the torch initially has layer 0, so it is behind the foreground tiles (which have layer 100). Once I change the layer of the torch to 150, it is drawn in front of the foreground tiles. The same can be done for candles and spotlights.

I made the default value for layer in these objects 0, to keep in line with existing behaviour.

Please check also my code for the torch - certain parts were drawn on `LAYER_TILES - 1`, which I changed to `m_layer - 1`. `LAYER_TILES` is defined to 0 in video/layer.hpp, so with the default value of 0 for `m_layer`, existing behaviour should be unaffected.
