### PR TITLE
Make badguys' pattern not random-based (WIP)

### DIFF
--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -29,7 +29,7 @@ const float PUFF_INTERVAL_MAX = 8.0f; /**< spawn new puff of smoke at least that
 
 FlyingSnowBall::FlyingSnowBall(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/flying_snowball/flying_snowball.sprite"),
-  normal_propeller_speed(),
+  total_time_elapsed(),
   puff_timer()
 {
   m_physic.enable_gravity(true);
@@ -45,7 +45,6 @@ void
 FlyingSnowBall::activate()
 {
   puff_timer.start(static_cast<float>(gameRandom.randf(PUFF_INTERVAL_MIN, PUFF_INTERVAL_MAX)));
-  normal_propeller_speed = gameRandom.randf(0.95f, 1.05f);
 }
 
 bool
@@ -69,7 +68,8 @@ FlyingSnowBall::collision_solid(const CollisionHit& hit)
 void
 FlyingSnowBall::active_update(float dt_sec)
 {
-
+  total_time_elapsed += dt_sec;
+  
   const float grav = Sector::get().get_gravity() * 100.0f;
   if (get_pos().y > m_start_position.y + 2*32) {
 
@@ -88,7 +88,23 @@ FlyingSnowBall::active_update(float dt_sec)
   } else {
 
     // Flying at acceptable altitude - normal propeller speed
-    m_physic.set_acceleration_y(-grav*normal_propeller_speed);
+
+    float direction = std::pow(std::sin(total_time_elapsed/3.5f), 3.f) +
+                      std::sin(3.f *
+                               ((total_time_elapsed/2.5f - 3.14159f) / 3.f)
+                              ) / 3.f;
+
+    // If you have a graphing calculator, type this :
+    //    sin(x)^3 + sin(3 * (x - pi / 3)) / 3
+    // It seems like a good regular pattern to me, however I didn't implement
+    // it properly here as I didn't want to change the pattern too much (it
+    // should still *look* random unless otherwise recommended.
+    //
+    // I believe a badguy's pattern should be easy to understand and predict,
+    // but I haven't discussed about it yet with the rest of the team.
+    //    ~ Semphris
+
+    m_physic.set_acceleration_y(-grav * (1.f + direction / 13.f));
 
   }
 
@@ -111,9 +127,9 @@ FlyingSnowBall::active_update(float dt_sec)
                                            LAYER_OBJECTS-1);
     puff_timer.start(gameRandom.randf(PUFF_INTERVAL_MIN, PUFF_INTERVAL_MAX));
 
-    normal_propeller_speed = gameRandom.randf(0.95f, 1.05f);
-    m_physic.set_velocity_y(m_physic.get_velocity_y() - 50);
+    //m_physic.set_velocity_y(m_physic.get_velocity_y() - 50);
   }
+  
 }
 
 /* EOF */

--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -17,6 +17,7 @@
 #include "badguy/flyingsnowball.hpp"
 
 #include "math/random.hpp"
+#include "math/util.hpp"
 #include "object/sprite_particle.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
