### PR TITLE
Prevent infinite growling sound from Haywire

### DIFF
--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -141,6 +141,14 @@ Haywire::active_update(float dt_sec)
 }
 
 void
+Haywire::deactivate()
+{
+  // stop ticking/grunting sounds, in case we are deactivated before actually
+  // exploding (see https://github.com/SuperTux/supertux/issues/1260)
+  stop_looping_sounds();
+}
+
+void
 Haywire::kill_fall()
 {
   if (is_exploding) {

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -31,6 +31,7 @@ public:
   virtual void ignite() override;
 
   virtual void active_update(float dt_sec) override;
+  virtual void deactivate() override;
 
   virtual bool is_freezable() const override;
   virtual void freeze() override;


### PR DESCRIPTION
Fixes #1260. The growling sound from Haywire (the purple bomb) will be stopped when it goes off-screen and is deactivated before actually exploding.