### PR TITLE
Fix assertion failure in triangle drawing on the SDL backend.

### DIFF
--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -464,47 +464,49 @@ SDLPainter::draw_line(const LineRequest& request)
 
 namespace {
 
-Rectf
+using Edge = std::pair<Vector, Vector>;
+
+Edge
 make_edge(int x1, int y1, int x2, int y2)
 {
   if (y1 < y2)
   {
-    return Rectf(Vector(static_cast<float>(x1), static_cast<float>(y1)),
-                 Vector(static_cast<float>(x2), static_cast<float>(y2)));
+    return Edge(Vector(static_cast<float>(x1), static_cast<float>(y1)),
+                Vector(static_cast<float>(x2), static_cast<float>(y2)));
   }
   else
   {
-    return Rectf(Vector(static_cast<float>(x2), static_cast<float>(y2)),
-                 Vector(static_cast<float>(x1), static_cast<float>(y1)));
+    return Edge(Vector(static_cast<float>(x2), static_cast<float>(y2)),
+                Vector(static_cast<float>(x1), static_cast<float>(y1)));
   }
 }
 
 void
-draw_span_between_edges(SDL_Renderer* renderer, const Rectf& e1, const Rectf& e2)
+draw_span_between_edges(SDL_Renderer* renderer, const Edge& e1, const Edge& e2)
 {
   // calculate difference between the y coordinates
   // of the first edge and return if 0
-  float e1ydiff = static_cast<float>(e1.get_bottom() - e1.get_top());
+  float e1ydiff = static_cast<float>(e1.second.y - e1.first.y);
   if (e1ydiff == 0.0f)
     return;
 
   // calculate difference between the y coordinates
   // of the second edge and return if 0
-  float e2ydiff = static_cast<float>(e2.get_bottom() - e2.get_top());
+  float e2ydiff = static_cast<float>(e2.second.y - e2.first.y);
   if (e2ydiff == 0.0f)
     return;
 
-  float e1xdiff = e1.get_right() - e1.get_left();
-  float e2xdiff = e2.get_right() - e2.get_left();
-  float factor1 = (e2.get_top() - e1.get_top()) / e1ydiff;
+  float e1xdiff = e1.second.x - e1.first.x;
+  float e2xdiff = e2.second.x - e2.first.x;
+  float factor1 = (e2.first.y - e1.first.y) / e1ydiff;
   float factorStep1 = 1.0f / e1ydiff;
   float factor2 = 0.0f;
   float factorStep2 = 1.0f / e2ydiff;
 
-  for (int y = static_cast<int>(e2.get_top()); y < static_cast<int>(e2.get_bottom()); y++) {
+  for (int y = static_cast<int>(e2.first.y); y < static_cast<int>(e2.second.y); y++) {
     SDL_RenderDrawLine(renderer,
-                       static_cast<int>(e1.get_left() + e1xdiff * factor1), y,
-                       static_cast<int>(e2.get_left() + e2xdiff * factor2), y);
+                       static_cast<int>(e1.first.x + e1xdiff * factor1), y,
+                       static_cast<int>(e2.first.x + e2xdiff * factor2), y);
     factor1 += factorStep1;
     factor2 += factorStep2;
   }
@@ -527,7 +529,7 @@ SDLPainter::draw_triangle(const TriangleRequest& request)
   int x3 = static_cast<int>(request.pos3.x);
   int y3 = static_cast<int>(request.pos3.y);
 
-  Rectf edges[3];
+  Edge edges[3];
   edges[0] = make_edge(x1, y1, x2, y2);
   edges[1] = make_edge(x2, y2, x3, y3);
   edges[2] = make_edge(x3, y3, x1, y1);
@@ -537,7 +539,7 @@ SDLPainter::draw_triangle(const TriangleRequest& request)
 
   // find edge with the greatest length in the y axis
   for (int i = 0; i < 3; i++) {
-    int length = static_cast<int>(edges[i].get_bottom() - edges[i].get_top());
+    int length = static_cast<int>(edges[i].second.y - edges[i].first.y);
     if (length > maxLength) {
       maxLength = length;
       longEdge = i;


### PR DESCRIPTION
Fixed by changing the type of an edge from Rectf to std::pair<Vector, Vector>.

This assertion was introduced in
https://github.com/SuperTux/supertux/commit/fa31cabc949342fd73d822dc3652a2910c0e08f5
(and if this causes more issues, we may want to retract this assertion
or turn it into a debug print for now).

Shouldn't affect optimized builds as asserts normally are off when
optimizing via -DNDEBUG.