### PR TITLE
Support for zooming from scripting

### DIFF
--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -137,7 +137,13 @@ Camera::Camera(const std::string& name) :
   m_scroll_goal(),
   m_scroll_to_pos(),
   m_scrollspeed(),
-  m_config(std::make_unique<CameraConfig>())
+  m_config(std::make_unique<CameraConfig>()),
+  m_scale(1.f),
+  m_scale_origin(1.f),
+  m_scale_target(1.f),
+  m_scale_time_total(0.f),
+  m_scale_time_remaining(0.f),
+  m_scale_easing()
 {
   reload_config();
 }
@@ -162,7 +168,13 @@ Camera::Camera(const ReaderMapping& reader) :
   m_scroll_goal(),
   m_scroll_to_pos(),
   m_scrollspeed(),
-  m_config(std::make_unique<CameraConfig>())
+  m_config(std::make_unique<CameraConfig>()),
+  m_scale(1.f),
+  m_scale_origin(1.f),
+  m_scale_target(1.f),
+  m_scale_time_total(0.f),
+  m_scale_time_remaining(0.f),
+  m_scale_easing()
 {
   std::string modename;
 
@@ -232,10 +244,11 @@ Camera::after_editor_set()
   }
 }
 
-const Vector&
+const Vector
 Camera::get_translation() const
 {
-  return m_translation;
+  Vector screen_size = Sizef(m_screen_size).as_vector();
+  return m_translation + ((screen_size * (m_scale - 1.f)) / 2.f);
 }
 
 void
@@ -305,6 +318,7 @@ Camera::update(float dt_sec)
     default:
       break;
   }
+  update_scale(dt_sec);
   shake();
 }
 
@@ -594,6 +608,13 @@ Camera::update_scroll_normal(float dt_sec)
       }
     }
 
+    if (m_lookahead_pos.x > RIGHTEND) {
+      m_lookahead_pos.x = RIGHTEND;
+    }
+    if (m_lookahead_pos.x < LEFTEND) {
+      m_lookahead_pos.x = LEFTEND;
+    }
+
     // adjust for level ends
     if (player_pos.x < LEFTEND) {
       m_lookahead_pos.x = LEFTEND;
@@ -674,6 +695,50 @@ Camera::update_scroll_to(float dt_sec)
   }
 
   m_translation = m_scroll_from + (m_scroll_goal - m_scroll_from) * m_scroll_to_pos;
+}
+
+void
+Camera::update_scale(float dt_sec)
+{
+  if (m_scale_time_remaining > 0.f)
+  {
+    m_scale_time_remaining -= dt_sec;
+
+    if (m_scale_time_remaining <= 0.f)
+    {
+      m_scale = m_scale_target;
+      m_scale_time_remaining = 0.f;
+    }
+    else
+    {
+      float progress = (m_scale_time_total - m_scale_time_remaining)
+                                                          / m_scale_time_total;
+      float true_progress = static_cast<float>(m_scale_easing(
+                                               static_cast<double>(progress)));
+      m_scale = m_scale_origin +
+                             (m_scale_target - m_scale_origin) * true_progress;
+    }
+
+    // Re-center camera when zooming
+    m_lookahead_pos /= 1.01f;
+  }
+
+  Vector screen_size = Sizef(m_screen_size).as_vector();
+  m_translation += screen_size * (1.f - m_scale) / 2.f;
+}
+
+void
+Camera::ease_scale(float scale, float time, easing ease)
+{
+  if (time <= 0.f) {
+    m_scale = scale;
+  } else {
+    m_scale_origin = m_scale;
+    m_scale_target = scale;
+    m_scale_time_total = time;
+    m_scale_time_remaining = time;
+    m_scale_easing = ease;
+  }
 }
 
 Vector

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -79,7 +79,7 @@ public:
   void reset(const Vector& tuxpos);
 
   /** return camera position */
-  const Vector& get_translation() const;
+  const Vector get_translation() const;
   void set_translation(const Vector& translation) { m_translation = translation; }
 
   /** shake camera in a direction 1 time */
@@ -97,12 +97,22 @@ public:
   Vector get_center() const;
 
   void set_mode(Mode mode_) { m_mode = mode_; }
+
+  /** get the exact scale at this exact moment */
+  float get_current_scale() { return m_scale; }
+
+  /** get the scale towards which the camera is moving */
+  float get_target_scale() { return m_scale_target; }
+
+  /** smoothly slide the scale of the camera towards a new value */
+  void ease_scale(float scale, float time, easing ease);
   /** @} */
 
 private:
   void update_scroll_normal(float dt_sec);
   void update_scroll_autoscroll(float dt_sec);
   void update_scroll_to(float dt_sec);
