### PR TITLE
Dispensers can obey gravity

### DIFF
--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -71,6 +71,7 @@ Dispenser::Dispenser(const ReaderMapping& reader) :
   m_swivel(false),
   m_broken(false),
   m_random(),
+  m_gravity(),
   m_type(),
   m_type_str(),
   m_limit_dispensed_badguys(),
@@ -80,6 +81,7 @@ Dispenser::Dispenser(const ReaderMapping& reader) :
   set_colgroup_active(COLGROUP_MOVING_STATIC);
   SoundManager::current()->preload("sounds/squish.wav");
   reader.get("cycle", m_cycle, 5.0f);
+  if (reader.get("gravity", m_gravity)) m_physic.enable_gravity(true);
   if ( !reader.get("badguy", m_badguys)) m_badguys.clear();
   reader.get("random", m_random, false);
   std::string type_s = "dropper"; //default
@@ -224,8 +226,13 @@ Dispenser::collision(GameObject& other, const CollisionHit& hit)
 }
 
 void
-Dispenser::active_update(float )
+Dispenser::active_update(float dt_sec)
 {
+  if (m_gravity)
+  {
+    BadGuy::active_update(dt_sec);
+    m_physic.enable_gravity(true);
+  }
   if (m_dispense_timer.check()) {
     // auto always shoots in Tux's direction
     if (m_autotarget) {
@@ -441,6 +448,8 @@ Dispenser::get_settings()
   result.add_badguy(_("Enemies"), &m_badguys, "badguy");
   result.add_bool(_("Limit dispensed badguys"), &m_limit_dispensed_badguys,
                   "limit-dispensed-badguys", false);
+  result.add_bool(_("Obey Gravity"), &m_gravity,
+                  "gravity", false);
   result.add_int(_("Max concurrent badguys"), &m_max_concurrent_badguys,
                  "max-concurrent-badguys", 0);
   result.add_enum(_("Type"), reinterpret_cast<int*>(&m_type),
@@ -448,7 +457,7 @@ Dispenser::get_settings()
                   {"dropper", "rocketlauncher", "cannon", "point"},
                   static_cast<int>(DispenserType::DROPPER), "type");
 
-  result.reorder({"cycle", "random", "type", "badguy", "direction", "limit-dispensed-badguys", "max-concurrent-badguys", "x", "y"});
+  result.reorder({"cycle", "random", "type", "badguy", "direction", "gravity", "limit-dispensed-badguys", "max-concurrent-badguys", "x", "y"});
 
   return result;
 }

--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -231,7 +231,6 @@ Dispenser::active_update(float dt_sec)
   if (m_gravity)
   {
     BadGuy::active_update(dt_sec);
-    m_physic.enable_gravity(true);
   }
   if (m_dispense_timer.check()) {
     // auto always shoots in Tux's direction

--- a/src/badguy/dispenser.hpp
+++ b/src/badguy/dispenser.hpp
@@ -73,6 +73,7 @@ private:
   bool m_swivel;
   bool m_broken;
   bool m_random;
+  bool m_gravity;
 
   DispenserType m_type;
   std::string m_type_str;


### PR DESCRIPTION
This adds a small option for dispensers to obey gravity.  With this, you can have moving dispensers by toggling gravity and putting them on a moving platform.  Enjoy.