### PR TITLE
Issue 1398 fix throwable bug with coins

### DIFF
--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -19,6 +19,8 @@
 #include "audio/sound_manager.hpp"
 #include "object/explosion.hpp"
 #include "object/coin.hpp"
+#include "badguy/badguy.hpp"
+#include "object/player.hpp"
 #include "supertux/sector.hpp"
 #include "supertux/tile.hpp"
 #include "util/reader_mapping.hpp"
@@ -129,9 +131,13 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
     if (hit.bottom && physic.get_velocity_y() > 200) {
       auto moving_object = dynamic_cast<MovingObject*> (&other);
       if (moving_object) {
-        //Getting a rock on the head hurts. A lot.
-        moving_object->collision_tile(Tile::HURTS);
-        physic.set_velocity_y(0);
+        auto badguy = dynamic_cast<BadGuy*> (moving_object);
+        auto player = dynamic_cast<Player*> (moving_object);
+        if (badguy || player) {
+          //Getting a rock on the head hurts. A lot.
+          moving_object->collision_tile(Tile::HURTS);
+          physic.set_velocity_y(0);
+        }
       }
     }
     return FORCE_MOVE;

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -20,6 +20,7 @@
 #include "object/explosion.hpp"
 #include "object/coin.hpp"
 #include "badguy/badguy.hpp"
+#include "badguy/flame.hpp"
 #include "object/player.hpp"
 #include "supertux/sector.hpp"
 #include "supertux/tile.hpp"
@@ -132,9 +133,11 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
       auto moving_object = dynamic_cast<MovingObject*> (&other);
       if (moving_object) {
         auto badguy = dynamic_cast<BadGuy*> (moving_object);
+        auto flame  = dynamic_cast<Flame*>  (moving_object);
         auto player = dynamic_cast<Player*> (moving_object);
-        if (badguy || player) {
+        if (player || (badguy && !flame)) {
           //Getting a rock on the head hurts. A lot.
+          //Applies to Tux and Badguys, but not Flames.
           moving_object->collision_tile(Tile::HURTS);
           physic.set_velocity_y(0);
         }

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -19,9 +19,6 @@
 #include "audio/sound_manager.hpp"
 #include "object/explosion.hpp"
 #include "object/coin.hpp"
-#include "badguy/badguy.hpp"
-#include "badguy/flame.hpp"
-#include "object/player.hpp"
 #include "supertux/sector.hpp"
 #include "supertux/tile.hpp"
 #include "util/reader_mapping.hpp"
@@ -131,16 +128,10 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
   if (!on_ground) {
     if (hit.bottom && physic.get_velocity_y() > 200) {
       auto moving_object = dynamic_cast<MovingObject*> (&other);
-      if (moving_object) {
-        auto badguy = dynamic_cast<BadGuy*> (moving_object);
-        auto flame  = dynamic_cast<Flame*>  (moving_object);
-        auto player = dynamic_cast<Player*> (moving_object);
-        if (player || (badguy && !flame)) {
-          //Getting a rock on the head hurts. A lot.
-          //Applies to Tux and Badguys, but not Flames.
-          moving_object->collision_tile(Tile::HURTS);
-          physic.set_velocity_y(0);
-        }
+      if (moving_object && moving_object->get_group() != COLGROUP_TOUCHABLE) {
+        //Getting a rock on the head hurts. A lot.
+        moving_object->collision_tile(Tile::HURTS);
+        physic.set_velocity_y(0);
       }
     }
     return FORCE_MOVE;


### PR DESCRIPTION
Fixes #1398. Throwable objects like rocks will no longer collide with coins or "flame" objects, like rotating ice balls.

Demo before:

![rock-coin-bug-before](https://user-images.githubusercontent.com/24422213/85586199-d39e3f80-b694-11ea-9284-7bee864382a0.gif)

Demo after:

![rock-coin-bug-after](https://user-images.githubusercontent.com/24422213/85586224-d862f380-b694-11ea-8132-2294c053f52d.gif)
