### PR TITLE
WIP: Maybe fix physfs path

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -140,7 +140,8 @@ AddonManager::AddonManager(const std::string& addon_directory,
   m_installed_addons(),
   m_repository_addons(),
   m_has_been_updated(false),
-  m_transfer_status()
+  m_transfer_status(),
+  m_enabled_addon_paths()
 {
   if (!PHYSFS_mkdir(m_addon_directory.c_str()))
   {
@@ -433,6 +434,7 @@ AddonManager::enable_addon(const AddonId& addon_id)
   else
   {
     log_debug << "Adding archive \"" << addon.get_install_filename() << "\" to search path" << std::endl;
+    m_enabled_addon_paths[addon_id] = addon.get_install_filename();
     //int PHYSFS_mount(addon.installed_install_filename.c_str(), "addons/", 0)
 
     // std::string mountpoint;
@@ -472,6 +474,7 @@ AddonManager::disable_addon(const AddonId& addon_id)
   }
   else
   {
+    m_enabled_addon_paths[addon_id] = nullptr;
     // log_debug << "Removing archive \"" << addon.get_install_filename() << "\" from search path" << std::endl;
     // if (PHYSFS_unmount(addon.get_install_filename().c_str()) == 0)
     // {

--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -474,7 +474,7 @@ AddonManager::disable_addon(const AddonId& addon_id)
   }
   else
   {
-    m_enabled_addon_paths[addon_id] = nullptr;
+    m_enabled_addon_paths.erase(addon_id);
     // log_debug << "Removing archive \"" << addon.get_install_filename() << "\" from search path" << std::endl;
     // if (PHYSFS_unmount(addon.get_install_filename().c_str()) == 0)
     // {

--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -435,29 +435,29 @@ AddonManager::enable_addon(const AddonId& addon_id)
     log_debug << "Adding archive \"" << addon.get_install_filename() << "\" to search path" << std::endl;
     //int PHYSFS_mount(addon.installed_install_filename.c_str(), "addons/", 0)
 
-    std::string mountpoint;
-    switch (addon.get_format()) {
-      case Addon::ORIGINAL:
-        mountpoint = "";
-        break;
-      default:
-        mountpoint = "custom/" + addon_id;
-        break;
-    }
+    // std::string mountpoint;
+    // switch (addon.get_format()) {
+    //   case Addon::ORIGINAL:
+    //     mountpoint = "";
+    //     break;
+    //   default:
+    //     mountpoint = "custom/" + addon_id;
+    //     break;
+    // }
 
-    if (PHYSFS_mount(addon.get_install_filename().c_str(), mountpoint.c_str(), 0) == 0)
-    {
-      log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
-                  << PHYSFS_getLastErrorCode() << std::endl;
-    }
-    else
-    {
+    // if (PHYSFS_mount(addon.get_install_filename().c_str(), mountpoint.c_str(), 0) == 0)
+    // {
+    //   log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
+    //               << PHYSFS_getLastErrorCode() << std::endl;
+    // }
+    // else
+    // {
       if (addon.get_type() == Addon::LANGUAGEPACK)
       {
         PHYSFS_enumerate(addon.get_id().c_str(), add_to_dictionary_path, nullptr);
       }
       addon.set_enabled(true);
-    }
+    // }
   }
 }
 
@@ -472,20 +472,20 @@ AddonManager::disable_addon(const AddonId& addon_id)
   }
   else
   {
-    log_debug << "Removing archive \"" << addon.get_install_filename() << "\" from search path" << std::endl;
-    if (PHYSFS_unmount(addon.get_install_filename().c_str()) == 0)
-    {
-      log_warning << "Could not remove " << addon.get_install_filename() << " from search path: "
-                  << PHYSFS_getLastErrorCode() << std::endl;
-    }
-    else
-    {
+    // log_debug << "Removing archive \"" << addon.get_install_filename() << "\" from search path" << std::endl;
+    // if (PHYSFS_unmount(addon.get_install_filename().c_str()) == 0)
+    // {
+    //   log_warning << "Could not remove " << addon.get_install_filename() << " from search path: "
+    //               << PHYSFS_getLastErrorCode() << std::endl;
+    // }
+    // else
+    // {
       if (addon.get_type() == Addon::LANGUAGEPACK)
       {
         PHYSFS_enumerate(addon.get_id().c_str(), remove_from_dictionary_path, nullptr);
       }
       addon.set_enabled(false);
-    }
+    // }
   }
 }
 

