### PR TITLE
Fixed bug where ScriptTrigger areas wouldn't save their name

### DIFF
--- a/src/supertux/moving_object.cpp
+++ b/src/supertux/moving_object.cpp
@@ -18,6 +18,7 @@
 
 #include "editor/resize_marker.hpp"
 #include "supertux/sector.hpp"
+#include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
 
 MovingObject::MovingObject() :
@@ -29,6 +30,16 @@ MovingObject::MovingObject(const ReaderMapping& reader) :
   GameObject(reader),
   m_col(COLGROUP_MOVING, *this)
 {
+  float height, width;
+
+  if (reader.get("width", width))
+    m_col.m_bbox.set_width(width);
+
+  if (reader.get("height", height))
+    m_col.m_bbox.set_height(height);
+
+  reader.get("x", m_col.m_bbox.get_left());
+  reader.get("y", m_col.m_bbox.get_top());
 }
 
 MovingObject::~MovingObject()

--- a/src/trigger/scripttrigger.cpp
+++ b/src/trigger/scripttrigger.cpp
@@ -24,6 +24,7 @@
 #include "video/drawing_context.hpp"
 
 ScriptTrigger::ScriptTrigger(const ReaderMapping& reader) :
+  TriggerBase(reader),
   triggerevent(),
   script(),
   new_size(),
@@ -31,14 +32,12 @@ ScriptTrigger::ScriptTrigger(const ReaderMapping& reader) :
   oneshot(false),
   runcount(0)
 {
-  reader.get("x", m_col.m_bbox.get_left());
-  reader.get("y", m_col.m_bbox.get_top());
-  float w = 32, h = 32;
-  reader.get("width", w);
-  reader.get("height", h);
-  m_col.m_bbox.set_size(w, h);
-  new_size.x = w;
-  new_size.y = h;
+  if (m_col.m_bbox.get_width() == 0.f)
+    m_col.m_bbox.set_width(32.f);
+
+  if (m_col.m_bbox.get_height() == 0.f)
+    m_col.m_bbox.set_height(32.f);
+
   reader.get("script", script);
   reader.get("button", must_activate);
   reader.get("oneshot", oneshot);
@@ -53,6 +52,7 @@ ScriptTrigger::ScriptTrigger(const ReaderMapping& reader) :
 }
 
 ScriptTrigger::ScriptTrigger(const Vector& pos, const std::string& script_) :
+  TriggerBase(),
   triggerevent(EVENT_TOUCH),
   script(script_),
   new_size(),
@@ -70,13 +70,8 @@ ScriptTrigger::get_settings()
   new_size.x = m_col.m_bbox.get_width();
   new_size.y = m_col.m_bbox.get_height();
 
-  ObjectSettings result(_("Script Trigger"));
+  ObjectSettings result = TriggerBase::get_settings();
 
-  result.add_text(_("Name"), &m_name);
-  result.add_float(_("Width"), &new_size.x, "width");
-  result.add_float(_("Height"), &new_size.y, "height");
-  result.add_float(_("X"), &m_col.m_bbox.get_left(), "x", {}, OPTION_HIDDEN);
-  result.add_float(_("Y"), &m_col.m_bbox.get_top(), "y", {}, OPTION_HIDDEN);
   result.add_script(_("Script"), &script, "script");
   result.add_bool(_("Button"), &must_activate, "button");
   result.add_bool(_("Oneshot"), &oneshot, "oneshot", false);
@@ -88,7 +83,7 @@ ScriptTrigger::get_settings()
 
 void
 ScriptTrigger::after_editor_set() {
-  m_col.m_bbox.set_size(new_size.x, new_size.y);
+  //m_col.m_bbox.set_size(new_size.x, new_size.y);
   if (must_activate) {
     triggerevent = EVENT_ACTIVATE;
   } else {

--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -29,6 +29,7 @@ public:
   ScriptTrigger(const Vector& pos, const std::string& script);
 
   virtual std::string get_class() const override { return "scripttrigger"; }
+  std::string get_display_name() const override { return _("Script Trigger"); }
   virtual bool has_variable_size() const override { return true; }
 
   virtual ObjectSettings get_settings() override;


### PR DESCRIPTION
Note: Adding the key name to the ObjectSettings on line 75 of src/trigger/scripttrigger.cpp (old version) wasn't enough, I had to refactor the code a bit (made it cleaner too)