### PR TITLE
Crash fix: handle dragging a selection rectangle up/left correctly.

### DIFF
--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -929,19 +929,26 @@ EditorOverlayWidget::draw(DrawingContext& context)
     // Draw selection rectangle...
     auto cam_translation = m_editor.get_sector()->get_camera().get_translation();
     Vector p0 = m_drag_start - cam_translation;
-    Vector p1 = Vector(m_drag_start.x, m_sector_pos.y) - cam_translation;
-    Vector p2 = Vector(m_sector_pos.x, m_drag_start.y) - cam_translation;
+    Vector p3 = m_mouse_pos;
+    if (p0.x > p3.x) {
+      std::swap(p0.x, p3.x);
+    }
+    if (p0.y > p3.y) {
+      std::swap(p0.y, p3.y);
+    }
+    Vector p1 = Vector(p0.x, p3.y);
+    Vector p2 = Vector(p3.x, p0.y);
 
     context.color().draw_filled_rect(Rectf(p0, p1 + Vector(2, 2)),
                                        Color(0.0f, 1.0f, 0.0f, 1.0f), 0.0f, LAYER_GUI-5);
-    context.color().draw_filled_rect(Rectf(p2, m_mouse_pos + Vector(2, 2)),
+    context.color().draw_filled_rect(Rectf(p2, p3 + Vector(2, 2)),
                                        Color(0.0f, 1.0f, 0.0f, 1.0f), 0.0f, LAYER_GUI-5);
     context.color().draw_filled_rect(Rectf(p0, p2 + Vector(2, 2)),
                                        Color(0.0f, 1.0f, 0.0f, 1.0f), 0.0f, LAYER_GUI-5);
-    context.color().draw_filled_rect(Rectf(p1, m_mouse_pos + Vector(2, 2)),
+    context.color().draw_filled_rect(Rectf(p1, p3 + Vector(2, 2)),
                                        Color(0.0f, 1.0f, 0.0f, 1.0f), 0.0f, LAYER_GUI-5);
 
-    context.color().draw_filled_rect(Rectf(p0, m_mouse_pos),
+    context.color().draw_filled_rect(Rectf(p0, p3),
                                        Color(0.0f, 1.0f, 0.0f, 0.2f), 0.0f, LAYER_GUI-5);
   }
 


### PR DESCRIPTION
Previously, this created a Rectf instance with negative size, crashing
the filled rectangle drawing routine.

I previously considered rather making the drawing routine support this
case, but then I started to wonder how to define the rounded rectangle
radius in that case... and then I saw the pre-existing assert in the
other Rectf constructor and decided that the intention was to not allow
this in the first place. So, dragging code fixed instead.