--- a/src/addon/addon_manager.hpp
+++ b/src/addon/addon_manager.hpp
@@ -50,6 +50,8 @@ private:
 
   TransferStatusPtr m_transfer_status;
 
+  std::map<std::string, std::string> m_enabled_addon_paths; 
+
 public:
   AddonManager(const std::string& addon_directory,
                std::vector<Config::Addon>& addon_config);
@@ -62,6 +64,10 @@ public:
 
   std::vector<AddonId> get_repository_addons() const;
   std::vector<AddonId> get_installed_addons() const;
+  std::map<std::string, std::string> get_enabled_addon_paths() const
+  {
+    return m_enabled_addon_paths;
+  }
 
   Addon& get_repository_addon(const AddonId& addon) const;
   Addon& get_installed_addon(const AddonId& addon) const;

--- a/src/squirrel/squirrel_vm.cpp
+++ b/src/squirrel/squirrel_vm.cpp
@@ -278,6 +278,7 @@ SquirrelVM::rename_table_entry(const char* oldname, const char* newname)
 std::vector<std::string>
 SquirrelVM::get_table_keys()
 {
+  auto old_top = sq_gettop(m_vm);
   std::vector<std::string> keys;
 
   sq_pushnull(m_vm);
@@ -297,6 +298,8 @@ SquirrelVM::get_table_keys()
     // pops key and val before the next iteration
     sq_pop(m_vm, 2);
   }
+
+  sq_settop(m_vm, old_top);
 
   return keys;
 }

--- a/src/supertux/levelset.cpp
+++ b/src/supertux/levelset.cpp
@@ -58,7 +58,6 @@ Levelset::walk_directory(const std::string& directory, bool recursively)
   for (const char* const* filename = files; *filename != nullptr; ++filename)
   {
     auto filepath = FileSystem::join(directory.c_str(), *filename);
-    log_warning << "Looking in filepath " << filepath << std::endl;
     if (physfsutil::is_directory(filepath) && recursively)
     {
       walk_directory(filepath, true);

--- a/src/supertux/levelset.cpp
+++ b/src/supertux/levelset.cpp
@@ -58,6 +58,7 @@ Levelset::walk_directory(const std::string& directory, bool recursively)
   for (const char* const* filename = files; *filename != nullptr; ++filename)
   {
     auto filepath = FileSystem::join(directory.c_str(), *filename);
+    log_warning << "Looking in filepath " << filepath << std::endl;
     if (physfsutil::is_directory(filepath) && recursively)
     {
       walk_directory(filepath, true);

--- a/src/supertux/savegame.cpp
+++ b/src/supertux/savegame.cpp
@@ -64,6 +64,20 @@ std::vector<LevelState> get_level_states(SquirrelVM& vm)
     sq_pop(vm.get_vm(), 2);
   }
 
+  if(SQ_FAILED(sq_next(vm.get_vm(), -2)))
+  {
+    sq_getlasterror(vm.get_vm());
+    auto type = sq_gettype(vm.get_vm(), -1);
+    log_warning << "Type of error: " << type << std::endl;
+    if(type == OT_STRING)
+    {
+      const char* lasterr;
+      sq_getstring(vm.get_vm(), -1, &lasterr);
+      log_warning << lasterr << std::endl;
+    }
+    sq_pop(vm.get_vm(), 1);
+  }
+
   return results;
 }
 
@@ -341,9 +355,16 @@ Savegame::get_worldmap_state(const std::string& name)
         vm.rename_table_entry(old_map_filename.c_str(), name.c_str());
       }
     }
+    for(const auto& key : vm.get_table_keys())
+      log_warning << key << std::endl;
 
     vm.get_or_create_table_entry(name);
+    for(const auto& key : vm.get_table_keys())
+      log_warning << key << std::endl;
+
     vm.get_or_create_table_entry("levels");
+    for(const auto& key : vm.get_table_keys())
+      log_warning << key << std::endl;
 
     result.level_states = get_level_states(vm);
   }

--- a/src/supertux/savegame.cpp
+++ b/src/supertux/savegame.cpp
@@ -355,10 +355,11 @@ Savegame::get_worldmap_state(const std::string& name)
         vm.rename_table_entry(old_map_filename.c_str(), name.c_str());
       }
     }
+    
     for(const auto& key : vm.get_table_keys())
       log_warning << key << std::endl;
 
-    vm.get_or_create_table_entry(name);
+    vm.get_or_create_table_entry("/" + name);
     for(const auto& key : vm.get_table_keys())
       log_warning << key << std::endl;
 

