### PR TITLE
Cheats in editor

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -18,6 +18,7 @@
 
 #include "audio/sound_manager.hpp"
 #include "control/input_manager.hpp"
+#include "editor/editor.hpp"
 #include "gui/menu_manager.hpp"
 #include "math/vector.hpp"
 #include "object/camera.hpp"
@@ -328,7 +329,9 @@ GameSession::update(float dt_sec, const Controller& controller)
     on_escape_press();
   }
 
-  if (controller.pressed(Control::CHEAT_MENU) && g_config->developer_mode)
+  if (controller.pressed(Control::CHEAT_MENU) &&
+      (g_config->developer_mode || (Editor::current() && Editor::current()->is_testing_level()))
+     )
   {
     if (!MenuManager::instance().is_active())
     {
@@ -337,7 +340,9 @@ GameSession::update(float dt_sec, const Controller& controller)
     }
   }
 
-  if (controller.pressed(Control::DEBUG_MENU) && g_config->developer_mode)
+  if (controller.pressed(Control::DEBUG_MENU) &&
+      (g_config->developer_mode || (Editor::current() && Editor::current()->is_testing_level()))
+     )
   {
     if (!MenuManager::instance().is_active())
     {

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -340,9 +340,7 @@ GameSession::update(float dt_sec, const Controller& controller)
     }
   }
 
-  if (controller.pressed(Control::DEBUG_MENU) &&
-      (g_config->developer_mode || (Editor::current() && Editor::current()->is_testing_level()))
-     )
+  if (controller.pressed(Control::DEBUG_MENU) && g_config->developer_mode)
   {
     if (!MenuManager::instance().is_active())
     {


### PR DESCRIPTION
Closes #1426.

This allows players without developer mode (default in releases) to access the cheat menu when playtesting a level from the editor. It does not allow them to open the cheats menu when playing level regularly.

I should've done that sooner, it was a one-line edit :^)