### PR TITLE
Coyote time

### DIFF
--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -256,6 +256,7 @@ private:
   bool m_jumping;
   bool m_can_jump;
   Timer m_jump_button_timer; /**< started when player presses the jump button; runs until Tux jumps or JUMP_GRACE_TIME runs out */
+  Timer m_coyote_timer; /**< started when Tux falls off a ledge; runs until Tux jumps or COYOTE_TIME runs out */
   bool m_wants_buttjump;
 
 public:

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -65,8 +65,9 @@ TitleScreen::make_tux_jump()
   // Check if we should press the jump button
   Rectf lookahead = tux.get_bbox();
   lookahead.set_right(lookahead.get_right() + 96);
+  lookahead.set_bottom(lookahead.get_bottom() - 2);
   bool pathBlocked = !sector.is_free_of_statics(lookahead);
-  if ((pathBlocked && jumpWasReleased) || !tux.on_ground()) {
+  if ((pathBlocked && jumpWasReleased) || tux.m_fall_mode == Player::FallMode::JUMPING) {
     m_controller->press(Control::JUMP);
     jumpWasReleased = false;
   } else {


### PR DESCRIPTION
Coyote time: If you run and jump from a ledge but press jump just too late, instead of falling of the ledge without jumping, it'll give you a very small amount of extra "gace" time where you can jump despite no longer being on the platform.

This is useful for jumping long ledges where you often have only one chance (as in, if you miss, you fall down and die immediately).