### PR TITLE
Allow scrolling in credits screen with up/down keys

### DIFF
--- a/src/object/textscroller.hpp
+++ b/src/object/textscroller.hpp
@@ -43,12 +43,12 @@ public:
   virtual std::string get_class() const override { return "textscroller"; }
   virtual std::string get_display_name() const override { return _("TextScroller"); }
 
-  void set_speed(float speed);
+  void set_default_speed(float default_speed);
   void scroll(float offset);
   bool is_finished() const { return m_finished; }
   
 protected:
-  Controller controller;
+  const Controller* controller;
 
 private:
   void parse_file(const std::string& filename);
@@ -59,7 +59,7 @@ private:
   std::string m_filename;
   std::vector<std::unique_ptr<InfoBoxLine> > m_lines;
   float m_scroll;
-  float m_speed;
+  float m_default_speed;
   bool m_finished;
   bool m_fading;
 

--- a/src/supertux/textscroller_screen.cpp
+++ b/src/supertux/textscroller_screen.cpp
@@ -69,6 +69,8 @@ TextScrollerScreen::TextScrollerScreen(const std::string& filename) :
 
       text_mapping.get("speed", m_defaultspeed);
       text_mapping.get("music", m_music);
+
+      m_text_scroller->set_default_speed(m_defaultspeed);
     }
   } catch (std::exception& e) {
     std::ostringstream msg;
@@ -94,33 +96,7 @@ TextScrollerScreen::setup()
 void
 TextScrollerScreen::update(float dt_sec, const Controller& controller)
 {
-  if (controller.hold(Control::UP)) {
-    m_text_scroller->set_speed(-m_defaultspeed * 5);
-  } else if (controller.hold(Control::DOWN)) {
-    m_text_scroller->set_speed(m_defaultspeed * 5);
-  } else {
-    m_text_scroller->set_speed(m_defaultspeed);
-  }
-
-  if ((controller.pressed(Control::JUMP) ||
-       controller.pressed(Control::ACTION) ||
-       controller.pressed(Control::MENU_SELECT)) &&
-      !(controller.pressed(Control::UP))) { // prevent skipping if jump with up is enabled
-    m_text_scroller->scroll(SCROLL);
-  }
-
-  if (controller.pressed(Control::START) ||
-      controller.pressed(Control::ESCAPE)) {
-    ScreenManager::current()->pop_screen(std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, 0.5));
-  }
-
-  { // close when done
-    if (m_text_scroller->is_finished() && !m_fading)
-    {
-      m_fading = true;
-      ScreenManager::current()->pop_screen(std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, 0.5));
-    }
-  }
+  // NOTE: Keyboard input is handled by the TextScroller class.
 
   m_text_scroller->update(dt_sec);
 }


### PR DESCRIPTION
Fixes #1231. You can now scroll in the Credits screen using the up and down arrow keys. You can also skip ahead using the action or jump keys.

Demo below. Here I use the down, up action ("a" for my setup) and jump (space) keys:

![credits-scroll-demo](https://user-images.githubusercontent.com/24422213/82350304-48a3a700-9a4f-11ea-88b0-b3753c09f5a7.gif)
