### PR TITLE
Update solid tilemaps in game manager after changes.

### DIFF
--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -30,6 +30,7 @@
 #include "video/drawing_context.hpp"
 #include "video/layer.hpp"
 #include "video/surface.hpp"
+#include "worldmap/worldmap.hpp"
 
 TileMap::TileMap(const TileSet *new_tileset) :
   ExposedObject<TileMap, scripting::TileMap>(this),
@@ -625,12 +626,20 @@ TileMap::move_by(const Vector& shift)
 void
 TileMap::update_effective_solid()
 {
+  bool old = m_effective_solid;
   if (!m_real_solid)
     m_effective_solid = false;
   else if (m_effective_solid && (m_current_alpha < 0.25f))
     m_effective_solid = false;
   else if (!m_effective_solid && (m_current_alpha >= 0.75f))
     m_effective_solid = true;
+  
+  if(Sector::current() != nullptr && old != m_effective_solid)  
+  {
+      Sector::get().update_solid(this);  
+  } else if(worldmap::WorldMap::current() != nullptr && old != m_effective_solid) {
+      worldmap::WorldMap::current()->update_solid(this);
+  }   
 }
 
 void

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -163,7 +163,7 @@ public:
   void set_tileset(const TileSet* new_tileset);
 
   const std::vector<uint32_t>& get_tiles() const { return m_tiles; }
-
+  
 private:
   void update_effective_solid();
   void float_channel(float target, float &current, float remaining_time, float dt_sec);

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -174,17 +174,30 @@ GameObjectManager::flush_game_objects()
       }
     }
   }
+  update_solids();
+}
 
-  { // update solid_tilemaps list
-    m_solid_tilemaps.clear();
-    for (auto tilemap : get_objects_by_type_index(typeid(TileMap)))
-    {
-      TileMap* tm = static_cast<TileMap*>(tilemap);
-      if (tm->is_solid()) m_solid_tilemaps.push_back(tm);
-    }
+void
+GameObjectManager::update_solids() 
+{
+  m_solid_tilemaps.clear();
+  for (auto tilemap : get_objects_by_type_index(typeid(TileMap)))
+  {
+    TileMap* tm = static_cast<TileMap*>(tilemap);
+    if (tm->is_solid()) m_solid_tilemaps.push_back(tm);
   }
 }
 
+void 
+GameObjectManager::update_solid(TileMap* tm) {
+  auto it = std::find(m_solid_tilemaps.begin(), m_solid_tilemaps.end(), tm);
+  bool found = it != m_solid_tilemaps.end();
+  if (tm->is_solid() && !found) {
+    m_solid_tilemaps.push_back(tm);
+  } else if(!tm->is_solid() && found) {
+    m_solid_tilemaps.erase(it);
+  }
+}
 void
 GameObjectManager::this_before_object_add(GameObject& object)
 {

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -177,6 +177,9 @@ public:
   }
 
   const std::vector<TileMap*>& get_solid_tilemaps() const { return m_solid_tilemaps; }
+  
+  void update_solids();
+  void update_solid(TileMap* solid);
 
 protected:
   void process_resolve_requests();


### PR DESCRIPTION
GameObjectManager is notifed, when solidity of tile maps change and the vector is fixed. 
It might be better to use a listener pattern (I didn't because it seemed like too much complexity for this small change).
Closes #1292