### PR TITLE
Editor: add a "test from here" option

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -85,6 +85,7 @@ Editor::Editor() :
   m_deactivate_request(false),
   m_save_request(false),
   m_test_request(false),
+  m_test_pos(),
   m_savegame(),
   m_sector(),
   m_levelloaded(false),
@@ -176,7 +177,7 @@ Editor::update(float dt_sec, const Controller& controller)
   if (m_test_request) {
     m_test_request = false;
     MouseCursor::current()->set_icon(nullptr);
-    test_level();
+    test_level(m_test_pos);
     return;
   }
 
@@ -232,7 +233,7 @@ Editor::get_level_directory() const
 }
 
 void
-Editor::test_level()
+Editor::test_level(const boost::optional<std::pair<std::string, Vector>>& test_pos)
 {
   Tile::draw_editor_images = false;
   Compositor::s_render_lighting = true;
@@ -252,7 +253,7 @@ Editor::test_level()
   m_level->save(m_test_levelfile);
   if (!m_level->is_worldmap())
   {
-    GameManager::current()->start_level(*current_world, backup_filename);
+    GameManager::current()->start_level(*current_world, backup_filename, test_pos);
   }
   else
   {
@@ -585,7 +586,7 @@ Editor::event(const SDL_Event& ev)
 	if (ev.type == SDL_KEYDOWN &&
         ev.key.keysym.sym == SDLK_t &&
         ev.key.keysym.mod & KMOD_CTRL) {
-		test_level();
+		test_level(boost::none);
 		}
 
 	if (ev.type == SDL_KEYDOWN &&

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -137,7 +137,7 @@ private:
   void reload_level();
   void quit_editor();
   void save_level();
-  void test_level();
+  void test_level(const boost::optional<std::pair<std::string, Vector>>& test_pos);
   void update_keyboard(const Controller& controller);
 
 protected:
@@ -155,6 +155,7 @@ public:
   bool m_deactivate_request;
   bool m_save_request;
   bool m_test_request;
+  boost::optional<std::pair<std::string, Vector>> m_test_pos;
 
   std::unique_ptr<Savegame> m_savegame;
 

--- a/src/editor/object_menu.cpp
+++ b/src/editor/object_menu.cpp
@@ -59,6 +59,15 @@ ObjectMenu::menu_action(MenuItem& item)
       m_object->remove_me();
       break;
 
+    case MNID_TEST_FROM_HERE: {
+      const MovingObject *here = dynamic_cast<const MovingObject *>(m_object);
+      m_editor.m_test_pos = std::make_pair(m_editor.get_sector()->get_name(),
+                                           here->get_pos());
+      m_editor.m_test_request = true;
+      MenuManager::instance().pop_menu();
+      break;
+    }
+
     default:
       break;
   }

--- a/src/editor/object_menu.hpp
+++ b/src/editor/object_menu.hpp
@@ -26,7 +26,8 @@ class ObjectMenu final : public Menu
 {
 public:
   enum {
-    MNID_REMOVE
+    MNID_REMOVE,
+    MNID_TEST_FROM_HERE
   };
 
 public:

--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -566,4 +566,21 @@ RemoveObjectOption::add_to_menu(Menu& menu) const
   menu.add_entry(ObjectMenu::MNID_REMOVE, get_text());
 }
 
+TestFromHereOption::TestFromHereOption() :
+  ObjectOption(_("Test from here"), "", 0)
+{
+}
+
+std::string
+TestFromHereOption::to_string() const
+{
+  return {};
+}
+
+void
+TestFromHereOption::add_to_menu(Menu& menu) const
+{
+  menu.add_entry(ObjectMenu::MNID_TEST_FROM_HERE, get_text());
+}
+
 /* EOF */

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -381,6 +381,20 @@ private:
   RemoveObjectOption& operator=(const RemoveObjectOption&) = delete;
 };
 
+class TestFromHereOption : public ObjectOption
+{
+public:
+  TestFromHereOption();
+
+  virtual void save(Writer& write) const override {}
+  virtual std::string to_string() const override;
+  virtual void add_to_menu(Menu& menu) const override;
+
+private:
+  TestFromHereOption(const TestFromHereOption&) = delete;
+  TestFromHereOption& operator=(const TestFromHereOption&) = delete;
+};
+
 #endif
 
 /* EOF */

--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -286,6 +286,12 @@ ObjectSettings::add_sexp(const std::string& text, const std::string& key, sexp::
 }
 
 void
+ObjectSettings::add_test_from_here()
+{
+  add_option(std::make_unique<TestFromHereOption>());
+}
+
+void
 ObjectSettings::reorder(const std::vector<std::string>& order)
 {
   std::vector<std::unique_ptr<ObjectOption> > new_options;

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -135,6 +135,7 @@ public:
                 unsigned int flags = 0);
   void add_sexp(const std::string& text, const std::string& key,
                 sexp::Value& value, unsigned int flags = 0);
+  void add_test_from_here();
 
   const std::vector<std::unique_ptr<ObjectOption> >& get_options() const { return m_options; }
 

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -140,4 +140,12 @@ Firefly::collision(GameObject& other, const CollisionHit& )
   return ABORT_MOVE;
 }
 