@@ -70,7 +71,7 @@ FlyingSnowBall::collision_solid(const CollisionHit& hit)
 void
 FlyingSnowBall::active_update(float dt_sec)
 {
-  total_time_elapsed += dt_sec;
+  total_time_elapsed = fmodf(total_time_elapsed + dt_sec, math::TAU / GLOBAL_SPEED_MULT);
 
   float delta = total_time_elapsed * GLOBAL_SPEED_MULT;
 
@@ -78,7 +79,7 @@ FlyingSnowBall::active_update(float dt_sec)
   // sin(x)^3 + sin(3(x - pi/3))/3
   float targetHgt = std::pow(std::sin(delta), 3.f) +
                     std::sin(3.f *
-                             ((delta - 3.14159f) / 3.f)
+                             ((delta - math::PI) / 3.f)
                             ) / 3.f;
   targetHgt = targetHgt * 100.f + m_start_position.y;
   m_physic.set_velocity_y(targetHgt - get_pos().y);

--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -25,6 +25,7 @@
 namespace {
 const float PUFF_INTERVAL_MIN = 4.0f; /**< spawn new puff of smoke at most that often */
 const float PUFF_INTERVAL_MAX = 8.0f; /**< spawn new puff of smoke at least that often */
+const float GLOBAL_SPEED_MULT = 0.8f; /**< the overall movement speed/rate */
 }
 
 FlyingSnowBall::FlyingSnowBall(const ReaderMapping& reader) :
@@ -71,11 +72,13 @@ FlyingSnowBall::active_update(float dt_sec)
 {
   total_time_elapsed += dt_sec;
 
+  float delta = total_time_elapsed * GLOBAL_SPEED_MULT;
+
   // Put that function in a graphing calculator :
   // sin(x)^3 + sin(3(x - pi/3))/3
-  float targetHgt = std::pow(std::sin(total_time_elapsed), 3.f) +
+  float targetHgt = std::pow(std::sin(delta), 3.f) +
                     std::sin(3.f *
-                             ((total_time_elapsed - 3.14159f) / 3.f)
+                             ((delta - 3.14159f) / 3.f)
                             ) / 3.f;
   targetHgt = targetHgt * 100.f + m_start_position.y;
   m_physic.set_velocity_y(targetHgt - get_pos().y);

--- a/src/badguy/flyingsnowball.hpp
+++ b/src/badguy/flyingsnowball.hpp
@@ -35,7 +35,7 @@ protected:
   virtual bool collision_squished(GameObject& object) override;
 
 private:
-  float normal_propeller_speed;
+  float total_time_elapsed;
   Timer puff_timer; /**< time until the next smoke puff is spawned */
 
 private:

--- a/src/badguy/skullyhop.cpp
+++ b/src/badguy/skullyhop.cpp
@@ -17,12 +17,9 @@
 #include "badguy/skullyhop.hpp"
 
 #include "audio/sound_manager.hpp"
-#include "math/random.hpp"
 #include "sprite/sprite.hpp"
 
 namespace {
-const float MIN_RECOVER_TIME = 0.1f; /**< minimum time to stand still before starting a (new) jump */
-const float MAX_RECOVER_TIME = 1.0f; /**< maximum time to stand still before starting a (new) jump */
 static const std::string SKULLYHOP_SOUND = "sounds/hop.ogg";
 }
 
@@ -50,8 +47,7 @@ SkullyHop::set_state(SkullyHopState newState)
     m_physic.set_velocity_y(0);
     m_sprite->set_action(m_dir == Direction::LEFT ? "standing-left" : "standing-right");
 
-    float recover_time = gameRandom.randf(MIN_RECOVER_TIME,MAX_RECOVER_TIME);
-    recover_timer.start(recover_time);
+    recover_timer.start(0.5);
   } else
     if (newState == CHARGING) {
       m_sprite->set_action(m_dir == Direction::LEFT ? "charging-left" : "charging-right", 1);


### PR DESCRIPTION
(Edit:) Resolves #959

A badguy that's fun to beat should have a well-defined, easy-to-understand pattern so that new players that aren't well used to the game dont get surprised by a sudden, unexpected change of movement from a badguy.

It also helps speedrunners by not throwing a whole run simply because mister pilot decided it'd hover at the worst height possible and stay there on the best run of the day.

**Currently:**
Pilots accelerate randomly. Each time you load a level, the pilot's pattern will be different.

**At the moment, this PR makes it so that:**
Pilot have a deterministic, but hard-to-predict pattern. That is, playing the same level and going at the same pace should result in similar encounters with the badguys. This solves the speedrunners' problems, but does not yet solve the predictability problem.

**To-do:**
- [x] Make the pilot/flying snowball follow a simple, clearly-defined movement. It could be a simple sine wave movement, or something a bit more complex like this : https://www.desmos.com/calculator/aw4dpgqntf (if link dies, the formula is `sin(x)^3 + sin(3 * (x - pi/3))/3`)
- [x] Investigate and remove randomness from the skullyhops, I've been told they have random movements too.

----------


I opened this draft PR so that people could share their thoughts about what should be done and how. Above are my opinions, but I'd like to hear about other team members, level designers, speedrunners and players too.