### PR TITLE
Fix issue with breaking out of script sequences

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -316,7 +316,7 @@ GameSession::update(float dt_sec, const Controller& controller)
   {
     if (!MenuManager::instance().is_active())
     {
-      m_game_pause = true;
+      toggle_pause();
       MenuManager::instance().set_menu(MenuStorage::CHEAT_MENU);
     }
   }
@@ -325,7 +325,7 @@ GameSession::update(float dt_sec, const Controller& controller)
   {
     if (!MenuManager::instance().is_active())
     {
-      m_game_pause = true;
+      toggle_pause();
       MenuManager::instance().set_menu(MenuStorage::DEBUG_MENU);
     }
   }


### PR DESCRIPTION
Fixes #1023. This prevents breaking out of scripted sequences using the cheat or debug menus. The menus will pause the game (stop the virtual machine) similar to the normal pause menu.

Demo attached below (zipped .ogv):

[menu-demo.zip](https://github.com/SuperTux/supertux/files/4314032/menu-demo.zip)

Note that Tux and everything else is stopped while the menus are active. In the video in the bug report they are still "moving in place".