### PR TITLE
Fix issue with live fire not fading after colliding with bomb

### DIFF
--- a/src/badguy/livefire.cpp
+++ b/src/badguy/livefire.cpp
@@ -134,6 +134,7 @@ LiveFire::kill_fall()
   m_lightsprite->set_blend(Blend::ADD);
   m_lightsprite->set_color(Color(1.0f, 0.9f, 0.8f));
   set_group(COLGROUP_DISABLED);
+  state = STATE_DEAD;
 
   // start dead-script
   run_dead_script();

--- a/src/badguy/livefire.hpp
+++ b/src/badguy/livefire.hpp
@@ -44,7 +44,8 @@ protected:
     STATE_SLEEPING,
     STATE_WAKING,
     STATE_WALKING,
-    STATE_DORMANT
+    STATE_DORMANT,
+    STATE_DEAD
   };
 
 protected:


### PR DESCRIPTION
Fixes #1403, at least partially. The walking fire will fade properly when Tux collides with it while carrying a bomb. Demo below:

Before:

![fire-bomb-fix-before](https://user-images.githubusercontent.com/24422213/82588280-a8848400-9bee-11ea-8287-7590f2350164.gif)

After:

![fire-bomb-fix-after](https://user-images.githubusercontent.com/24422213/82588288-ae7a6500-9bee-11ea-9300-98b80b9b866b.gif)

However, the fire still goes diagonally down while fading (into the ground), which looks awkward. But at least it fades.

The problem was in `LiveFire::active_update` line 63-66, if state was still `STATE_WALKING`, the sprite action would be set to regular walking (not fading) just after hitting the bomb. Since collision group is set to `COLGROUP_DISABLED`, it also would not interact with objects anymore. So an extra state is added `STATE_DEAD` to avoid this.