### PR TITLE
Override only configurable keys (partially fixes #1400)

### DIFF
--- a/src/control/keyboard_config.cpp
+++ b/src/control/keyboard_config.cpp
@@ -24,6 +24,7 @@
 
 KeyboardConfig::KeyboardConfig() :
   m_keymap(),
+  m_configurable_controls(),
   m_jump_with_up_kbd(false)
 {
   // initialize default keyboard map
@@ -47,6 +48,22 @@ KeyboardConfig::KeyboardConfig() :
   m_keymap[SDLK_F1]       = Control::CHEAT_MENU;
   m_keymap[SDLK_F2]       = Control::DEBUG_MENU;
   m_keymap[SDLK_BACKSPACE]= Control::REMOVE;
+
+  m_configurable_controls = {
+    Control::UP,
+    Control::DOWN,
+    Control::LEFT,
+    Control::RIGHT,
+    Control::JUMP,
+    Control::ACTION,
+    Control::PEEK_LEFT,
+    Control::PEEK_RIGHT,
+    Control::PEEK_UP,
+    Control::PEEK_DOWN,
+    Control::CONSOLE,
+    Control::CHEAT_MENU,
+    Control::DEBUG_MENU
+  };
 }
 
 void
@@ -77,7 +94,9 @@ KeyboardConfig::read(const ReaderMapping& keymap_mapping)
 
     const boost::optional<Control> maybe_control = Control_from_string(control_text);
     if (maybe_control) {
-      bind_key(static_cast<SDL_Keycode>(key), *maybe_control);
+      if (m_configurable_controls.count(*maybe_control)) {
+        bind_key(static_cast<SDL_Keycode>(key), *maybe_control);
+      }
     } else {
       log_warning << "Invalid control '" << control_text << "' in keymap" << std::endl;
     }

--- a/src/control/keyboard_config.hpp
+++ b/src/control/keyboard_config.hpp
@@ -19,6 +19,7 @@
 
 #include <SDL.h>
 #include <map>
+#include <set>
 
 #include "control/controller.hpp"
 
@@ -41,6 +42,7 @@ public:
 
 private:
   std::map<SDL_Keycode, Control> m_keymap;
+  std::set<Control> m_configurable_controls;
   bool m_jump_with_up_kbd;
 
 private:


### PR DESCRIPTION
See #1400 

Idea here is to introduce "configurable keys" because (unless there are some hacks in config file) it doesn't make sense to re-bind keys that can't be configured through GUI menu.

I'm not very familiar with the code base. I'm not sure if proposed resolution is proper one. I think it's a little bit fragile because it will be easy to introduce inconsistencies (e.g. adding more items to menu but forgetting about configurable keys set in keyboard config class).

Therefore please advise where this PR should go. And please let me know if re-binding keys that aren't present in the kbd menu should be allowed.