### PR TITLE
Remove music fading on death

### DIFF
--- a/src/object/music_object.cpp
+++ b/src/object/music_object.cpp
@@ -74,7 +74,7 @@ MusicObject::resume_music()
 {
   if (SoundManager::current()->get_current_music() == m_music)
   {
-    SoundManager::current()->resume_music(3.2f);
+    SoundManager::current()->resume_music(0);
   }
   else
   {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1802,7 +1802,6 @@ Player::kill(bool completely)
 
     // TODO: need nice way to handle players dying in co-op mode
     Sector::get().get_effect().fade_out(3.0);
-    SoundManager::current()->pause_music(3.0);
   }
 }
 


### PR DESCRIPTION
My reasoning for removing music fading upon death is because the music resumes after you respawn anyway, so it'd sound better to just let it continue playing.

The only exception to this would be if the music in the sector you re-spawned in is different to the one you died in, but I wasn't sure how to code it to check if there's a difference. If anybody else can figure that out, please do