### PR TITLE
Enable the flip transform for decals

### DIFF
--- a/src/object/decal.cpp
+++ b/src/object/decal.cpp
@@ -22,7 +22,8 @@
 Decal::Decal(const ReaderMapping& reader) :
   MovingSprite(reader, "images/decal/explanations/billboard-bigtux.png", LAYER_OBJECTS, COLGROUP_DISABLED),
   default_action("default"),
-  solid()
+  solid(),
+  flip(NO_FLIP)
 {
   m_layer = reader_get_layer(reader, LAYER_OBJECTS);
 
@@ -50,5 +51,12 @@ Decal::get_settings()
 Decal::~Decal()
 {
 }
+
+void
+Decal::draw(DrawingContext& context)
+{
+  m_sprite->draw(context.color(), get_pos(), m_layer, flip);
+}
+
 
 /* EOF */

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -24,6 +24,8 @@ class ReaderMapping;
 /** A decorative image, perhaps part of the terrain */
 class Decal final : public MovingSprite
 {
+  friend class FlipLevelTransformer;
+
 public:
   Decal(const ReaderMapping& reader);
   virtual ~Decal();
@@ -35,9 +37,12 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
+  virtual void draw(DrawingContext& context) override;
+
 private:
   std::string default_action;
   bool solid;
+  Flip flip;
 
 private:
   Decal(const Decal&) = delete;

--- a/src/supertux/flip_level_transformer.cpp
+++ b/src/supertux/flip_level_transformer.cpp
@@ -19,6 +19,7 @@
 #include "badguy/badguy.hpp"
 #include "object/block.hpp"
 #include "object/camera.hpp"
+#include "object/decal.hpp"
 #include "object/flower.hpp"
 #include "object/platform.hpp"
 #include "object/player.hpp"
@@ -61,6 +62,10 @@ FlipLevelTransformer::transform_sector(Sector& sector)
     auto mobject = dynamic_cast<MovingObject*>(object.get());
     if (mobject) {
       transform_moving_object(height, *mobject);
+    }
+    auto decal = dynamic_cast<Decal*>(object.get());
+    if (decal) {
+      transform_decal(height, *decal);
     }
   }
 
@@ -114,6 +119,12 @@ FlipLevelTransformer::transform_badguy(float height, BadGuy& badguy)
   Vector pos = badguy.get_start_position();
   pos.y = height - pos.y;
   badguy.set_start_position(pos);
+}
+
+void
+FlipLevelTransformer::transform_decal(float height, Decal& decal)
+{
+  decal.flip = transform_flip(decal.flip);
 }
 
 void

--- a/src/supertux/flip_level_transformer.hpp
+++ b/src/supertux/flip_level_transformer.hpp
@@ -28,6 +28,7 @@ class Flower;
 class Platform;
 class Block;
 class Path;
+class Decal;
 
 /** Vertically or horizontally flip a level */
 class FlipLevelTransformer final : public LevelTransformer
@@ -45,6 +46,7 @@ private:
   void transform_flower(Flower& flower);
   void transform_platform(float height, Platform& platform);
   void transform_block(float height, Block& block);
+  void transform_decal(float height, Decal& decal);
 };
 
 #endif


### PR DESCRIPTION
Fixes #1355. Enables the Flip Level Transformer to flip decal objects.

Demo below. Note how the decal object (the tree) is flipped upside down and back up again with the rest of the sector:

![decal-flip-demo](https://user-images.githubusercontent.com/24422213/80142731-c4046b00-85ff-11ea-8a4f-2bf25ab19471.gif)

For this I used similar code to the `Flower` object.