### PR TITLE
don't spawn Tux in the ground

### DIFF
--- a/data/levels/misc/menu.stl.in
+++ b/data/levels/misc/menu.stl.in
@@ -39,7 +39,7 @@ logo.set_visible(true);
     )
     (spawnpoint
       (name "main")
-      (x 0)
+      (x 96)
       (y 0)
     )
     (tilemap


### PR DESCRIPTION
When returning to the main screen from a world, this warning would appear:
```
[WARNING] src/supertux/sector.cpp:231 [levels/misc/menu.stl] Tried spawning Tux in solid matter. Compensating.
```
Since Tux is always "small" in this level, this code is triggered, which pushes Tux into the ground. By moving the spawnpoint up to match other levels, it pushes Tux to the expected position.

https://github.com/SuperTux/supertux/blob/40d1facdf7e9b674296ee39d8d6dc2d68f86ba08/src/supertux/sector.cpp#L222-L223