### PR TITLE
Fixed a bug where you could travel through magic blocks while holding…

### DIFF
--- a/src/object/magicblock.cpp
+++ b/src/object/magicblock.cpp
@@ -37,7 +37,7 @@ const float MIN_INTENSITY = 0.8f;
 const float ALPHA_SOLID = 0.7f;
 const float ALPHA_NONSOLID = 0.3f;
 const float MIN_SOLIDTIME = 1.0f;
-const float SWITCH_DELAY = 0.06f; /**< seconds to wait for stable conditions until switching solidity */
+const float SWITCH_DELAY = 0.0f; /**< seconds to wait for stable conditions until switching solidity */
 
 } // namespace
 


### PR DESCRIPTION
… a lantern of the same color by going fast enough.

I simply removed the delay before the block becomes solid.

When swimming, Tux can gain enough velocity to pass through magic blocks while carrying a lantern of a color that should make them turn solid. Levels that relies on the player's inability to pass a magic wall block while holding a lantern of a certain color can be easily broken by this.