### PR TITLE
Crash fix: do not allow deleting the last node of a path.

### DIFF
--- a/src/editor/node_marker.cpp
+++ b/src/editor/node_marker.cpp
@@ -69,6 +69,10 @@ NodeMarker::move_to(const Vector& pos)
 void
 NodeMarker::editor_delete()
 {
+  if (m_path->m_nodes.size() <= 1)
+  {
+    return;
+  }
   m_path->m_nodes.erase(m_node);
   Editor::current()->update_node_iterators();
 }


### PR DESCRIPTION
Doing so would create a zero length path. Worse, the path widget still
appears and trying to delete that would make a -1 length path, iterating
over which takes forever (but eventually segfaults).