### PR TITLE
Layout widget in editor is now scrollable

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -647,7 +647,7 @@ Editor::event(const SDL_Event& ev)
 
     // Scroll with mouse wheel, if the mouse is not over the toolbox.
     // The toolbox does scrolling independently from the main area.
-    if (ev.type == SDL_MOUSEWHEEL && !m_toolbox_widget->has_mouse_focus()) {
+    if (ev.type == SDL_MOUSEWHEEL && !m_toolbox_widget->has_mouse_focus() && !m_layers_widget->has_mouse_focus()) {
       float scroll_x = static_cast<float>(ev.wheel.x * -32);
       float scroll_y = static_cast<float>(ev.wheel.y * -32);
       scroll({scroll_x, scroll_y});

--- a/src/editor/layer_icon.cpp
+++ b/src/editor/layer_icon.cpp
@@ -65,9 +65,7 @@ LayerIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
   ObjectIcon::draw(context, pos, pixels_shown);
   int l = get_zpos();
   if (l != std::numeric_limits<int>::min()) {
-    //context.color().draw_text(Resources::small_font, std::to_string(l),
-    //                            pos + Vector(16,16),
-    //                            ALIGN_CENTER, LAYER_GUI, ColorScheme::Menu::default_color);
+    // Don't draw the text if the icon is not 100% visible
     if (TileMap* tilemap = dynamic_cast<TileMap*>(m_layer)) {
       if (tilemap->m_editor_active) {
         context.color().draw_surface(m_selection, pos, LAYER_GUI - 1);

--- a/src/editor/layer_icon.cpp
+++ b/src/editor/layer_icon.cpp
@@ -57,6 +57,25 @@ LayerIcon::draw(DrawingContext& context, const Vector& pos)
   }
 }
 
+void
+LayerIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
+{
+  if (!is_valid()) return;
+
+  ObjectIcon::draw(context, pos, pixels_shown);
+  int l = get_zpos();
+  if (l != std::numeric_limits<int>::min()) {
+    //context.color().draw_text(Resources::small_font, std::to_string(l),
+    //                            pos + Vector(16,16),
+    //                            ALIGN_CENTER, LAYER_GUI, ColorScheme::Menu::default_color);
+    if (TileMap* tilemap = dynamic_cast<TileMap*>(m_layer)) {
+      if (tilemap->m_editor_active) {
+        context.color().draw_surface(m_selection, pos, LAYER_GUI - 1);
+      }
+    }
+  }
+}
+
 int
 LayerIcon::get_zpos() const
 {

--- a/src/editor/layer_icon.hpp
+++ b/src/editor/layer_icon.hpp
@@ -29,6 +29,7 @@ public:
   virtual ~LayerIcon() {}
 
   virtual void draw(DrawingContext& context, const Vector& pos) override;
+  virtual void draw(DrawingContext& context, const Vector& pos, int pixels_shown) override;
 
   int get_zpos() const;
   bool is_valid() const;

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -137,7 +137,7 @@ EditorLayersWidget::update(float dt_sec)
   {
     m_scroll -= 2;
   }
-  else if (m_scroll_speed > 0 && m_scroll < static_cast<int>(m_layer_icons.size()) * 35)
+  else if (m_scroll_speed > 0 && m_scroll < (static_cast<int>(m_layer_icons.size()) - 1) * 35)
   {
     m_scroll += 2;
   }
@@ -243,6 +243,45 @@ EditorLayersWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
   }
 
   return true;
+}
+
+
+bool
+EditorLayersWidget::on_mouse_wheel(const SDL_MouseWheelEvent& wheel)
+{
+  if (m_hovered_item != HoveredItem::NONE)
+  {
+    if((wheel.x < 0 || wheel.y < 0) && !(wheel.x > 0 || wheel.y > 0))
+    {
+      if (m_scroll >= 16)
+      {
+        m_scroll -= 16;
+      }
+      else
+      {
+        m_scroll = 0;
+      }
+    }
+    else if ((wheel.x > 0 || wheel.y > 0) && !(wheel.x < 0 || wheel.y < 0))
+    {
+      if (m_scroll < (static_cast<int>(m_layer_icons.size()) - 1) * 35)
+      {
+        m_scroll += 16;
+      }
+      else
+      {
+        m_scroll = (static_cast<int>(m_layer_icons.size()) - 1) * 35;
+      }
+      
+    }
+  }
+  return false;
+}
+
+bool
+EditorLayersWidget::has_mouse_focus() const
+{
+  return m_hovered_item != HoveredItem::NONE;
 }
 
 void

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -47,7 +47,8 @@ EditorLayersWidget::EditorLayersWidget(Editor& editor) :
   m_sector_text_width(0),
   m_hovered_item(HoveredItem::NONE),
   m_hovered_layer(-1),
-  m_object_tip()
+  m_object_tip(),
+  m_has_mouse_focus(false)
 {
 }
 
@@ -110,10 +111,10 @@ EditorLayersWidget::draw(DrawingContext& context)
   int pos = 0;
   for (const auto& layer_icon : m_layer_icons) {
     if (layer_icon->is_valid()) {
-      if (pos*35 >= m_scroll) {
+      if (pos * 35 >= m_scroll) {
         layer_icon->draw(context, get_layer_coords(pos));
-      } else if ((pos+1)*35 >= m_scroll) {
-        layer_icon->draw(context, get_layer_coords(pos), 35 - (m_scroll - pos*35));
+      } else if ((pos + 1) * 35 >= m_scroll) {
+        layer_icon->draw(context, get_layer_coords(pos), 35 - (m_scroll - pos * 35));
       }
     }
     pos++;
@@ -135,11 +136,11 @@ EditorLayersWidget::update(float dt_sec)
   
   if(m_scroll_speed < 0 && m_scroll > 0)
   {
-    m_scroll -= 2;
+    m_scroll -= 5;
   }
   else if (m_scroll_speed > 0 && m_scroll < (static_cast<int>(m_layer_icons.size()) - 1) * 35)
   {
-    m_scroll += 2;
+    m_scroll += 5;
   }
 }
 
@@ -214,8 +215,13 @@ EditorLayersWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
   if (y < 0 || x > static_cast<float>(m_Width)) {
     m_hovered_item = HoveredItem::NONE;
     m_object_tip = nullptr;
+    m_has_mouse_focus = false;
+    m_scroll_speed = 0;
     return false;
   }
+
+  m_has_mouse_focus = true;
+
   if (x < 0) {
     m_hovered_item = HoveredItem::SPAWNPOINTS;
     m_object_tip = nullptr;
@@ -249,7 +255,7 @@ EditorLayersWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
 bool
 EditorLayersWidget::on_mouse_wheel(const SDL_MouseWheelEvent& wheel)
 {
-  if (m_hovered_item != HoveredItem::NONE)
+  if (m_has_mouse_focus)
   {
     if((wheel.x < 0 || wheel.y < 0) && !(wheel.x > 0 || wheel.y > 0))
     {
@@ -281,7 +287,7 @@ EditorLayersWidget::on_mouse_wheel(const SDL_MouseWheelEvent& wheel)
 bool
 EditorLayersWidget::has_mouse_focus() const
 {
-  return m_hovered_item != HoveredItem::NONE;
+  return m_has_mouse_focus;
 }
 
 void

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -88,6 +88,8 @@ private:
 
   std::unique_ptr<Tip> m_object_tip;
 
+  bool m_has_mouse_focus;
+
 private:
   EditorLayersWidget(const EditorLayersWidget&) = delete;
   EditorLayersWidget& operator=(const EditorLayersWidget&) = delete;

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -49,6 +49,7 @@ public:
   virtual bool on_mouse_button_up(const SDL_MouseButtonEvent& button) override;
   virtual bool on_mouse_button_down(const SDL_MouseButtonEvent& button) override;
   virtual bool on_mouse_motion(const SDL_MouseMotionEvent& motion) override;
+  virtual bool on_mouse_wheel(const SDL_MouseWheelEvent& wheel) override;
 
   virtual void setup() override;
   virtual void resize() override;
@@ -58,6 +59,8 @@ public:
   void refresh_sector_text();
   void sort_layers();
   void add_layer(GameObject* layer);
+
+  bool has_mouse_focus() const;
 
   TileMap* get_selected_tilemap() const { return m_selected_tilemap; }
 

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -74,6 +74,8 @@ private:
   int m_Ypos;
   const int m_Xpos = 32;
   int m_Width;
+  int m_scroll;
+  int m_scroll_speed;
 
   std::string m_sector_text;
   int m_sector_text_width;

--- a/src/editor/object_icon.cpp
+++ b/src/editor/object_icon.cpp
@@ -65,18 +65,25 @@ void
 ObjectIcon::draw(DrawingContext& context, const Vector& pos)
 {
   context.color().draw_surface_scaled(m_surface,
-                                      Rectf(pos + m_offset, pos + Vector(32,32) - m_offset), LAYER_GUI - 9);
+                                      Rectf(
+                                        pos + m_offset,
+                                        pos + Vector(32, 32) - m_offset
+                                      ),
+                                      LAYER_GUI - 9);
 }
 
 void
 ObjectIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
 {
-  auto cropped_surface = m_surface->region(Rect(32-pixels_shown,
+  auto cropped_surface = m_surface->region(Rect(static_cast<float>(32-pixels_shown),
                                                 0,
                                                 32,
                                                 32));
   context.color().draw_surface_scaled(cropped_surface,
-                                      Rectf(pos + Vector(32-pixels_shown,0) + m_offset, pos + Vector(32,32) - m_offset),
+                                      Rectf(
+                                        pos + Vector(static_cast<float>(32 - pixels_shown), 0) + m_offset,
+                                        pos + Vector(32, 32) - m_offset
+                                      ),
                                       LAYER_GUI - 9);
 }
 

--- a/src/editor/object_icon.cpp
+++ b/src/editor/object_icon.cpp
@@ -75,7 +75,7 @@ ObjectIcon::draw(DrawingContext& context, const Vector& pos)
 void
 ObjectIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
 {
-  auto cropped_surface = m_surface->region(Rect(32-pixels_shown,
+  auto cropped_surface = m_surface->region(Rect(32 - pixels_shown,
                                                 0,
                                                 32,
                                                 32));

--- a/src/editor/object_icon.cpp
+++ b/src/editor/object_icon.cpp
@@ -68,4 +68,16 @@ ObjectIcon::draw(DrawingContext& context, const Vector& pos)
                                       Rectf(pos + m_offset, pos + Vector(32,32) - m_offset), LAYER_GUI - 9);
 }
 
+void
+ObjectIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
+{
+  auto cropped_surface = m_surface->region(Rect(32-pixels_shown,
+                                                0,
+                                                32,
+                                                32));
+  context.color().draw_surface_scaled(cropped_surface,
+                                      Rectf(pos + Vector(32-pixels_shown,0) + m_offset, pos + Vector(32,32) - m_offset),
+                                      LAYER_GUI - 9);
+}
+
 /* EOF */

--- a/src/editor/object_icon.cpp
+++ b/src/editor/object_icon.cpp
@@ -75,7 +75,7 @@ ObjectIcon::draw(DrawingContext& context, const Vector& pos)
 void
 ObjectIcon::draw(DrawingContext& context, const Vector& pos, int pixels_shown)
 {
-  auto cropped_surface = m_surface->region(Rect(static_cast<float>(32-pixels_shown),
+  auto cropped_surface = m_surface->region(Rect(32-pixels_shown,
                                                 0,
                                                 32,
                                                 32));

--- a/src/editor/object_icon.hpp
+++ b/src/editor/object_icon.hpp
@@ -33,6 +33,7 @@ public:
   virtual ~ObjectIcon();
 
   virtual void draw(DrawingContext& context, const Vector& pos);
+  virtual void draw(DrawingContext& context, const Vector& pos, int pixels_shown);
 
   std::string get_object_class() const { return m_object_class; }
 


### PR DESCRIPTION
Having dozens of tilemaps and other sector elements is no longer a pain to manage - now you can scroll the toolbar and access those sneaky little icons!

----------

> Urgh! I can't access all my tilemaps! They're going off-screen!

![Screenshot from 2020-09-05 01-19-34](https://user-images.githubusercontent.com/66701383/92298364-78f84e00-ef37-11ea-8f6b-b07804e3859e.png)

> Ah, much better.

![Screenshot from 2020-09-05 01-19-47](https://user-images.githubusercontent.com/66701383/92298362-74cc3080-ef37-11ea-9610-5489f6164a21.png)