+ObjectSettings
+Firefly::get_settings()
+{
+  ObjectSettings result = MovingObject::get_settings();
+  result.add_test_from_here();
+  return result;
+}
+
 /* EOF */

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -34,6 +34,7 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual std::string get_class() const override { return "firefly"; }
   virtual std::string get_display_name() const override { return _("Checkpoint"); }
+  virtual ObjectSettings get_settings() override;
 
 private:
   SpritePtr m_sprite_light;

--- a/src/object/spawnpoint.cpp
+++ b/src/object/spawnpoint.cpp
@@ -54,4 +54,12 @@ SpawnPointMarker::draw(DrawingContext& context)
   }
 }
 
+ObjectSettings
+SpawnPointMarker::get_settings()
+{
+  ObjectSettings result = MovingObject::get_settings();
+  result.add_test_from_here();
+  return result;
+}
+
 /* EOF */

--- a/src/object/spawnpoint.hpp
+++ b/src/object/spawnpoint.hpp
@@ -44,6 +44,7 @@ public:
 
   virtual std::string get_class() const override { return "spawnpoint"; }
   virtual std::string get_display_name() const override { return _("Spawnpoint"); }
+  virtual ObjectSettings get_settings() override;
 
 private:
   SurfacePtr m_surface;

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -38,13 +38,15 @@ GameManager::GameManager() :
 }
 
 void
-GameManager::start_level(const World& world, const std::string& level_filename)
+GameManager::start_level(const World& world, const std::string& level_filename,
+                         const boost::optional<std::pair<std::string, Vector>>& start_pos)
 {
   m_savegame = Savegame::from_file(world.get_savegame_filename());
 
   auto screen = std::make_unique<LevelsetScreen>(world.get_basedir(),
                                                  level_filename,
-                                                 *m_savegame);
+                                                 *m_savegame,
+                                                 start_pos);
   ScreenManager::current()->push_screen(std::move(screen));
 }
 

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -17,8 +17,10 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_GAME_MANAGER_HPP
 #define HEADER_SUPERTUX_SUPERTUX_GAME_MANAGER_HPP
 
+#include <boost/optional.hpp>
 #include <memory>
 #include <string>
+#include "math/vector.hpp"
 #include "util/currenton.hpp"
 
 class Savegame;
@@ -30,7 +32,8 @@ public:
   GameManager();
 
   void start_worldmap(const World& world, const std::string& spawnpoint = "", const std::string& worldmap_filename = "");
-  void start_level(const World& world, const std::string& level_filename);
+  void start_level(const World& world, const std::string& level_filename,
+                   const boost::optional<std::pair<std::string, Vector>>& start_pos = boost::none);
 
   bool load_next_worldmap();
   void set_next_worldmap(const std::string& worldmap, const std::string &spawnpoint);

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -57,6 +57,7 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_levelfile(levelfile_),
   m_start_sector("main"),
   m_start_spawnpoint("main"),
+  m_start_pos(),
   m_reset_sector(),
   m_reset_pos(),
   m_newsector(),
@@ -134,7 +135,11 @@ GameSession::restart_level(bool after_death)
       if (!m_currentsector)
         throw std::runtime_error("Couldn't find main sector");
       m_play_time = 0;
