### PR TITLE
remove extra space from function and parameter

### DIFF
--- a/data/music/castle/fortress.music
+++ b/data/music/castle/fortress.music
@@ -1,5 +1,5 @@
 (supertux-music
   (file "fortress.ogg")
   (loop-begin 11.37)
-  (loop-at    -1)
+  (loop-at -1)
 )


### PR DESCRIPTION
Was there extra space here that should be removed in this function?