### PR TITLE
Improve teleporter dot FPS

### DIFF
--- a/data/images/worldmap/common/teleporterdot.sprite
+++ b/data/images/worldmap/common/teleporterdot.sprite
@@ -2,7 +2,7 @@
   (action
     (name "default")
     (hitbox 16 16 0 0)
-    (fps 3)
+    (fps 10)
     (images "teleporterdot_1.png"
 	    "teleporterdot_2.png"
 	    "teleporterdot_3.png"


### PR DESCRIPTION
I mostly think that the teleporter dot FPS should be increased to 10, but if you think it should be increased to something else or keep the current, please close this pull request. I don't have much info as this is just a FPS increase.