-      m_currentsector->activate(m_start_spawnpoint);
+      if (m_start_spawnpoint.empty()) {
+        m_currentsector->activate(m_start_pos);
+      } else {
+        m_currentsector->activate(m_start_spawnpoint);
+      }
     }
   } catch(std::exception& e) {
     log_fatal << "Couldn't start level: " << e.what() << std::endl;
@@ -465,6 +470,16 @@ GameSession::set_start_point(const std::string& sector,
 {
   m_start_sector = sector;
   m_start_spawnpoint = spawnpoint;
+  m_start_pos = Vector();
+}
+
+void
+GameSession::set_start_pos(const std::string& sector,
+                           const Vector& pos)
+{
+  m_start_sector = sector;
+  m_start_spawnpoint = "";
+  m_start_pos = pos;
 }
 
 void

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -57,6 +57,7 @@ public:
   void reset_level();
   void set_start_point(const std::string& sectorname,
                        const std::string& spawnpointname);
+  void set_start_pos(const std::string& sectorname, const Vector& pos);
   void set_reset_point(const std::string& sectorname, const Vector& pos);
   std::string get_reset_point_sectorname() const { return m_reset_sector; }
 
@@ -115,8 +116,10 @@ private:
   std::string m_levelfile;
 
   // spawn point (the point where tux respawns at startup). Usually both "main".
+  // If m_start_spawnpoint is set, m_start_pos shall not, and vice versa.
   std::string m_start_sector;
   std::string m_start_spawnpoint;
+  Vector m_start_pos;
 
   // reset point (the point where tux respawns if he dies)
   std::string m_reset_sector;

--- a/src/supertux/levelset_screen.cpp
+++ b/src/supertux/levelset_screen.cpp
@@ -27,12 +27,14 @@
 #include "util/log.hpp"
 
 LevelsetScreen::LevelsetScreen(const std::string& basedir, const std::string& level_filename,
-                               Savegame& savegame) :
+                               Savegame& savegame,
+                               const boost::optional<std::pair<std::string, Vector>>& start_pos) :
   m_basedir(basedir),
   m_level_filename(level_filename),
   m_savegame(savegame),
   m_level_started(false),
-  m_solved(false)
+  m_solved(false),
+  m_start_pos(start_pos)
 {
   Levelset levelset(basedir);
   for (int i = 0; i < levelset.get_num_levels(); ++i)
@@ -83,6 +85,10 @@ LevelsetScreen::setup()
     } else {
       auto screen = std::make_unique<GameSession>(FileSystem::join(m_basedir, m_level_filename),
                                                   m_savegame);
+      if (m_start_pos) {
+        screen->set_start_pos(m_start_pos->first, m_start_pos->second);
+        screen->restart_level();
+      }
       ScreenManager::current()->push_screen(std::move(screen));
     }
   }

--- a/src/supertux/levelset_screen.hpp
+++ b/src/supertux/levelset_screen.hpp
@@ -17,8 +17,10 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_LEVELSET_SCREEN_HPP
 #define HEADER_SUPERTUX_SUPERTUX_LEVELSET_SCREEN_HPP
 
+#include <boost/optional.hpp>
 #include <string>
 
+#include "math/vector.hpp"
 #include "supertux/screen.hpp"
 #include "util/currenton.hpp"
 
@@ -35,7 +37,8 @@ private:
   bool m_solved;
 
 public:
-  LevelsetScreen(const std::string& basedir, const std::string& level_filename, Savegame& savegame);
+  LevelsetScreen(const std::string& basedir, const std::string& level_filename, Savegame& savegame,
+                 const boost::optional<std::pair<std::string, Vector>>& start_pos);
 
   virtual void draw(Compositor& compositor) override;
   virtual void update(float dt_sec, const Controller& controller) override;
@@ -46,6 +49,8 @@ public:
   void finished_level(bool win);
 
 private:
+  boost::optional<std::pair<std::string, Vector>> m_start_pos;
+
   LevelsetScreen(const LevelsetScreen&) = delete;
   LevelsetScreen& operator=(const LevelsetScreen&) = delete;
 };

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -111,6 +111,7 @@ EditorMenu::menu_action(MenuItem& item)
     {
       editor->check_save_prerequisites([editor]() {
         MenuManager::instance().clear_menu_stack();
+        editor->m_test_pos = boost::none;
         editor->m_test_request = true;
       });
     }


### PR DESCRIPTION
You can now "test from here" from the options dialog of spawnpoints and resetpoints to allow easier testing of your level. Enjoy!