### PR TITLE
Add option for wind objects to affect badguys

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -915,13 +915,13 @@ void
 BadGuy::add_wind_velocity(const Vector& velocity, const Vector& end_speed)
 {
   // only add velocity in the same direction as the wind
-  if (end_speed.x > 0  &&  m_physic.get_velocity_x() < end_speed.x)
+  if (end_speed.x > 0 && m_physic.get_velocity_x() < end_speed.x)
     m_physic.set_velocity_x(std::min(m_physic.get_velocity_x() + velocity.x, end_speed.x));
-  if (end_speed.x < 0  &&  m_physic.get_velocity_x() > end_speed.x)
+  if (end_speed.x < 0 && m_physic.get_velocity_x() > end_speed.x)
     m_physic.set_velocity_x(std::max(m_physic.get_velocity_x() + velocity.x, end_speed.x));
-  if (end_speed.y > 0  &&  m_physic.get_velocity_y() < end_speed.y)
+  if (end_speed.y > 0 && m_physic.get_velocity_y() < end_speed.y)
     m_physic.set_velocity_y(std::min(m_physic.get_velocity_y() + velocity.y, end_speed.y));
-  if (end_speed.y < 0  &&  m_physic.get_velocity_y() > end_speed.y)
+  if (end_speed.y < 0 && m_physic.get_velocity_y() > end_speed.y)
     m_physic.set_velocity_y(std::max(m_physic.get_velocity_y() + velocity.y, end_speed.y));
 }
 

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -905,4 +905,24 @@ BadGuy::after_editor_set()
   }
 }
 
+bool
+BadGuy::can_be_affected_by_wind() const
+{
+  return !on_ground();
+}
+
+void
+BadGuy::add_wind_velocity(const Vector& velocity, const Vector& end_speed)
+{
+  // only add velocity in the same direction as the wind
+  if (end_speed.x > 0  &&  m_physic.get_velocity_x() < end_speed.x)
+    m_physic.set_velocity_x(std::min(m_physic.get_velocity_x() + velocity.x, end_speed.x));
+  if (end_speed.x < 0  &&  m_physic.get_velocity_x() > end_speed.x)
+    m_physic.set_velocity_x(std::max(m_physic.get_velocity_x() + velocity.x, end_speed.x));
+  if (end_speed.y > 0  &&  m_physic.get_velocity_y() < end_speed.y)
+    m_physic.set_velocity_y(std::min(m_physic.get_velocity_y() + velocity.y, end_speed.y));
+  if (end_speed.y < 0  &&  m_physic.get_velocity_y() > end_speed.y)
+    m_physic.set_velocity_y(std::max(m_physic.get_velocity_y() + velocity.y, end_speed.y));
+}
+
 /* EOF */

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -123,6 +123,12 @@ public:
   /** Returns the dispenser this badguys was spawned by */
   Dispenser* get_parent_dispenser() const { return m_parent_dispenser; }
 
+  /** Returns true if the badguy can currently be affected by wind */
+  virtual bool can_be_affected_by_wind() const;
+
+  /** Adds velocity from wind */
+  virtual void add_wind_velocity(const Vector& velocity, const Vector& end_speed);
+
 protected:
   enum State {
     STATE_INIT,

--- a/src/object/wind.cpp
+++ b/src/object/wind.cpp
@@ -49,7 +49,7 @@ Wind::Wind(const ReaderMapping& reader) :
 
   reader.get("acceleration", acceleration, 100.0f);
 
-  reader.get("affectsbadguys", affects_badguys, false);
+  reader.get("affects-badguys", affects_badguys, false);
 
   set_group(COLGROUP_TOUCHABLE);
 }
@@ -68,9 +68,9 @@ Wind::get_settings()
   result.add_float(_("Speed Y"), &speed.y, "speed-y");
   result.add_float(_("Acceleration"), &acceleration, "acceleration");
   result.add_bool(_("Blowing"), &blowing, "blowing", true);
-  result.add_bool(_("Affects Badguys"), &affects_badguys, "affectsbadguys", false);
+  result.add_bool(_("Affects Badguys"), &affects_badguys, "affects-badguys", false);
 
-  result.reorder({"blowing", "speed-x", "speed-y", "acceleration", "affectsbadguys", "region", "name", "x", "y"});
+  result.reorder({"blowing", "speed-x", "speed-y", "acceleration", "affects-badguys", "region", "name", "x", "y"});
 
   return result;
 }
@@ -115,7 +115,7 @@ Wind::collision(GameObject& other, const CollisionHit& )
   }
 
   auto badguy = dynamic_cast<BadGuy*> (&other);
-  if (badguy  &&  this->affects_badguys) {
+  if (badguy && this->affects_badguys) {
     if (badguy->can_be_affected_by_wind()) {
       badguy->add_wind_velocity(speed * acceleration * dt_sec, speed);
     }

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -60,6 +60,8 @@ private:
 
   float dt_sec; /**< stores last dt_sec gotten at update() */
 
+  bool affects_badguys; /**< whether the wind can affect badguys */
+
 private:
   Wind(const Wind&) = delete;
   Wind& operator=(const Wind&) = delete;


### PR DESCRIPTION
Fixes #982. This adds an option to Wind objects: "Affects Badguys". This is false (off) by default. Checking this option will make the wind affect badguys in a similar manner to Tux.

Demo below (zipped OGV file). This shows some cannon shots and bouncing snowballs being affected by an upward wind:

[wind-badguys-full-demo.zip](https://github.com/SuperTux/supertux/files/4488824/wind-badguys-full-demo.zip)