### PR TITLE
Improved game speed scripting

### DIFF
--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -436,6 +436,15 @@ int rand()
 
 void set_game_speed(float speed)
 {
+  if (speed < 0.05f)
+  {
+    // Always put a minimum speed above 0 - if the user enabled transitions,
+    // executing transitions would take an unreaonably long time if we allow
+    // game speeds like 0.00001
+    log_warning << "Cannot set game speed to less than 0.05" << std::endl;
+    throw new std::runtime_error("Cannot set game speed to less than 0.05");
+  }
+
   ::g_debug.set_game_speed_multiplier(speed);
 }
 

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -439,6 +439,8 @@ ScreenManager::handle_screen_switch()
       {
         if (current_screen != m_screen_stack.back().get())
         {
+          g_debug.set_game_speed_multiplier(1.f);
+
           if (current_screen != nullptr)
           {
             current_screen->leave();
@@ -494,7 +496,7 @@ ScreenManager::run()
 
     g_real_time = static_cast<float>(ticks) / 1000.0f;
 
-    float speed_multiplier = 1.0f / g_debug.get_game_speed_multiplier();
+    float speed_multiplier = g_debug.get_game_speed_multiplier();
     int steps = elapsed_ticks / ms_per_step;
 
     // Do not calculate more than a few steps at once


### PR DESCRIPTION
Added:
- Minimum value of 0.05 to avoid slowing down the game to unreasonable levels, or freezing the game with a speed of 0, or breaking the game with negative values
- Speed multiplier resets when changing screen (to not propagate the spped multiplier too much)
- Game speed is now a multiplier and not a divisor (A value of 2 means double speed; it used to mean half speed)