### PR TITLE
Remember --spawnpoint and --sector across deaths.

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -359,7 +359,7 @@ Editor::set_sector(Sector* sector)
   if (!sector) return;
 
   m_sector = sector;
-  m_sector->activate("main");
+  m_sector->activate(m_sector->get_spawn_location("main"));
 
   { // initialize badguy sprites and other GameObject stuff
     BIND_SECTOR(*m_sector);
@@ -422,7 +422,8 @@ Editor::set_level(std::unique_ptr<Level> level, bool reset)
 
   if (m_sector != nullptr)
   {
-    m_sector->activate(sector_name);
+    // Why do we assume the same name for sector and spawnpoint?
+    m_sector->activate(m_sector->get_spawn_location(sector_name));
     m_sector->get_camera().set_mode(Camera::Mode::MANUAL);
 
     if (!reset) {

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -132,7 +132,7 @@ GameSession::restart_level(bool after_death)
       if (!m_currentsector)
         throw std::runtime_error("Couldn't find main sector");
       m_play_time = 0;
-      m_currentsector->activate("main");
+      m_currentsector->activate(m_currentsector->get_spawn_location("main"));
     }
   } catch(std::exception& e) {
     log_fatal << "Couldn't start level: " << e.what() << std::endl;
@@ -351,7 +351,7 @@ GameSession::update(float dt_sec, const Controller& controller)
       sector = m_level->get_sector("main");
     }
     m_currentsector->stop_looping_sounds();
-    sector->activate(m_newspawnpoint);
+    sector->activate(sector->get_spawn_location(m_newspawnpoint));
     sector->get_singleton_by_type<MusicObject>().play_music(LEVEL_MUSIC);
     m_currentsector = sector;
     m_currentsector->play_looping_sounds();
@@ -462,6 +462,14 @@ GameSession::set_reset_point(const std::string& sector, const Vector& pos)
 {
   m_reset_sector = sector;
   m_reset_pos = pos;
+}
+
+void
+GameSession::set_reset_point(const std::string& sector,
+                             const std::string& spawnpoint)
+{
+  set_reset_point(sector,
+                  m_level->get_sector(sector)->get_spawn_location(spawnpoint));
 }
 
 std::string

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -55,6 +55,8 @@ public:
   void respawn(const std::string& sectorname, const std::string& spawnpointname,
                const bool invincibility = false, const int invincibilityperiod = 0);
   void reset_level();
+  void set_reset_point(const std::string& sectorname,
+                       const std::string& spawnpointname);
   void set_reset_point(const std::string& sectorname, const Vector& pos);
   std::string get_reset_point_sectorname() const { return m_reset_sector; }
 

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -503,6 +503,7 @@ Main::launch_game(const CommandLineArguments& args)
           std::string spawnpointname = args.spawnpoint.get_value_or(default_spawnpoint);
 
           session->respawn(sectorname, spawnpointname);
+          session->set_reset_point(sectorname, spawnpointname);
         }
 
         if (g_config->tux_spawn_pos)

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -167,8 +167,8 @@ Sector::get_level() const
   return m_level;
 }
 
-void
-Sector::activate(const std::string& spawnpoint)
+Vector
+Sector::get_spawn_location(const std::string& spawnpoint)
 {
   SpawnPointMarker* sp = nullptr;
   for (auto& spawn_point : get_objects_by_type<SpawnPointMarker>()) {
@@ -181,12 +181,12 @@ Sector::activate(const std::string& spawnpoint)
   if (!sp) {
     log_warning << "Spawnpoint '" << spawnpoint << "' not found." << std::endl;
     if (spawnpoint != "main") {
-      activate("main");
+      return get_spawn_location("main");
     } else {
-      activate(Vector(0, 0));
+      return Vector(0, 0);
     }
   } else {
-    activate(sp->get_pos());
+    return sp->get_pos();
   }
 }
 

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -71,7 +71,7 @@ public:
   Level& get_level() const;
 
   /** activates this sector (change music, initialize player class, ...) */
-  void activate(const std::string& spawnpoint);
+  Vector get_spawn_location(const std::string& spawnpoint);
   void activate(const Vector& player_pos);
   void deactivate();
 

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -74,7 +74,7 @@ TitleScreen::make_tux_jump()
 
   // Wrap around at the end of the level back to the beginning
   if (sector.get_width() - 320 < tux.get_pos().x) {
-    sector.activate("main");
+    sector.activate(sector.get_spawn_location("main"));
     sector.get_camera().reset(tux.get_pos());
   }
 }


### PR DESCRIPTION
Makes playtesting nasty levels much easier.

Note: I am unsure about this implementation; I find abusing the checkpoint system rather nasty. I wonder if it would be a better idea to rather override a lot of what game_session does, by moving name of initial spawnpoint into a member or something.

Decided to not overload Sector::activate to make clearer at callsites what is a spawnpoint name (there appears to be some confusion in one spot, comment added).