### PR TITLE
Cache players in GameObjectManager

### DIFF
--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -177,10 +177,9 @@ GameObjectManager::flush_game_objects()
 
   { // update solid_tilemaps list
     m_solid_tilemaps.clear();
-    for (const auto& obj : m_gameobjects)
+    for (auto tilemap : get_objects_by_type_index(typeid(TileMap)))
     {
-      const auto& tm = dynamic_cast<TileMap*>(obj.get());
-      if (!tm) continue;
+      TileMap* tm = static_cast<TileMap*>(tilemap);
       if (tm->is_solid()) m_solid_tilemaps.push_back(tm);
     }
   }

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -212,7 +212,8 @@ Sector::activate(const Vector& player_pos)
 
   // two-player hack: move other players to main player's position
   // Maybe specify 2 spawnpoints in the level?
-  for (auto& player : get_objects_by_type<Player>()) {
+  for (auto player_ptr : get_objects_by_type_index(typeid(Player))) {
+    Player& player = *static_cast<Player*>(player_ptr);
     // spawn smalltux below spawnpoint
     if (!player.is_big()) {
       player.move(player_pos + Vector(0,32));
@@ -427,7 +428,8 @@ Sector::free_line_of_sight(const Vector& line_start, const Vector& line_end, con
 bool
 Sector::can_see_player(const Vector& eye) const
 {
-  for (const auto& player : get_objects_by_type<Player>()) {
+  for (auto player_ptr : get_objects_by_type_index(typeid(Player))) {
+    Player& player = *static_cast<Player*>(player_ptr);
     // test for free line of sight to any of all four corners and the middle of the player's bounding box
     if (free_line_of_sight(eye, player.get_bbox().p1(), &player)) return true;
     if (free_line_of_sight(eye, Vector(player.get_bbox().get_right(), player.get_bbox().get_top()), &player)) return true;
@@ -525,8 +527,9 @@ Sector::get_nearest_player (const Vector& pos) const
   Player *nearest_player = nullptr;
   float nearest_dist = std::numeric_limits<float>::max();
 
-  for (auto& player : get_objects_by_type<Player>())
+  for (auto player_ptr : get_objects_by_type_index(typeid(Player)))
   {
+    Player& player = *static_cast<Player*>(player_ptr);
     if (player.is_dying() || player.is_dead())
       continue;
 
@@ -685,7 +688,7 @@ Sector::get_camera() const
 Player&
 Sector::get_player() const
 {
-  return get_singleton_by_type<Player>();
+  return *static_cast<Player*>(get_objects_by_type_index(typeid(Player)).at(0));
 }
 
 DisplayEffect&


### PR DESCRIPTION
`get_nearest_player` was spending a lot of time searching for Player objects, so this PR adds a list for players, similar to the solid_tilemaps list.

For me, this increases performance on "A Fork in the Road" from 40fps to 60fps.