### PR TITLE
Make the other Rectf ctor also assert that size can't be negative.

### DIFF
--- a/src/math/rectf.hpp
+++ b/src/math/rectf.hpp
@@ -49,6 +49,8 @@ public:
   Rectf(const Vector& np1, const Vector& np2) :
     m_p1(np1), m_size(np2.x - np1.x, np2.y - np1.y)
   {
+    assert(m_size.width >= 0 &&
+           m_size.height >= 0);
   }
 
   Rectf(float x1, float y1, float x2, float y2) :


### PR DESCRIPTION
Helped locate and fix the "crash on dragging rectangles up or left" bug.