### PR TITLE
Editor autosave

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -42,6 +42,8 @@
 #include "sdk/integration.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "supertux/game_manager.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/level.hpp"
 #include "supertux/level_parser.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -155,7 +157,8 @@ Editor::update(float dt_sec, const Controller& controller)
   // Auto-save (interval)
   if (m_level) {
     m_time_since_last_save += dt_sec;
-    if (m_time_since_last_save >= 10.f) {
+    if (m_time_since_last_save >= static_cast<float>(std::max(
+        g_config->editor_autosave_frequency, 1)) * 60.f) {
       m_time_since_last_save = 0.f;
       std::string backup_filename = get_autosave_from_levelname(m_levelfile);
       std::string directory = get_level_directory();

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -30,6 +30,7 @@
 #include "util/currenton.hpp"
 #include "util/file_system.hpp"
 #include "util/log.hpp"
+#include "util/string_util.hpp"
 #include "video/surface_ptr.hpp"
 
 class GameObject;
@@ -47,6 +48,17 @@ class Editor final : public Screen,
 {
 public:
   static bool is_active();
+
+private:
+  static bool is_autosave_file(const std::string& filename) {
+    return StringUtil::has_suffix(filename, "~");
+  }
+  static std::string get_levelname_from_autosave(const std::string& filename) {
+    return is_autosave_file(filename) ? filename.substr(0, filename.size() - 1) : filename;
+  }
+  static std::string get_autosave_from_levelname(const std::string& filename) {
+    return is_autosave_file(filename) ? filename : filename + "~";
+  }
 
 public:
   static bool s_resaving_in_progress;
@@ -92,6 +104,8 @@ public:
   void open_level_directory();
 
   bool is_testing_level() const { return m_leveltested; }
+
+  void remove_autosave_file();
 
   /** Checks whether the level can be saved and does not contain
       obvious issues (currently: check if main sector and a spawn point
@@ -145,7 +159,7 @@ protected:
   std::unique_ptr<World> m_world;
 
   std::string m_levelfile;
-  std::string m_test_levelfile;
+  std::string m_autosave_levelfile;
 
 public:
   bool m_quit_request;
@@ -179,6 +193,8 @@ private:
   bool m_ignore_sector_change;
   
   bool m_level_first_loaded;
+  
+  float m_time_since_last_save;
 
 private:
   Editor(const Editor&) = delete;

--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -29,12 +29,13 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
-Dialog::Dialog(bool passive) :
+Dialog::Dialog(bool passive, bool auto_clear_dialogs) :
   m_text(),
   m_buttons(),
   m_selected_button(),
   m_cancel_button(-1),
   m_passive(passive),
+  m_clear_diags(auto_clear_dialogs),
   m_text_size()
 {
 }
@@ -258,7 +259,10 @@ Dialog::on_button_click(int button) const
   {
     m_buttons[button].callback();
   }
-  MenuManager::instance().set_dialog({});
+  if (m_clear_diags || button == m_cancel_button)
+  {
+    MenuManager::instance().set_dialog({});
+  }
 }
 
 /* EOF */

--- a/src/gui/dialog.hpp
+++ b/src/gui/dialog.hpp
@@ -43,11 +43,12 @@ private:
   int m_selected_button;
   int m_cancel_button;
   bool m_passive;
+  bool m_clear_diags;
 
   Sizef m_text_size;
 
 public:
-  Dialog(bool passive = false);
+  Dialog(bool passive = false, bool auto_clear_dialogs = true);
   virtual ~Dialog();
 
   void set_text(const std::string& text);

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -61,6 +61,7 @@ Config::Config() :
   enable_discord(false),
   discord_hide_editor(false),
 #endif
+  editor_autosave_frequency(5),
   repository_url()
 {
 }
@@ -92,6 +93,8 @@ Config::load()
     config_integrations_mapping->get("discord_hide_editor", discord_hide_editor);
 #endif
   }
+
+  config_mapping.get("editor_autosave_frequency", editor_autosave_frequency);
 
   EditorOverlayWidget::autotile_help = !developer_mode;
 
@@ -209,7 +212,9 @@ Config::save()
 #endif
   }
   writer.end_list("integrations");
-  
+
+  writer.write("editor_autosave_frequency", editor_autosave_frequency);
+
   if (is_christmas()) {
     writer.write("christmas", christmas_mode);
   }

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -103,6 +103,8 @@ public:
   bool discord_hide_editor;
 #endif
 
+  int editor_autosave_frequency;
+
   std::string repository_url;
 
   bool is_christmas() const {

--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -29,6 +29,8 @@
 #include <physfs.h>
 #include <numeric>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 Level* Level::s_current = nullptr;
 
 Level::Level(bool worldmap) :
@@ -89,7 +91,9 @@ Level::save(const std::string& filepath, bool retry)
 
     Writer writer(filepath);
     save(writer);
-    log_warning << "Level saved as " << filepath << "." << std::endl;
+    log_warning << "Level saved as " << filepath << "." 
+                << (boost::algorithm::ends_with(filepath, "~") ? " [Autosave]" : "")
+                << std::endl;
   } catch(std::exception& e) {
     if (retry) {
       std::stringstream msg;

--- a/src/supertux/menu/editor_level_select_menu.cpp
+++ b/src/supertux/menu/editor_level_select_menu.cpp
@@ -155,7 +155,7 @@ EditorLevelSelectMenu::menu_action(MenuItem& item)
 
     if (PHYSFS_exists((file_name_full + "~").c_str())) {
       auto dialog = std::make_unique<Dialog>(/* passive = */ false, /* auto_clear_dialogs = */ false);
-      dialog->set_text(_("An auto-save file has been found. Would you like to open the auto-save file?\n"));
+      dialog->set_text(_("An auto-save recovery file was found. Would you like to restore the recovery\nfile and resume where you were before the editor crashed?"));
       dialog->clear_buttons();
       dialog->add_default_button(_("Yes"), [this, file_name] {
         open_level(file_name + "~");

--- a/src/supertux/menu/editor_level_select_menu.cpp
+++ b/src/supertux/menu/editor_level_select_menu.cpp
@@ -135,15 +135,43 @@ EditorLevelSelectMenu::create_item(bool worldmap)
 }
 
 void
+EditorLevelSelectMenu::open_level(const std::string& filename)
+{
+  auto editor = Editor::current();
+  editor->set_level(filename);
+  MenuManager::instance().clear_menu_stack();
+}
+
+void
 EditorLevelSelectMenu::menu_action(MenuItem& item)
 {
   auto editor = Editor::current();
   World* world = editor->get_world();
   if (item.get_id() >= 0)
   {
-    editor->set_level(m_levelset->get_level_filename(item.get_id()));
 
-    MenuManager::instance().clear_menu_stack();
+    std::string file_name = m_levelset->get_level_filename(item.get_id());
+    std::string file_name_full = FileSystem::join(editor->get_level_directory(), file_name);
+
+    if (PHYSFS_exists((file_name_full + "~").c_str())) {
+      auto dialog = std::make_unique<Dialog>(/* passive = */ false, /* auto_clear_dialogs = */ false);
+      dialog->set_text(_("An auto-save file has been found. Would you like to open the auto-save file?\n"));
+      dialog->clear_buttons();
+      dialog->add_default_button(_("Yes"), [this, file_name] {
+        open_level(file_name + "~");
+        MenuManager::instance().set_dialog({});
+      });
+      dialog->add_button(_("No"), [this, file_name] {
+        Dialog::show_confirmation(_("This will delete the auto-save file. Are you sure?"), [this, file_name] {
+          open_level(file_name);
+        });
+      });
+      dialog->add_cancel_button(_("Cancel"));
+      MenuManager::instance().set_dialog(std::move(dialog));
+    } else {
+      open_level(file_name);
+    }
+
   } else {
     switch (item.get_id()) {
       case -1:

--- a/src/supertux/menu/editor_level_select_menu.hpp
+++ b/src/supertux/menu/editor_level_select_menu.hpp
@@ -34,6 +34,8 @@ public:
 
   void menu_action(MenuItem& item) override;
 
+  void open_level(const std::string& filename);
+
 private:
   void initialize();
   void create_level();

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -22,6 +22,7 @@
 #include "gui/menu_manager.hpp"
 #include "supertux/level.hpp"
 #include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/menu/menu_storage.hpp"
 #include "util/gettext.hpp"
 #include "video/compositor.hpp"
@@ -68,6 +69,7 @@ EditorMenu::EditorMenu()
   add_toggle(-1, _("Render Light"), &Compositor::s_render_lighting);
   add_toggle(-1, _("Autotile Mode"), &EditorOverlayWidget::autotile_mode);
   add_toggle(-1, _("Enable Autotile Help"), &EditorOverlayWidget::autotile_help);
+  add_intfield(_("Autosave Frequency"), &(g_config->editor_autosave_frequency));
 
   add_submenu(worldmap ? _("Worldmap Settings") : _("Level Settings"),
               MenuStorage::EDITOR_LEVEL_MENU);


### PR DESCRIPTION
Closes #1551 

The new autosave feature will automaticaly save the current level to a backup file (**not** the level file, but a different one) each time the level is tested or at most 5 minutes after the level was last saved/auto-saved (amount of time customizable through the editor pause menu).

If the editor crashes, the recovery file will survive and will be detected by the editor on next launch. Level editors will have the option to open the recovery file or not.
- If they choose to open the recovery file, they must save the file manually to apply the recovery data to the main save file. Not saving before quitting the editor will discard the recovery data permanently.
- If they choose to *not* open the recovery file, the regular file will be opened instead and progress will be where it was at the last *manual* save (Ctrl+S, or through the menu). Although from this point onwards, the recovery file is already assumed to be gone, it will not actually be deleted/overwritten unless the user takes one of the actions listed below.

**The recovery file is deleted when:**
1. _The user saves the level manually._
The recovery file is deleted until a new autosave request is initiated by the game. The reason is that manually saving makes the regular file more recent than the recovery file; the auto-save would then be useless, as it is older than the actual save.

2. _The user quits the editor._
Quitting the editor is considered a normal operation. The user is assumed to be aware of the state of the save file upon quitting the editor (they will be told if their level has unsaved changes and asked to confirm their choice). The recovery file is then needless (no need to offer a user to recover unsaved changes if they explicitly chose to discard them).
