### PR TITLE
Fixed several problems with the sound system

### DIFF
--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -25,14 +25,11 @@ OpenALSoundSource::OpenALSoundSource() :
   m_volume(1.0f)
 {
   alGenSources(1, &m_source);
-  try
-  {
-    SoundManager::check_al_error("Couldn't create audio source: ");
-  }
-  catch(std::exception& e)
-  {
-    log_warning << e.what() << std::endl;
-  }
+
+  // Don't catch anything here: force the caller to catch the error, so that
+  // the caller won't handle an object in an invalid state thinking it's clean
+  SoundManager::check_al_error("Couldn't create audio source: ");
+
   set_reference_distance(128);
 }
 
@@ -86,7 +83,14 @@ void
 OpenALSoundSource::pause()
 {
   alSourcePause(m_source);
-  SoundManager::check_al_error("Couldn't pause audio source: ");
+  try
+  {
+    SoundManager::check_al_error("Couldn't pause audio source: ");
+  }
+  catch(const std::exception& e)
+  {
+    log_warning << e.what() << std::endl;
+  }
 }
 
 void

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -193,7 +193,8 @@ Coin::collision(GameObject& other, const CollisionHit& )
 /* The following defines a coin subject to gravity */
 HeavyCoin::HeavyCoin(const Vector& pos, const Vector& init_velocity) :
   Coin(pos),
-  m_physic()
+  m_physic(),
+  m_last_hit()
 {
   m_physic.enable_gravity(true);
   SoundManager::current()->preload("sounds/coin2.ogg");
@@ -203,7 +204,8 @@ HeavyCoin::HeavyCoin(const Vector& pos, const Vector& init_velocity) :
 
 HeavyCoin::HeavyCoin(const ReaderMapping& reader) :
   Coin(reader),
-  m_physic()
+  m_physic(),
+  m_last_hit()
 {
   m_physic.enable_gravity(true);
   SoundManager::current()->preload("sounds/coin2.ogg");
@@ -222,9 +224,10 @@ HeavyCoin::collision_solid(const CollisionHit& hit)
 {
   float clink_threshold = 100.0f; // sets the minimum speed needed to result in collision noise
   //TODO: colliding HeavyCoins should have their own unique sound
+
   if (hit.bottom) {
-    if (m_physic.get_velocity_y() > clink_threshold)
-      SoundManager::current()->play("sounds/coin2.ogg");
+    if (m_physic.get_velocity_y() > clink_threshold && !m_last_hit.bottom)
+        SoundManager::current()->play("sounds/coin2.ogg");
     if (m_physic.get_velocity_y() > 200) {// lets some coins bounce
       m_physic.set_velocity_y(-99);
     } else {
@@ -233,15 +236,21 @@ HeavyCoin::collision_solid(const CollisionHit& hit)
     }
   }
   if (hit.right || hit.left) {
-    if (m_physic.get_velocity_x() > clink_threshold || m_physic.get_velocity_x() < clink_threshold)
+    if ((m_physic.get_velocity_x() > clink_threshold ||
+         m_physic.get_velocity_x()< -clink_threshold) &&
+         hit.right != m_last_hit.right && hit.left != m_last_hit.left)
       SoundManager::current()->play("sounds/coin2.ogg");
     m_physic.set_velocity_x(-m_physic.get_velocity_x());
   }
   if (hit.top) {
-    if (m_physic.get_velocity_y() < clink_threshold)
+    if (m_physic.get_velocity_y() < -clink_threshold && !m_last_hit.top)
       SoundManager::current()->play("sounds/coin2.ogg");
     m_physic.set_velocity_y(-m_physic.get_velocity_y());
   }
+
+  // Only make a sound if the coin wasn't hittin anything last frame (A coin
+  // stuck in solid matter would flood the sound manager - see #1555 on GitHub)
+  m_last_hit = hit;
 }
 
 void

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -79,6 +79,7 @@ public:
 
 private:
   Physic m_physic;
+  CollisionHit m_last_hit;
 
 private:
   HeavyCoin(const HeavyCoin&) = delete;


### PR DESCRIPTION
Fixes #1555 

This PR fixes no less than four problems I found with the sound system:
- A heavy coin hitting a wall from below or from the right will now only play sound when at the same speed required for hitting to the left or from above (a. k. a., fixed handling of negative values)
- Coins stuck in solid matter will no longer request to play a sound every single frame.
- A sound failing to pause will no longer throw the error back to the main game loop, resulting in an unexpected crash. It will rather be handled on the spot, just like playing, stopping or resuming.
- Oppositely, a sound that fails to be created will no longer silently catch the error and continue the execution normally, but instead will force the caller to handle the error and, as one can logically assume, will not store the audio for further manipulations.

I really need to do that code cleanup, I think.