### PR TITLE
Allow sprite animations to continue each other

### DIFF
--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -75,12 +75,18 @@ Sprite::set_action(const std::string& name, int loops)
     return;
   }
 
-  m_action = newaction;
   // If the new action has a loops property,
   // we prefer that over the parameter.
   m_animation_loops = newaction->has_custom_loops ? newaction->loops : loops;
-  m_frame = 0;
-  m_frameidx = 0;
+
+  // Only reset the frames if both actions don't have the same family name
+  if (m_action->family_name != newaction->family_name)
+  {
+    m_frame = 0;
+    m_frameidx = 0;
+  }
+
+  m_action = newaction;
 }
 
 void

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -65,6 +65,12 @@ private:
         has custom loops defined */
     bool has_custom_loops;
 
+    /** A unique identifier that's shared across
+        actions that should continue each other
+        (aka not reset when switching from one
+        to another) */
+    std::string family_name;
+
     std::vector<SurfacePtr> surfaces;
   };
 


### PR DESCRIPTION
Fixes #1462 

Added family-name property to sprites.

Family names are a way for the game to identify sprites that continue each other; when switching between actions with the same family name, animations won't reset.

------

### Technical details

Add an optional property called "family-name" for all sprite actions. For a given sprite, switching between actions with the same family name will remember "progress" in the animation. This will prevent resetting the animation, for example, when flipped.

If the property is absent, the game will assign family names automatically based on links created by the mirror_action and clone_action properties. That means if you have an action, plus another action which is a mirror of the first one, plus another which is a clone of either the first or the second, they will all share the same family name.

Result:
- Two actions with the same family name will make both actions continue (aka not reset) when switching from one to another directly.
- Two actions with different family names or without family names will make animations reset when switching form one to another.
- A mirrored or cloned action without a family name that links to an action without a family name will make the game create a random family name and assign the same to both. (as if they both had the same family name)
- A mirrored or cloned action without a family name that links to an action with a family name will make the mirrored action inherit its linked action's family name. (the mirrored/cloned action will have the same family name as its parent)
- A mirrored or cloned action with a family name that links to an action without a family name will make both actions have different family names, and therefore will cancel the effect of this proposal.