### PR TITLE
Added acknowledgements, required by some third-party libraries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ before_build:
     vcpkg install boost-date-time:x86-windows
     vcpkg install boost-filesystem:x86-windows
     vcpkg install boost-format:x86-windows
+    vcpkg install boost-iostreams:x86-windows
     vcpkg install boost-locale:x86-windows
     vcpkg install boost-optional:x86-windows
     vcpkg install boost-system:x86-windows

--- a/appveyor64.yml
+++ b/appveyor64.yml
@@ -32,6 +32,7 @@ before_build:
     vcpkg install boost-date-time:x64-windows
     vcpkg install boost-filesystem:x64-windows
     vcpkg install boost-format:x64-windows
+    vcpkg install boost-iostreams:x64-windows
     vcpkg install boost-locale:x64-windows
     vcpkg install boost-optional:x64-windows
     vcpkg install boost-system:x64-windows

--- a/data/ACKNOWLEDGEMENTS.txt
+++ b/data/ACKNOWLEDGEMENTS.txt
@@ -1,0 +1,263 @@
+
+This is a list of libraries used by SuperTux, with their licenses.
+
+Some licenses require giving proper attribution in executable programs; here
+is where you can find such attribution. If a library is missing, please contact
+the SuperTux Development Team so we can fix this immediately.
+
+-------------------------------------------------------------------------------
+
+
+
+TINYGETTEXT
+===========
+
+tinygettext - A gettext replacement that works directly on .po files
+
+Copyright (c) 2004-2016
+
+    Bastiaan Zapf bzapf@example.org
+    Christoph Sommer mail@christoph-sommer.de
+    Georg Kilzer (leper) leper@wildfiregames.com
+    Ingo Ruhnke grumbel@gmail.com
+    Mathnerd314 mathnerd314.gph@gmail.com
+    Matt McCutchen matt@mattmccutchen.net
+    Matthias Braun matze@braunis.de
+    Nathan Phillip Brink ohnobinki@ohnopublishing.net
+    Poren Chiang ren.chiang@gmail.com
+    Ravu al Hemio ondra.hosek@gmail.com
+    Ryan Flegel rflegel@gmail.com
+    Tim Goya tuxdev103@gmail.com
+    Tobias Markus tobbi.bugs@gmail.com
+    Wolfgang Becker uafr@gmx.de
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use of
+this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject to
+the following restrictions:
+
+  - The origin of this software must not be misrepresented; you must not claim
+    that you wrote the original software. If you use this software in a product,
+    an acknowledgement in the product documentation would be appreciated but is
+    not required.
+  - Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+  - This notice may not be removed or altered from any source distribution.
+
+
+
+SQUIRREL
+========
+
+Copyright (c) 2003-2017 Alberto Demichelis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+GOOGLETEST
+==========
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  - Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+  - Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+SEXP-CPP
+========
+
+SExp - A S-Expression Parser for C++
+Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+              2018 Ingo Ruhnke <grumbel@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+
+PHYSFS
+======
+
+Copyright (c) 2001-2018 Ryan C. Gordon and others.
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from
+the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software in a
+product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+    Ryan C. Gordon <icculus@icculus.org>
+
+
+
+SDL_ttf
+=======
+
+SDL_ttf:  A companion library to SDL for working with TrueType (tm) fonts
+Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+
+
+
+DISCORD-RPC
+===========
+
+Copyright 2017 Discord, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+SDL, SDL_image
+==============
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+
+
+
+LIBRAQM
+=======
+
+The MIT License (MIT)
+
+Copyright © 2015 Information Technology Authority (ITA) <foss@ita.gov.om>
+Copyright © 2016 Khaled Hosny <khaledhosny@eglug.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+FREETYPE
+========
+
+Portions of this software are copyright © <year> The FreeType
+Project (www.freetype.org).  All rights reserved.
+

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -17,10 +17,12 @@
 #include "supertux/command_line_arguments.hpp"
 
 #include <boost/format.hpp>
+#include <boost/iostreams/copy.hpp>
 #include <config.h>
 #include <physfs.h>
 
 #include "editor/overlay_widget.hpp"
+#include "physfs/ifile_stream.hpp"
 #include "supertux/gameconfig.hpp"
 #include "util/gettext.hpp"
 #include "version.h"
@@ -69,6 +71,20 @@ CommandLineArguments::print_datadir() const
 }
 
 void
+CommandLineArguments::print_acknowledgements() const
+{
+  IFileStream in("ACKNOWLEDGEMENTS.txt");
+  if (!in.good())
+  {
+    throw std::runtime_error("Could not find acknowledgement file");
+  }
+  else
+  {
+    boost::iostreams::copy(in, std::cerr);
+  }
+}
+
+void
 CommandLineArguments::print_help(const char* arg0) const
 {
   std::cerr
@@ -78,7 +94,8 @@ CommandLineArguments::print_help(const char* arg0) const
     << _("  -v, --version                Show SuperTux version and quit") << "\n"
     << _("  --verbose                    Print verbose messages") << "\n"
     << _("  --debug                      Print extra verbose messages") << "\n"
-    << _( "  --print-datadir              Print SuperTux's primary data directory.") << "\n"
+    << _("  --print-datadir              Print SuperTux's primary data directory.") << "\n"
+    << _("  --acknowledgements           Print the licenses of libraries used by SuperTux.") << "\n"
     << "\n"
     << _("Video Options:") << "\n"
     << _("  -f, --fullscreen             Run in fullscreen mode") << "\n"
@@ -148,6 +165,10 @@ CommandLineArguments::parse_args(int argc, char** argv)
     else if (arg == "--print-datadir")
     {
       m_action = PRINT_DATADIR;
+    }
+    else if (arg == "--acknowledgements")
+    {
+      m_action = PRINT_ACKNOWLEDGEMENTS;
     }
     else if (arg == "--debug")
     {

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -80,7 +80,9 @@ CommandLineArguments::print_acknowledgements() const
   }
   else
   {
-    boost::iostreams::copy(in, std::cerr);
+    // Boost uses 0 as null pointer contants
+    boost::iostreams::copy(in, std::cerr,
+                boost::iostreams::default_device_buffer_size, nullptr, nullptr);
   }
 }
 

--- a/src/supertux/command_line_arguments.hpp
+++ b/src/supertux/command_line_arguments.hpp
@@ -36,7 +36,8 @@ public:
     NO_ACTION,
     PRINT_VERSION,
     PRINT_HELP,
-    PRINT_DATADIR
+    PRINT_DATADIR,
+    PRINT_ACKNOWLEDGEMENTS
   };
 
 private:
@@ -94,6 +95,7 @@ public:
   void print_help(const char* arg0) const;
   void print_version() const;
   void print_datadir() const;
+  void print_acknowledgements() const;
 
   void merge_into(Config& config);
 

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -619,6 +619,10 @@ Main::run(int argc, char** argv)
         args.print_datadir();
         return 0;
 
+      case CommandLineArguments::PRINT_ACKNOWLEDGEMENTS:
+        args.print_acknowledgements();
+        return 0;
+
       default:
         launch_game(args);
         break;


### PR DESCRIPTION
Some third-party libraries use licenses that require attribution in all copies of the software.

In source form, this isn't a problem, since the licenses are bundled with their respective source code. However, in binary form, all comments are lost and the licenses and acknowledgmeents are gone.

This PR adds a new CLI argument, namingly `--acknowledgements`, that allows the user to list all third-party libraries, as well as their licenses.