+  void update_scale(float dt_sec);
   void keep_in_bounds(Vector& vector);
   void shake();
 
@@ -134,6 +144,13 @@ private:
   float m_scrollspeed;
 
   std::unique_ptr<CameraConfig> m_config;
+
+  float m_scale,
+        m_scale_origin,
+        m_scale_target,
+        m_scale_time_total,
+        m_scale_time_remaining;
+  easing m_scale_easing;
 
 private:
   Camera(const Camera&) = delete;

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -99,10 +99,10 @@ public:
   void set_mode(Mode mode_) { m_mode = mode_; }
 
   /** get the exact scale at this exact moment */
-  float get_current_scale() { return m_scale; }
+  float get_current_scale() const { return m_scale; }
 
   /** get the scale towards which the camera is moving */
-  float get_target_scale() { return m_scale_target; }
+  float get_target_scale() const { return m_scale_target; }
 
   /** smoothly slide the scale of the camera towards a new value */
   void ease_scale(float scale, float time, easing ease);

--- a/src/scripting/camera.cpp
+++ b/src/scripting/camera.cpp
@@ -73,7 +73,7 @@ Camera::scroll_to(float x, float y, float scrolltime)
 float
 Camera::get_current_scale()
 {
-  SCRIPT_GUARD_RETURN(1.f);
+  SCRIPT_GUARD_DEFAULT;
   BIND_SECTOR(::Sector::get());
   return object.get_current_scale();
 }
@@ -81,7 +81,7 @@ Camera::get_current_scale()
 float
 Camera::get_target_scale()
 {
-  SCRIPT_GUARD_RETURN(1.f);
+  SCRIPT_GUARD_DEFAULT;
   BIND_SECTOR(::Sector::get());
   return object.get_target_scale();
 }

--- a/src/scripting/camera.cpp
+++ b/src/scripting/camera.cpp
@@ -70,6 +70,42 @@ Camera::scroll_to(float x, float y, float scrolltime)
   object.scroll_to(Vector(x, y), scrolltime);
 }
 
+float
+Camera::get_current_scale()
+{
+  SCRIPT_GUARD_RETURN(1.f);
+  BIND_SECTOR(::Sector::get());
+  return object.get_current_scale();
+}
+
+float
+Camera::get_target_scale()
+{
+  SCRIPT_GUARD_RETURN(1.f);
+  BIND_SECTOR(::Sector::get());
+  return object.get_target_scale();
+}
+
+void
+Camera::set_scale(float scale)
+{
+  ease_scale(scale, 0, "");
+}
+
+void
+Camera::scale(float scale, float time)
+{
+  ease_scale(scale, time, "");
+}
+
+void
+Camera::ease_scale(float scale, float time, std::string ease)
+{
+  SCRIPT_GUARD_VOID;
+  BIND_SECTOR(::Sector::get());
+  object.ease_scale(scale, time, getEasingByName(EasingMode_from_string(ease)));
+}
+
 } // namespace scripting
 
 /* EOF */

--- a/src/scripting/camera.hpp
+++ b/src/scripting/camera.hpp
@@ -51,6 +51,16 @@ public:
   void set_mode(const std::string& mode);
   /** Scroll camera to position x,y in scrolltime seconds */
   void scroll_to(float x, float y, float scrolltime);
+  /** Get the curent scale factor of the camera */
+  float get_current_scale();
+  /** Get the scale factor the camera is fading towards */
+  float get_target_scale();
+  /** Set the scale factor */
+  void set_scale(float scale);
+  /** Fade the scale factor over time */
+  void scale(float scale, float time);
+  /** Fade the scale factor over time with easing (smooth movement) */
+  void ease_scale(float scale, float time, std::string ease);
 };
 
 } // namespace scripting

--- a/src/scripting/sector.cpp
+++ b/src/scripting/sector.cpp
@@ -16,6 +16,7 @@
 
 #include "scripting/sector.hpp"
 
