### PR TITLE
Improve text wrapping for languages with no space characters

### DIFF
--- a/src/video/ttf_font.cpp
+++ b/src/video/ttf_font.cpp
@@ -152,7 +152,30 @@ TTFFont::wrap_to_width(const std::string& text, float width, std::string* overfl
     }
   }
 
-  // FIXME: hard-wrap at width, taking care of multibyte characters
+  // hard-wrap at width, taking care of multibyte characters
+  unsigned int char_bytes = 1;
+  for (int i = 0; i < static_cast<int>(s.length()); i += char_bytes) {
+
+    // calculate the number of bytes in the character
+    char_bytes = 1;
+    auto iter = s.begin() + i + 1; // iter points to next byte
+    while ( iter != s.end() && (*iter & 128) && !(*iter & 64) ) {
+      // this is a "continuation" byte in the form 10xxxxxx
+      ++iter;
+      ++char_bytes;
+    }
+
+    // check whether text now goes over allowed width, and if so
+    // return everything up to the character and put the rest in the overflow
+    std::string s2 = s.substr(0,i+char_bytes);
+    if (get_text_width(s2) > width) {
+      if (i == 0) i += char_bytes; // edge case when even one char is too wide
+      if (overflow) *overflow = s.substr(i);
+      return s.substr(0, i);
+    }
+  }
+
+  // should in theory never reach here
   if (overflow) *overflow = "";
   return s;
 }


### PR DESCRIPTION
Fixes #1028. Text from Info Boxes now hard-wraps to allowed width if there are no spaces between words. Tested with both Japanese and Traditional Chinese (I don't speak either language, but the wrapping seems OK.)

Example screenshot below using Japanese, before fix:

![screenshot-before-fix](https://user-images.githubusercontent.com/24422213/78270473-5d8fae00-7567-11ea-92b1-28fb8ccff206.png)

After fix:

![screenshot-after-fix](https://user-images.githubusercontent.com/24422213/78270484-608a9e80-7567-11ea-8d71-301760261af0.png)

Video demo also (zipped):

[wrap-demo-video.zip](https://github.com/SuperTux/supertux/files/4422141/wrap-demo-video.zip)

