### PR TITLE
Remove link between coins and checkpoints

### DIFF
--- a/src/supertux/player_status.cpp
+++ b/src/supertux/player_status.cpp
@@ -63,8 +63,7 @@ PlayerStatus::get_max_coins() const
 bool
 PlayerStatus::can_reach_checkpoint() const
 {
-  return coins >= 25
-    && !GameSession::current()->get_reset_point_sectorname().empty();
+  return !GameSession::current()->get_reset_point_sectorname().empty();
 }
 
 void


### PR DESCRIPTION
This very simple change makes it to where you won't be punished for losing coins at checkpoints, as you can always respawn at them now.  However, the coins can still be removed by dying at a checkpoint, as a sort of score system, as being a score system is now coins' only purpose.  This makes hard levels much fairer, and a vote done in the SuperTux Discord proved this option more favorable than keeping it the same.

The reason this is a Pull Request and not directly implemented is because of discussion that can still be had.  If it is agreed on by the SuperTux team then this will be merged.