### PR TITLE
Fix animation issue with slow framerates

### DIFF
--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -116,12 +116,9 @@ Sprite::update()
     m_frameidx++;
   }
 
-  while (m_frameidx >= get_frames()) {
+  while (m_frameidx >= get_frames() && !animation_done()) {
     m_frameidx -= get_frames();
     m_animation_loops--;
-    if (animation_done()) {
-      break;
-    }
   }
 
   if (animation_done()) {


### PR DESCRIPTION
Fixes #1453. Sprites with 1 animation loop now stop as expected, when playing with low frame-rates. I.e. they don't continue forever.

Demo below, recorded using the `export LIBGL_ALWAYS_SOFTWARE=true` as in https://github.com/SuperTux/supertux/issues/1453#issuecomment-654967674.

![animation-fix-demo](https://user-images.githubusercontent.com/24422213/88235428-f725cb80-ccce-11ea-9649-fd06c841d67a.gif)
