### PR TITLE
Avoid scrolling main area of editor and toolbox at same time

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -635,8 +635,9 @@ Editor::event(const SDL_Event& ev)
       }
     }
 
-    // scroll with mouse wheel
-    if (ev.type == SDL_MOUSEWHEEL) {
+    // Scroll with mouse wheel, if the mouse is not over the toolbox.
+    // The toolbox does scrolling independently from the main area.
+    if (ev.type == SDL_MOUSEWHEEL && !m_toolbox_widget->has_mouse_focus()) {
       float scroll_x = static_cast<float>(ev.wheel.x * -32);
       float scroll_y = static_cast<float>(ev.wheel.y * -32);
       scroll({scroll_x, scroll_y});

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -56,7 +56,8 @@ EditorToolboxWidget::EditorToolboxWidget(Editor& editor) :
   m_starting_tile(0),
   m_dragging(false),
   m_drag_start(0, 0),
-  m_Xpos(512)
+  m_Xpos(512),
+  m_has_mouse_focus(false)
 {
   m_select_mode->push_mode("images/engine/editor/select-mode1.png");
   m_select_mode->push_mode("images/engine/editor/select-mode2.png");
@@ -389,8 +390,12 @@ EditorToolboxWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
   if (x < 0) {
     m_hovered_item = HoveredItem::NONE;
     m_tile_scrolling = TileScrolling::NONE;
+    m_has_mouse_focus = false;
     return false;
   }
+
+  // mouse is currently over the toolbox
+  m_has_mouse_focus = true;
 
   if (y < 0) {
     if (y < -64) {
@@ -565,6 +570,12 @@ EditorToolboxWidget::select_objectgroup(int id)
   m_input_type = EditorToolboxWidget::InputType::OBJECT;
   m_starting_tile = 0;
   update_mouse_icon();
+}
+
+bool
+EditorToolboxWidget::has_mouse_focus() const
+{
+  return m_has_mouse_focus;
 }
 
 /* EOF */

--- a/src/editor/toolbox_widget.hpp
+++ b/src/editor/toolbox_widget.hpp
@@ -78,6 +78,8 @@ public:
   std::string get_object() const { return m_object; }
   TileSelection* get_tiles() const { return m_tiles.get(); }
 
+  bool has_mouse_focus() const;
+
 private:
   Vector get_tile_coords(const int pos) const;
   int get_tile_pos(const Vector& coords) const;
@@ -121,6 +123,8 @@ private:
 
   int m_Xpos;
   const int m_Ypos = 96;
+
+  bool m_has_mouse_focus;
 
 private:
   EditorToolboxWidget(const EditorToolboxWidget&) = delete;


### PR DESCRIPTION
Fixes #1358. If the mouse is over the toolbox, the mouse wheel will scroll the toolbox only, not the main area of the editor. Demo below:

![scroll-fix-demo](https://user-images.githubusercontent.com/24422213/79060465-5b50f080-7cd9-11ea-9201-950d155f894b.gif)
