### PR TITLE
Remember --spawnpoint and --sector across deaths.

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -55,6 +55,8 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_game_pause(false),
   m_speed_before_pause(ScreenManager::current()->get_speed()),
   m_levelfile(levelfile_),
+  m_start_sector("main"),
+  m_start_spawnpoint("main"),
   m_reset_sector(),
   m_reset_pos(),
   m_newsector(),
@@ -128,11 +130,11 @@ GameSession::restart_level(bool after_death)
       }
       m_currentsector->activate(m_reset_pos);
     } else {
-      m_currentsector = m_level->get_sector("main");
+      m_currentsector = m_level->get_sector(m_start_sector);
       if (!m_currentsector)
         throw std::runtime_error("Couldn't find main sector");
       m_play_time = 0;
-      m_currentsector->activate("main");
+      m_currentsector->activate(m_start_spawnpoint);
     }
   } catch(std::exception& e) {
     log_fatal << "Couldn't start level: " << e.what() << std::endl;
@@ -348,7 +350,7 @@ GameSession::update(float dt_sec, const Controller& controller)
     auto sector = m_level->get_sector(m_newsector);
     if (sector == nullptr) {
       log_warning << "Sector '" << m_newsector << "' not found" << std::endl;
-      sector = m_level->get_sector("main");
+      sector = m_level->get_sector(m_start_sector);
     }
     m_currentsector->stop_looping_sounds();
     sector->activate(m_newspawnpoint);
@@ -455,6 +457,14 @@ GameSession::respawn(const std::string& sector, const std::string& spawnpoint,
   m_newspawnpoint = spawnpoint;
   m_pastinvincibility = invincibility;
   m_newinvincibilityperiod = invincibilityperiod;
+}
+
+void
+GameSession::set_start_point(const std::string& sector,
+                             const std::string& spawnpoint)
+{
+  m_start_sector = sector;
+  m_start_spawnpoint = spawnpoint;
 }
 
 void

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -55,6 +55,8 @@ public:
   void respawn(const std::string& sectorname, const std::string& spawnpointname,
                const bool invincibility = false, const int invincibilityperiod = 0);
   void reset_level();
+  void set_start_point(const std::string& sectorname,
+                       const std::string& spawnpointname);
   void set_reset_point(const std::string& sectorname, const Vector& pos);
   std::string get_reset_point_sectorname() const { return m_reset_sector; }
 
@@ -111,6 +113,10 @@ private:
   float m_speed_before_pause;
 
   std::string m_levelfile;
+
+  // spawn point (the point where tux respawns at startup). Usually both "main".
+  std::string m_start_sector;
+  std::string m_start_spawnpoint;
 
   // reset point (the point where tux respawns if he dies)
   std::string m_reset_sector;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -502,7 +502,8 @@ Main::launch_game(const CommandLineArguments& args)
             "" : spawnpoints.begin()->get_name();
           std::string spawnpointname = args.spawnpoint.get_value_or(default_spawnpoint);
 
-          session->respawn(sectorname, spawnpointname);
+          session->set_start_point(sectorname, spawnpointname);
+          session->restart_level();
         }
 
         if (g_config->tux_spawn_pos)


### PR DESCRIPTION
Makes playtesting nasty levels much easier.

A less intrusive way, as an alternative to https://github.com/SuperTux/supertux/pull/1417