--- a/src/supertux/savegame.cpp
+++ b/src/supertux/savegame.cpp
@@ -64,20 +64,6 @@ std::vector<LevelState> get_level_states(SquirrelVM& vm)
     sq_pop(vm.get_vm(), 2);
   }
 
-  if(SQ_FAILED(sq_next(vm.get_vm(), -2)))
-  {
-    sq_getlasterror(vm.get_vm());
-    auto type = sq_gettype(vm.get_vm(), -1);
-    log_warning << "Type of error: " << type << std::endl;
-    if(type == OT_STRING)
-    {
-      const char* lasterr;
-      sq_getstring(vm.get_vm(), -1, &lasterr);
-      log_warning << lasterr << std::endl;
-    }
-    sq_pop(vm.get_vm(), 1);
-  }
-
   return results;
 }
 
@@ -355,18 +341,9 @@ Savegame::get_worldmap_state(const std::string& name)
         vm.rename_table_entry(old_map_filename.c_str(), name.c_str());
       }
     }
-    
-    for(const auto& key : vm.get_table_keys())
-      log_warning << key << std::endl;
 
     vm.get_or_create_table_entry("/" + name);
-    for(const auto& key : vm.get_table_keys())
-      log_warning << key << std::endl;
-
     vm.get_or_create_table_entry("levels");
-    for(const auto& key : vm.get_table_keys())
-      log_warning << key << std::endl;
-
     result.level_states = get_level_states(vm);
   }
   catch(const std::exception& err)

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -37,11 +37,6 @@ World::from_directory(const std::string& directory)
 
   try
   {
-    if(PHYSFS_mount(directory.c_str(), "", 0) == 0)
-    {
-      log_warning << "Failed to add add-on directory to PHYSFS search path" << std::endl;
-    }
-
     register_translation_directory(info_filename);
     auto doc = ReaderDocument::from_file(info_filename);
     auto root = doc.get_root();
@@ -115,18 +110,10 @@ World::World(const std::string& directory) :
   m_basedir(directory),
   m_hide_from_contribs(false)
 {
-  if(PHYSFS_mount(m_basedir.c_str(), "", 0) == 0)
-  {
-    log_warning << "Failed to add add-on directory to PHYSFS search path" << std::endl;
-  }
 }
 
 World::~World()
 {
-  if (PHYSFS_unmount(m_basedir.c_str()) == 0)
-  {
-    log_warning << "Failed to remove add-on directory from PHYSFS search path" << std::endl;
-  }
 }
 
 void

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -37,6 +37,11 @@ World::from_directory(const std::string& directory)
 
   try
   {
+    if(PHYSFS_mount(directory.c_str(), "", 0) == 0)
+    {
+      log_warning << "Failed to add add-on directory to PHYSFS search path" << std::endl;
+    }
+
     register_translation_directory(info_filename);
     auto doc = ReaderDocument::from_file(info_filename);
     auto root = doc.get_root();
@@ -95,6 +100,11 @@ World::create(const std::string& title, const std::string& desc)
   world->m_title = title;
   world->m_description = desc;
 
+  if(PHYSFS_mount(dirname.c_str(), "", 0) == 0)
+  {
+    log_warning << "Failed to add add-on directory to PHYSFS search path" << std::endl;
+  }
+
   return world;
 }
 
@@ -105,6 +115,18 @@ World::World(const std::string& directory) :
   m_basedir(directory),
   m_hide_from_contribs(false)
 {
+  if(PHYSFS_mount(m_basedir.c_str(), "", 0) == 0)
+  {
+    log_warning << "Failed to add add-on directory to PHYSFS search path" << std::endl;
+  }
+}
+
+World::~World()
+{
+  if (PHYSFS_unmount(m_basedir.c_str()) == 0)
+  {
+    log_warning << "Failed to remove add-on directory from PHYSFS search path" << std::endl;
+  }
 }
 
 void

--- a/src/supertux/world.hpp
+++ b/src/supertux/world.hpp
@@ -32,6 +32,9 @@ private:
   World(const std::string& directory);
 
 public:
+  ~World();
+
+public:
   std::string get_basedir() const { return m_basedir; }
   std::string get_title() const { return m_title; }
 


### PR DESCRIPTION
Okay, so obviously this does not work...Or maybe not so obviously...

I tried adding the physfs paths of add-ons to a list...
And I'm basically, then mounting them when the list of contrib levels get loaded...So far so good...

The only problem is that the loading of the completed levels from the physfs shares does not seem to be working...as all the contrib levels are marked as new...So, squirrel does not load the state table properly. Why? The hell do I know...

If someone who knows about these things could take a look, that would be much appreciated.