### PR TITLE
Add missing releases to appdata file

### DIFF
--- a/supertux2.appdata.xml
+++ b/supertux2.appdata.xml
@@ -43,6 +43,8 @@
     <binary>supertux2</binary>
   </provides>
   <releases>
+    <release version="0.6.2" date="2020-05-14" />
+    <release version="0.6.1.1" date="2019-12-19" />
     <release version="0.6.1" date="2019-12-15" />
     <release version="0.6.0" date="2018-12-23" />
     <release version="0.5.1" date="2016-11-05" />


### PR DESCRIPTION
This data is used by flatpak and because it was not updated for the previous releases, it lists the distributed version 0.6.2 as 0.6.1: https://flathub.org/apps/details/org.supertuxproject.SuperTux