+#include "math/easing.hpp"
 #include "object/ambient_light.hpp"
 #include "object/music_object.hpp"
 #include "supertux/sector.hpp"

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -576,6 +576,183 @@ static SQInteger Camera_scroll_to_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Camera_get_current_scale_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_current_scale' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Camera*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_current_scale();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_current_scale'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Camera_get_target_scale_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_target_scale' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Camera*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_target_scale();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_target_scale'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Camera_set_scale_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_scale' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Camera*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_scale(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_scale'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Camera_scale_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'scale' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Camera*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->scale(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'scale'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Camera_ease_scale_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_scale' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Camera*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_scale(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_scale'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Candle_release_hook(SQUserPointer ptr, SQInteger )
 {
   auto _this = reinterpret_cast<scripting::Candle*> (ptr);
@@ -8216,6 +8393,41 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnn");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'scroll_to'");
+  }
+
+  sq_pushstring(v, "get_current_scale", -1);
+  sq_newclosure(v, &Camera_get_current_scale_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_current_scale'");
+  }
+
+  sq_pushstring(v, "get_target_scale", -1);
+  sq_newclosure(v, &Camera_get_target_scale_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_target_scale'");
+  }
+
+  sq_pushstring(v, "set_scale", -1);
+  sq_newclosure(v, &Camera_set_scale_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_scale'");
+  }
+
+  sq_pushstring(v, "scale", -1);
+  sq_newclosure(v, &Camera_scale_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'scale'");
+  }
+
+  sq_pushstring(v, "ease_scale", -1);
+  sq_newclosure(v, &Camera_ease_scale_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_scale'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -391,6 +391,7 @@ Sector::draw(DrawingContext& context)
 
   context.push_transform();
   context.set_translation(camera.get_translation());
+  context.scale(camera.get_current_scale());
 
   GameObjectManager::draw(context);
 

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "math/anchor_point.hpp"
+#include "math/easing.hpp"
 #include "squirrel/squirrel_environment.hpp"
 #include "supertux/d_scope.hpp"
 #include "supertux/game_object_manager.hpp"

--- a/src/video/canvas.cpp
+++ b/src/video/canvas.cpp
@@ -127,7 +127,9 @@ Canvas::draw_surface(const SurfacePtr& surface,
   request->blend = blend;
 
   request->srcrects.emplace_back(Rectf(surface->get_region()));
-  request->dstrects.emplace_back(Rectf(apply_translate(position)*scale(), Size(surface->get_width()*scale(), surface->get_height()*scale())));
+  request->dstrects.emplace_back(Rectf(apply_translate(position)*scale(),
+                                 Sizef(static_cast<float>(surface->get_width())*scale(),
+                                       static_cast<float>(surface->get_height())*scale())));
   request->angles.emplace_back(angle);
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();

--- a/src/video/canvas.cpp
+++ b/src/video/canvas.cpp
@@ -127,7 +127,7 @@ Canvas::draw_surface(const SurfacePtr& surface,
   request->blend = blend;
 
   request->srcrects.emplace_back(Rectf(surface->get_region()));
-  request->dstrects.emplace_back(Rectf(apply_translate(position), Size(surface->get_width(), surface->get_height())));
+  request->dstrects.emplace_back(Rectf(apply_translate(position)*scale(), Size(surface->get_width()*scale(), surface->get_height()*scale())));
   request->angles.emplace_back(angle);
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();
@@ -165,7 +165,7 @@ Canvas::draw_surface_part(const SurfacePtr& surface, const Rectf& srcrect, const
   request->blend = style.get_blend();
 
   request->srcrects.emplace_back(srcrect);
-  request->dstrects.emplace_back(apply_translate(dstrect.p1()), dstrect.get_size());
+  request->dstrects.emplace_back(apply_translate(dstrect.p1())*scale(), dstrect.get_size()*scale());
   request->angles.emplace_back(0.0f);
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();
@@ -213,7 +213,7 @@ Canvas::draw_surface_batch(const SurfacePtr& surface,
 
   for (auto& dstrect : request->dstrects)
   {
-    dstrect = Rectf(apply_translate(dstrect.p1()), dstrect.get_size());
+    dstrect = Rectf(apply_translate(dstrect.p1())*scale(), dstrect.get_size()*scale());
   }
 
   request->texture = surface->get_texture().get();
@@ -254,8 +254,8 @@ Canvas::draw_gradient(const Color& top, const Color& bottom, int layer,
   request->top = top;
   request->bottom = bottom;
   request->direction = direction;
-  request->region = Rectf(apply_translate(region.p1()),
-                          apply_translate(region.p2()));
+  request->region = Rectf(apply_translate(region.p1())*scale(),
+                          apply_translate(region.p2())*scale());
 
   m_requests.push_back(request);
 }
@@ -278,8 +278,8 @@ Canvas::draw_filled_rect(const Rectf& rect, const Color& color, float radius, in
   request->flip = m_context.transform().flip;
   request->alpha = m_context.transform().alpha;
 
-  request->rect = Rectf(apply_translate(rect.p1()),
-                        rect.get_size());
+  request->rect = Rectf(apply_translate(rect.p1())*scale(),
+                        rect.get_size()*scale());
   request->color = color;
   request->color.alpha = color.alpha * m_context.transform().alpha;
   request->radius = radius;
@@ -298,10 +298,10 @@ Canvas::draw_inverse_ellipse(const Vector& pos, const Vector& size, const Color&
   request->flip = m_context.transform().flip;
   request->alpha = m_context.transform().alpha;
 
-  request->pos          = apply_translate(pos);
+  request->pos          = apply_translate(pos)*scale();
   request->color        = color;
   request->color.alpha  = color.alpha * m_context.transform().alpha;
-  request->size         = size;
+  request->size         = size*scale();
 
   m_requests.push_back(request);
 }
@@ -317,10 +317,10 @@ Canvas::draw_line(const Vector& pos1, const Vector& pos2, const Color& color, in
   request->flip = m_context.transform().flip;
   request->alpha = m_context.transform().alpha;
 
-  request->pos          = apply_translate(pos1);
+  request->pos          = apply_translate(pos1)*scale();
   request->color        = color;
   request->color.alpha  = color.alpha * m_context.transform().alpha;
-  request->dest_pos     = apply_translate(pos2);
+  request->dest_pos     = apply_translate(pos2)*scale();
 
   m_requests.push_back(request);
 }
@@ -336,9 +336,9 @@ Canvas::draw_triangle(const Vector& pos1, const Vector& pos2, const Vector& pos3
   request->flip = m_context.transform().flip;
   request->alpha = m_context.transform().alpha;
 
-  request->pos1 = apply_translate(pos1);
-  request->pos2 = apply_translate(pos2);
-  request->pos3 = apply_translate(pos3);
+  request->pos1 = apply_translate(pos1)*scale();
+  request->pos2 = apply_translate(pos2)*scale();
+  request->pos3 = apply_translate(pos3)*scale();
   request->color = color;
   request->color.alpha = color.alpha * m_context.transform().alpha;
 
@@ -350,7 +350,7 @@ Canvas::get_pixel(const Vector& position, const std::shared_ptr<Color>& color_ou
 {
   assert(color_out);
 
-  Vector pos = apply_translate(position);
+  Vector pos = apply_translate(position)*scale();
 
   // There is no light offscreen.
   if (pos.x >= static_cast<float>(m_context.get_viewport().get_width()) ||
@@ -377,6 +377,12 @@ Canvas::apply_translate(const Vector& pos) const
   Vector translation = m_context.transform().translation;
   return (pos - translation) + Vector(static_cast<float>(m_context.get_viewport().left),
                                       static_cast<float>(m_context.get_viewport().top));
+}
+
+float
+Canvas::scale() const
+{
+  return m_context.transform().scale;
 }
 
 /* EOF */

--- a/src/video/canvas.cpp
+++ b/src/video/canvas.cpp
@@ -127,9 +127,9 @@ Canvas::draw_surface(const SurfacePtr& surface,
   request->blend = blend;
 
   request->srcrects.emplace_back(Rectf(surface->get_region()));
-  request->dstrects.emplace_back(Rectf(apply_translate(position)*scale(),
-                                 Sizef(static_cast<float>(surface->get_width())*scale(),
-                                       static_cast<float>(surface->get_height())*scale())));
+  request->dstrects.emplace_back(Rectf(apply_translate(position) * scale(),
+                                 Sizef(static_cast<float>(surface->get_width()) * scale(),
+                                       static_cast<float>(surface->get_height()) * scale())));
   request->angles.emplace_back(angle);
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();

--- a/src/video/canvas.hpp
+++ b/src/video/canvas.hpp
@@ -92,6 +92,7 @@ public:
 
 private:
   Vector apply_translate(const Vector& pos) const;
+  float scale() const;
 
 private:
   DrawingContext& m_context;

--- a/src/video/drawing_context.cpp
+++ b/src/video/drawing_context.cpp
@@ -56,8 +56,8 @@ DrawingContext::get_cliprect() const
 {
   return Rectf(get_translation().x,
                get_translation().y,
-               get_translation().x + static_cast<float>(m_viewport.get_width()),
-               get_translation().y + static_cast<float>(m_viewport.get_height()));
+               get_translation().x + static_cast<float>(m_viewport.get_width()) / transform().scale,
+               get_translation().y + static_cast<float>(m_viewport.get_height()) / transform().scale);
 }
 
 void
@@ -109,6 +109,37 @@ DrawingContext::pop_transform()
 {
   m_transform_stack.pop_back();
   assert(!m_transform_stack.empty());
+}
+
+const Rect
+DrawingContext::get_viewport() const
+{
+  Rect tmp(
+    static_cast<int>(static_cast<float>(m_viewport.left) / transform().scale),
+    static_cast<int>(static_cast<float>(m_viewport.top) / transform().scale),
+    static_cast<int>(static_cast<float>(m_viewport.right) / transform().scale),
+    static_cast<int>(static_cast<float>(m_viewport.bottom) / transform().scale)
+  );
+
+  return m_viewport;
+}
+
+int
+DrawingContext::get_width() const
+{
+  return static_cast<int>(static_cast<float>(m_viewport.get_width()) / transform().scale);
+}
+
+int
+DrawingContext::get_height() const
+{
+  return static_cast<int>(static_cast<float>(m_viewport.get_height()) / transform().scale);
+}
+
+Vector
+DrawingContext::get_size() const
+{
+  return Vector(static_cast<float>(get_width()), static_cast<float>(get_height())) * transform().scale;
 }
 
 /* EOF */

--- a/src/video/drawing_context.hpp
+++ b/src/video/drawing_context.hpp
@@ -75,7 +75,7 @@ public:
   void set_translation(const Vector& newtranslation)
   {  transform().translation = newtranslation;  }
 
-  bool get_scale() const { return transform().scale; }
+  float get_scale() const { return transform().scale; }
   void scale(float scale) { transform().scale *= scale; }
 
   /** Apply that flip in the next draws (flips are listed on surface.h). */

--- a/src/video/drawing_context.hpp
+++ b/src/video/drawing_context.hpp
@@ -75,6 +75,9 @@ public:
   void set_translation(const Vector& newtranslation)
   {  transform().translation = newtranslation;  }
 
+  bool get_scale() const { return transform().scale; }
+  void scale(float scale) { transform().scale *= scale; }
+
   /** Apply that flip in the next draws (flips are listed on surface.h). */
   void set_flip(Flip flip);
   Flip get_flip() const;
@@ -94,11 +97,11 @@ public:
     m_viewport = viewport;
   }
 
-  const Rect& get_viewport() const { return m_viewport; }
+  const Rect get_viewport() const;
 
-  int get_width() const { return m_viewport.get_width(); }
-  int get_height() const { return m_viewport.get_height(); }
-  Vector get_size() const { return Vector(static_cast<float>(get_width()), static_cast<float>(get_height())); }
+  int get_width() const;
+  int get_height() const;
+  Vector get_size() const;
   Rectf get_rect() const { return Rectf(Vector(0, 0), get_size()); }
 
   bool use_lightmap() const

--- a/src/video/drawing_transform.hpp
+++ b/src/video/drawing_transform.hpp
@@ -26,11 +26,13 @@ public:
   Vector translation;
   Flip flip;
   float alpha;
+  float scale;
 
   DrawingTransform() :
     translation(),
     flip(NO_FLIP),
-    alpha(1.0f)
+    alpha(1.0f),
+    scale(1.0f)
   {}
 };
 


### PR DESCRIPTION
## Zooming now available to level designers!

![zooming](https://user-images.githubusercontent.com/66701383/96773180-ac9e1300-13d3-11eb-8a81-0f75a3f0fdfe.gif)

If you have a portion of you level that is bigger or smaller, you can now use zooming to increase the effect on the player :)

Accessible from `Camera.set_scale(scale)`, `Camera.scale(scale, time)` and `Camera.ease_scale(scale, time, easing)` where:
- **scale** is a decimal number which is the zoom multiplier. 1 is default zoom, The gif uses 0.75. A smaller number = a larger portion of the level visible to the screen.
- **time** is a decimal number that represent the time it will take to reach the scale.
- **easing** is a string with the name of the easing you want to use, following the format "Ease`[Mode][Direction]`" where "Mode" is the easing mode (Sine, Exponential, Back, Bounce, etc.) and Direction is In, Out, or InOut. For a ful llist of possibilites, see: https://easings.net/ (note that the name are not exactly the name, the order is different). Examples: "EaseSineInOut", "EaseBounceOut", "EaseBackIn"