### PR TITLE
Added complete scripting support for custom particles

### DIFF
--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -541,7 +541,7 @@ CustomParticleSystem::update(float dt_sec)
   //  update the already existing particles regardless, if any
 
   // Handle easings
-  for (auto req : script_easings)
+  for (auto& req : script_easings)
   {
     req.time_remain -= dt_sec;
     if (req.time_remain <= 0)

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -43,6 +43,7 @@
 
 CustomParticleSystem::CustomParticleSystem() :
   ExposedObject<CustomParticleSystem, scripting::CustomParticles>(this),
+  script_easings(),
   texture_sum_odds(0.f),
   time_last_remaining(0.f),
   m_textures(),

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -550,7 +550,7 @@ CustomParticleSystem::update(float dt_sec)
     else
     {
       float progress = 1.f - (req.time_remain / req.time_total);
-      progress = req.func(progress);
+      progress = static_cast<float>(req.func(progress));
       *(req.value) = req.begin + progress * (req.end - req.begin);
     }
   }

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -43,9 +43,9 @@
 
 CustomParticleSystem::CustomParticleSystem() :
   ExposedObject<CustomParticleSystem, scripting::CustomParticles>(this),
-  script_easings(),
   texture_sum_odds(0.f),
   time_last_remaining(0.f),
+  script_easings(),
   m_textures(),
   custom_particles(),
   m_particle_main_texture("/images/engine/editor/sparkle.png"),
@@ -89,6 +89,7 @@ CustomParticleSystem::CustomParticleSystem(const ReaderMapping& reader) :
   ExposedObject<CustomParticleSystem, scripting::CustomParticles>(this),
   texture_sum_odds(0.f),
   time_last_remaining(0.f),
+  script_easings(),
   m_textures(),
   custom_particles(),
   m_particle_main_texture("/images/engine/editor/sparkle.png"),

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -538,6 +538,23 @@ CustomParticleSystem::update(float dt_sec)
   // "enabled" being false only means new particles shouldn't spawn;
   //  update the already existing particles regardless, if any
 
+  // Handle easings
+  for (auto req : script_easings)
+  {
+    req.time_remain -= dt_sec;
+    if (req.time_remain <= 0)
+    {
+      req.time_remain = 0;
+      *(req.value) = req.end;
+    }
+    else
+    {
+      float progress = 1.f - (req.time_remain / req.time_total);
+      progress = req.func(progress);
+      *(req.value) = req.begin + progress * (req.end - req.begin);
+    }
+  }
+
   // Update existing particles
   for (auto& it : custom_particles) {
     auto particle = dynamic_cast<CustomParticle*>(it.get());
@@ -1206,6 +1223,19 @@ CustomParticleSystem::spawn_particles(float lifetime)
 
 // SCRIPTING
 
+void
+CustomParticleSystem::ease_value(float* value, float target, float time, easing func) {
+  assert(value);
 
+  ease_request req;
+  req.value = value;
+  req.begin = *value;
+  req.end = target;
+  req.time_total = time;
+  req.time_remain = time;
+  req.func = func;
+
+  script_easings.push_back(req);
+}
 
 /* EOF */

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -550,7 +550,7 @@ CustomParticleSystem::update(float dt_sec)
     else
     {
       float progress = 1.f - (req.time_remain / req.time_total);
-      progress = static_cast<float>(req.func(progress));
+      progress = static_cast<float>(req.func(static_cast<double>(progress)));
       *(req.value) = req.begin + progress * (req.end - req.begin);
     }
   }

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -30,6 +30,7 @@ class CustomParticleSystem :
   public ExposedObject<CustomParticleSystem, scripting::CustomParticles>
 {
   friend class ParticleEditor;
+  friend class scripting::CustomParticles;
 public:
   CustomParticleSystem();
   CustomParticleSystem(const ReaderMapping& reader);
@@ -63,6 +64,15 @@ protected:
   CollisionHit get_collision(Particle* particle, const Vector& movement);
 
 private:
+  struct ease_request
+  {
+    float* value;
+    float begin;
+    float end;
+    float time_total;
+    float time_remain;
+    easing func;
+  };
 
   // Local
   void add_particle(float lifetime, float x, float y);
@@ -79,8 +89,11 @@ private:
 public:
   // Scripting
   void clear() { custom_particles.clear(); }
+  void ease_value(float* value, float target, float time, easing func);
 
 private:
+  std::vector<ease_request> script_easings;
+
   enum class RotationMode {
     Fixed,
     Facing,

--- a/src/scripting/custom_particles.cpp
+++ b/src/scripting/custom_particles.cpp
@@ -50,6 +50,7 @@ void CustomParticles::spawn_particles(int amount, bool instantly)
   else
   {
     // TODO
+    log_warning << "Delayed spawn mode not yet implemented for scripting" << std::endl;
   }
 }
 
@@ -85,6 +86,239 @@ void CustomParticles::set_cover_screen(bool cover)
   SCRIPT_GUARD_VOID;
   object.m_cover_screen = cover;
 }
+
+
+
+
+std::string CustomParticles::get_birth_mode()
+{
+  SCRIPT_GUARD_DEFAULT;
+  switch (object.m_particle_birth_mode)
+  {
+  case CustomParticleSystem::FadeMode::None:
+    return "None";
+
+  case CustomParticleSystem::FadeMode::Fade:
+    return "Fade";
+
+  case CustomParticleSystem::FadeMode::Shrink:
+    return "Shrink";
+  
+  default:
+    return "";
+  }
+}
+
+void CustomParticles::set_birth_mode(std::string mode)
+{
+  SCRIPT_GUARD_VOID;
+  if (mode == "None")
+  {
+    object.m_particle_birth_mode = CustomParticleSystem::FadeMode::None;
+  }
+  else if (mode == "Fade")
+  {
+    object.m_particle_birth_mode = CustomParticleSystem::FadeMode::Fade;
+  }
+  else if (mode == "Shrink")
+  {
+    object.m_particle_birth_mode = CustomParticleSystem::FadeMode::Shrink;
+  }
+  else
+  {
+    log_warning << "Invalid option " + mode + "; valid options are: None, Fade, Shrink" << std::endl;
+  }
+}
+
+
+std::string CustomParticles::get_death_mode()
+{
+  SCRIPT_GUARD_DEFAULT;
+  switch (object.m_particle_death_mode)
+  {
+  case CustomParticleSystem::FadeMode::None:
+    return "None";
+
+  case CustomParticleSystem::FadeMode::Fade:
+    return "Fade";
+
+  case CustomParticleSystem::FadeMode::Shrink:
+    return "Shrink";
+  
+  default:
+    return "";
+  }
+}
+
+void CustomParticles::set_death_mode(std::string mode)
+{
+  SCRIPT_GUARD_VOID;
+  if (mode == "None")
+  {
+    object.m_particle_death_mode = CustomParticleSystem::FadeMode::None;
+  }
+  else if (mode == "Fade")
+  {
+    object.m_particle_death_mode = CustomParticleSystem::FadeMode::Fade;
+  }
+  else if (mode == "Shrink")
+  {
+    object.m_particle_death_mode = CustomParticleSystem::FadeMode::Shrink;
+  }
+  else
+  {
+    log_warning << "Invalid option " + mode + "; valid options are: None, Fade, Shrink" << std::endl;
+  }
+}
+
+
+std::string CustomParticles::get_rotation_mode()
+{
+  SCRIPT_GUARD_DEFAULT;
+  switch (object.m_particle_rotation_mode)
+  {
+  case CustomParticleSystem::RotationMode::Fixed:
+    return "Fixed";
+
+  case CustomParticleSystem::RotationMode::Facing:
+    return "Facing";
+
+  case CustomParticleSystem::RotationMode::Wiggling:
+    return "Wiggling";
+  
+  default:
+    return "";
+    break;
+  }
+}
+
+void CustomParticles::set_rotation_mode(std::string mode)
+{
+  SCRIPT_GUARD_VOID;
+  if (mode == "Fixed")
+  {
+    object.m_particle_rotation_mode = CustomParticleSystem::RotationMode::Fixed;
+  }
+  else if (mode == "Facing")
+  {
+    object.m_particle_rotation_mode = CustomParticleSystem::RotationMode::Facing;
+  }
+  else if (mode == "Wiggling")
+  {
+    object.m_particle_rotation_mode = CustomParticleSystem::RotationMode::Wiggling;
+  }
+  else
+  {
+    log_warning << "Invalid option " + mode + "; valid options are: Fixed, Facing, Wiggling" << std::endl;
+  }
+}
+
+
+std::string CustomParticles::get_collision_mode()
+{
+  SCRIPT_GUARD_DEFAULT;
+  switch (object.m_particle_collision_mode)
+  {
+  case CustomParticleSystem::CollisionMode::Ignore:
+    return "Ignore";
+
+  case CustomParticleSystem::CollisionMode::Stick:
+    return "Stick";
+
+  case CustomParticleSystem::CollisionMode::StickForever:
+    return "StickForever";
+
+  case CustomParticleSystem::CollisionMode::BounceHeavy:
+    return "BounceHeavy";
+
+  case CustomParticleSystem::CollisionMode::BounceLight:
+    return "BounceLight";
+
+  case CustomParticleSystem::CollisionMode::Destroy:
+    return "Destroy";
+  
+  default:
+    return "";
+    break;
+  }
+}
+
+void CustomParticles::set_collision_mode(std::string mode)
+{
+  SCRIPT_GUARD_VOID;
+  if (mode == "Ignore")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::Ignore;
+  }
+  else if (mode == "Stick")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::Stick;
+  }
+  else if (mode == "StickForever")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::StickForever;
+  }
+  else if (mode == "BounceHeavy")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::BounceHeavy;
+  }
+  else if (mode == "BounceLight")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::BounceLight;
+  }
+  else if (mode == "Destroy")
+  {
+    object.m_particle_collision_mode = CustomParticleSystem::CollisionMode::Destroy;
+  }
+  else
+  {
+    log_warning << "Invalid option " + mode + "; valid options are: Ignore, Stick, StickForever, BounceHeavy, BounceLight, Destroy" << std::endl;
+  }
+}
+
+
+std::string CustomParticles::get_offscreen_mode()
+{
+  SCRIPT_GUARD_DEFAULT;
+  switch (object.m_particle_offscreen_mode)
+  {
+  case CustomParticleSystem::OffscreenMode::Never:
+    return "Never";
+
+  case CustomParticleSystem::OffscreenMode::OnlyOnExit:
+    return "OnlyOnExit";
+
+  case CustomParticleSystem::OffscreenMode::Always:
+    return "Always";
+  
+  default:
+    return "";
+    break;
+  }
+}
+
+void CustomParticles::set_offscreen_mode(std::string mode)
+{
+  SCRIPT_GUARD_VOID;
+  if (mode == "Never")
+  {
+    object.m_particle_offscreen_mode = CustomParticleSystem::OffscreenMode::Never;
+  }
+  else if (mode == "OnlyOnExit")
+  {
+    object.m_particle_offscreen_mode = CustomParticleSystem::OffscreenMode::OnlyOnExit;
+  }
+  else if (mode == "Always")
+  {
+    object.m_particle_offscreen_mode = CustomParticleSystem::OffscreenMode::Always;
+  }
+  else
+  {
+    log_warning << "Invalid option " + mode + "; valid options are: Never, OnlyOnExit, Always" << std::endl;
+  }
+}
+
+
 
 
 

--- a/src/scripting/custom_particles.cpp
+++ b/src/scripting/custom_particles.cpp
@@ -31,28 +31,698 @@ bool CustomParticles::get_enabled() const
   return object.get_enabled();
 }
 
-void CustomParticles::fade_speed(float speed, float time)
-{
-  //SCRIPT_GUARD_VOID;
-  //object.fade_speed(speed, time);
-}
-
-void CustomParticles::fade_amount(int amount, float time, float time_between)
-{
-  //SCRIPT_GUARD_VOID;
-  //object.fade_amount(amount, time, time_between);
-}
-
-void CustomParticles::set_amount(int amount, float time)
-{
-  //SCRIPT_GUARD_VOID;
-  //object.fade_amount(amount, time);
-}
-
 void CustomParticles::clear()
 {
   SCRIPT_GUARD_VOID;
   object.clear();
+}
+
+void CustomParticles::spawn_particles(int amount, bool instantly)
+{
+  SCRIPT_GUARD_VOID;
+  if (instantly)
+  {
+    for (int i  = 0; i < amount; i++)
+    {
+      object.spawn_particles(0.f);
+    }
+  }
+  else
+  {
+    // TODO
+  }
+}
+
+
+
+// =============================================================================
+// ============================   ATTRIBUTES   =================================
+// =============================================================================
+
+
+
+
+int CustomParticles::get_max_amount()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_max_amount;
+}
+
+void CustomParticles::set_max_amount(int amount)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_max_amount = amount;
+}
+
+bool CustomParticles::get_cover_screen()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_cover_screen;
+}
+
+void CustomParticles::set_cover_screen(bool cover)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_cover_screen = cover;
+}
+
+
+
+
+// =============================================================================
+//   delay
+// -----------------------------------------------------------------------------
+float CustomParticles::get_delay()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_delay;
+}
+
+void CustomParticles::set_delay(float delay)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_delay = delay;
+}
+
+void CustomParticles::fade_delay(float delay, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_delay, delay, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_delay(float delay, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_delay, delay, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   lifetime
+// -----------------------------------------------------------------------------
+float CustomParticles::get_lifetime()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_lifetime;
+}
+
+void CustomParticles::set_lifetime(float lifetime)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_lifetime = lifetime;
+}
+
+void CustomParticles::fade_lifetime(float lifetime, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_lifetime, lifetime, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_lifetime(float lifetime, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_lifetime, lifetime, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   lifetime_variation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_lifetime_variation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_lifetime_variation;
+}
+
+void CustomParticles::set_lifetime_variation(float lifetime_variation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_lifetime_variation = lifetime_variation;
+}
+
+void CustomParticles::fade_lifetime_variation(float lifetime_variation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_lifetime_variation, lifetime_variation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_lifetime_variation(float lifetime_variation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_lifetime_variation, lifetime_variation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   birth_time
+// -----------------------------------------------------------------------------
+float CustomParticles::get_birth_time()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_birth_time;
+}
+
+void CustomParticles::set_birth_time(float birth_time)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_birth_time = birth_time;
+}
+
+void CustomParticles::fade_birth_time(float birth_time, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_birth_time, birth_time, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_birth_time(float birth_time, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_birth_time, birth_time, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   birth_time_variation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_birth_time_variation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_birth_time_variation;
+}
+
+void CustomParticles::set_birth_time_variation(float birth_time_variation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_birth_time_variation = birth_time_variation;
+}
+
+void CustomParticles::fade_birth_time_variation(float birth_time_variation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_birth_time_variation, birth_time_variation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_birth_time_variation(float birth_time_variation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_birth_time_variation, birth_time_variation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   death_time
+// -----------------------------------------------------------------------------
+float CustomParticles::get_death_time()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_death_time;
+}
+
+void CustomParticles::set_death_time(float death_time)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_death_time = death_time;
+}
+
+void CustomParticles::fade_death_time(float death_time, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_death_time, death_time, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_death_time(float death_time, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_death_time, death_time, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   death_time_variation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_death_time_variation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_death_time_variation;
+}
+
+void CustomParticles::set_death_time_variation(float death_time_variation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_death_time_variation = death_time_variation;
+}
+
+void CustomParticles::fade_death_time_variation(float death_time_variation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_death_time_variation, death_time_variation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_death_time_variation(float death_time_variation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_death_time_variation, death_time_variation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   speed_x
+// -----------------------------------------------------------------------------
+float CustomParticles::get_speed_x()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_speed_x;
+}
+
+void CustomParticles::set_speed_x(float speed_x)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_speed_x = speed_x;
+}
+
+void CustomParticles::fade_speed_x(float speed_x, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_x, speed_x, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_speed_x(float speed_x, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_x, speed_x, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   speed_y
+// -----------------------------------------------------------------------------
+float CustomParticles::get_speed_y()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_speed_y;
+}
+
+void CustomParticles::set_speed_y(float speed_y)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_speed_y = speed_y;
+}
+
+void CustomParticles::fade_speed_y(float speed_y, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_y, speed_y, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_speed_y(float speed_y, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_y, speed_y, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   speed_variation_x
+// -----------------------------------------------------------------------------
+float CustomParticles::get_speed_variation_x()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_speed_variation_x;
+}
+
+void CustomParticles::set_speed_variation_x(float speed_variation_x)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_speed_variation_x = speed_variation_x;
+}
+
+void CustomParticles::fade_speed_variation_x(float speed_variation_x, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_variation_x, speed_variation_x, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_speed_variation_x(float speed_variation_x, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_variation_x, speed_variation_x, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   speed_variation_y
+// -----------------------------------------------------------------------------
+float CustomParticles::get_speed_variation_y()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_speed_variation_y;
+}
+
+void CustomParticles::set_speed_variation_y(float speed_variation_y)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_speed_variation_y = speed_variation_y;
+}
+
+void CustomParticles::fade_speed_variation_y(float speed_variation_y, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_variation_y, speed_variation_y, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_speed_variation_y(float speed_variation_y, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_speed_variation_y, speed_variation_y, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   acceleration_x
+// -----------------------------------------------------------------------------
+float CustomParticles::get_acceleration_x()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_acceleration_x;
+}
+
+void CustomParticles::set_acceleration_x(float acceleration_x)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_acceleration_x = acceleration_x;
+}
+
+void CustomParticles::fade_acceleration_x(float acceleration_x, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_acceleration_x, acceleration_x, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_acceleration_x(float acceleration_x, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_acceleration_x, acceleration_x, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   acceleration_y
+// -----------------------------------------------------------------------------
+float CustomParticles::get_acceleration_y()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_acceleration_y;
+}
+
+void CustomParticles::set_acceleration_y(float acceleration_y)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_acceleration_y = acceleration_y;
+}
+
+void CustomParticles::fade_acceleration_y(float acceleration_y, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_acceleration_y, acceleration_y, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_acceleration_y(float acceleration_y, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_acceleration_y, acceleration_y, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   friction_x
+// -----------------------------------------------------------------------------
+float CustomParticles::get_friction_x()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_friction_x;
+}
+
+void CustomParticles::set_friction_x(float friction_x)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_friction_x = friction_x;
+}
+
+void CustomParticles::fade_friction_x(float friction_x, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_friction_x, friction_x, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_friction_x(float friction_x, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_friction_x, friction_x, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   friction_y
+// -----------------------------------------------------------------------------
+float CustomParticles::get_friction_y()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_friction_y;
+}
+
+void CustomParticles::set_friction_y(float friction_y)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_friction_y = friction_y;
+}
+
+void CustomParticles::fade_friction_y(float friction_y, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_friction_y, friction_y, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_friction_y(float friction_y, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_friction_y, friction_y, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   feather_factor
+// -----------------------------------------------------------------------------
+float CustomParticles::get_feather_factor()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_feather_factor;
+}
+
+void CustomParticles::set_feather_factor(float feather_factor)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_feather_factor = feather_factor;
+}
+
+void CustomParticles::fade_feather_factor(float feather_factor, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_feather_factor, feather_factor, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_feather_factor(float feather_factor, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_feather_factor, feather_factor, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation;
+}
+
+void CustomParticles::set_rotation(float rotation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation = rotation;
+}
+
+void CustomParticles::fade_rotation(float rotation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation, rotation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation(float rotation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation, rotation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation_variation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation_variation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation_variation;
+}
+
+void CustomParticles::set_rotation_variation(float rotation_variation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation_variation = rotation_variation;
+}
+
+void CustomParticles::fade_rotation_variation(float rotation_variation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_variation, rotation_variation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation_variation(float rotation_variation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_variation, rotation_variation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation_speed
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation_speed()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation_speed;
+}
+
+void CustomParticles::set_rotation_speed(float rotation_speed)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation_speed = rotation_speed;
+}
+
+void CustomParticles::fade_rotation_speed(float rotation_speed, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_speed, rotation_speed, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation_speed(float rotation_speed, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_speed, rotation_speed, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation_speed_variation
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation_speed_variation()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation_speed_variation;
+}
+
+void CustomParticles::set_rotation_speed_variation(float rotation_speed_variation)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation_speed_variation = rotation_speed_variation;
+}
+
+void CustomParticles::fade_rotation_speed_variation(float rotation_speed_variation, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_speed_variation, rotation_speed_variation, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation_speed_variation(float rotation_speed_variation, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_speed_variation, rotation_speed_variation, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation_acceleration
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation_acceleration()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation_acceleration;
+}
+
+void CustomParticles::set_rotation_acceleration(float rotation_acceleration)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation_acceleration = rotation_acceleration;
+}
+
+void CustomParticles::fade_rotation_acceleration(float rotation_acceleration, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_acceleration, rotation_acceleration, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation_acceleration(float rotation_acceleration, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_acceleration, rotation_acceleration, time, getEasingByName(EasingMode_from_string(easing)));
+}
+
+
+
+// =============================================================================
+//   rotation_decceleration
+// -----------------------------------------------------------------------------
+float CustomParticles::get_rotation_decceleration()
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.m_particle_rotation_decceleration;
+}
+
+void CustomParticles::set_rotation_decceleration(float rotation_decceleration)
+{
+  SCRIPT_GUARD_VOID;
+  object.m_particle_rotation_decceleration = rotation_decceleration;
+}
+
+void CustomParticles::fade_rotation_decceleration(float rotation_decceleration, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_decceleration, rotation_decceleration, time, getEasingByName(EasingMode::EaseNone));
+}
+
+void CustomParticles::ease_rotation_decceleration(float rotation_decceleration, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_value(&object.m_particle_rotation_decceleration, rotation_decceleration, time, getEasingByName(EasingMode_from_string(easing)));
 }
 
 } // namespace scripting

--- a/src/scripting/custom_particles.cpp
+++ b/src/scripting/custom_particles.cpp
@@ -188,7 +188,6 @@ std::string CustomParticles::get_rotation_mode()
   
   default:
     return "";
-    break;
   }
 }
 
@@ -239,7 +238,6 @@ std::string CustomParticles::get_collision_mode()
   
   default:
     return "";
-    break;
   }
 }
 
@@ -293,7 +291,6 @@ std::string CustomParticles::get_offscreen_mode()
   
   default:
     return "";
-    break;
   }
 }
 

--- a/src/scripting/custom_particles.hpp
+++ b/src/scripting/custom_particles.hpp
@@ -43,17 +43,150 @@ public:
   void set_enabled(bool enable);
   bool get_enabled() const;
 
-  /** Smoothly changes the rain speed to the given value */
-  void fade_speed(float speed, float time);
-
-  /** Smoothly changes the amount of particles to the given value */
-  void fade_amount(int amount, float time, float time_between);
-
-  /** Smoothly changes the amount of particles to the given value */
-  void set_amount(int amount, float time);
-
   /** Instantly removes all particles of that type on the screen */
   void clear();
+
+  /**
+   * Spawns particles regardless of whether or not the particles are enabled.
+   * If "instantly" is true, disregard the delay settings.
+   */
+  void spawn_particles(int amount, bool instantly);
+
+
+
+  int get_max_amount();
+  void set_max_amount(int amount);
+
+// TODO: Implement these
+/*
+  std::string get_birth_mode();
+  void set_birth_mode(std::string mode);
+
+  std::string get_death_mode();
+  void set_death_mode(std::string mode);
+
+  std::string get_rotation_mode();
+  void set_rotation_mode(std::string mode);
+
+  std::string get_collision_mode();
+  void set_collision_mode(std::string mode);
+
+  std::string get_offscreen_mode();
+  void set_offscreen_mode(std::string mode);
+*/
+  bool get_cover_screen();
+  void set_cover_screen(bool cover);
+
+  float get_delay();
+  void set_delay(float delay);
+  void fade_delay(float delay, float time);
+  void ease_delay(float delay, float time, std::string easing);
+
+  float get_lifetime();
+  void set_lifetime(float lifetime);
+  void fade_lifetime(float lifetime, float time);
+  void ease_lifetime(float lifetime, float time, std::string easing);
+
+  float get_lifetime_variation();
+  void set_lifetime_variation(float lifetime_variation);
+  void fade_lifetime_variation(float lifetime_variation, float time);
+  void ease_lifetime_variation(float lifetime_variation, float time, std::string easing);
+
+  float get_birth_time();
+  void set_birth_time(float birth_time);
+  void fade_birth_time(float birth_time, float time);
+  void ease_birth_time(float birth_time, float time, std::string easing);
+
+  float get_birth_time_variation();
+  void set_birth_time_variation(float birth_time_variation);
+  void fade_birth_time_variation(float birth_time_variation, float time);
+  void ease_birth_time_variation(float birth_time_variation, float time, std::string easing);
+
+  float get_death_time();
+  void set_death_time(float death_time);
+  void fade_death_time(float death_time, float time);
+  void ease_death_time(float death_time, float time, std::string easing);
+
+  float get_death_time_variation();
+  void set_death_time_variation(float death_time_variation);
+  void fade_death_time_variation(float death_time_variation, float time);
+  void ease_death_time_variation(float death_time_variation, float time, std::string easing);
+
+  float get_speed_x();
+  void set_speed_x(float speed_x);
+  void fade_speed_x(float speed_x, float time);
+  void ease_speed_x(float speed_x, float time, std::string easing);
+
+  float get_speed_y();
+  void set_speed_y(float speed_y);
+  void fade_speed_y(float speed_y, float time);
+  void ease_speed_y(float speed_y, float time, std::string easing);
+
+  float get_speed_variation_x();
+  void set_speed_variation_x(float speed_variation_x);
+  void fade_speed_variation_x(float speed_variation_x, float time);
+  void ease_speed_variation_x(float speed_variation_x, float time, std::string easing);
+
+  float get_speed_variation_y();
+  void set_speed_variation_y(float speed_variation_y);
+  void fade_speed_variation_y(float speed_variation_y, float time);
+  void ease_speed_variation_y(float speed_variation_y, float time, std::string easing);
+
+  float get_acceleration_x();
+  void set_acceleration_x(float acceleration_x);
+  void fade_acceleration_x(float acceleration_x, float time);
+  void ease_acceleration_x(float acceleration_x, float time, std::string easing);
+
+  float get_acceleration_y();
+  void set_acceleration_y(float acceleration_y);
+  void fade_acceleration_y(float acceleration_y, float time);
+  void ease_acceleration_y(float acceleration_y, float time, std::string easing);
+
+  float get_friction_x();
+  void set_friction_x(float friction_x);
+  void fade_friction_x(float friction_x, float time);
+  void ease_friction_x(float friction_x, float time, std::string easing);
+
+  float get_friction_y();
+  void set_friction_y(float friction_y);
+  void fade_friction_y(float friction_y, float time);
+  void ease_friction_y(float friction_y, float time, std::string easing);
+
+  float get_feather_factor();
+  void set_feather_factor(float feather_factor);
+  void fade_feather_factor(float feather_factor, float time);
+  void ease_feather_factor(float feather_factor, float time, std::string easing);
+
+  float get_rotation();
+  void set_rotation(float rotation);
+  void fade_rotation(float rotation, float time);
+  void ease_rotation(float rotation, float time, std::string easing);
+
+  float get_rotation_variation();
+  void set_rotation_variation(float rotation_variation);
+  void fade_rotation_variation(float rotation_variation, float time);
+  void ease_rotation_variation(float rotation_variation, float time, std::string easing);
+
+  float get_rotation_speed();
+  void set_rotation_speed(float rotation_speed);
+  void fade_rotation_speed(float rotation_speed, float time);
+  void ease_rotation_speed(float rotation_speed, float time, std::string easing);
+
+  float get_rotation_speed_variation();
+  void set_rotation_speed_variation(float rotation_speed_variation);
+  void fade_rotation_speed_variation(float rotation_speed_variation, float time);
+  void ease_rotation_speed_variation(float rotation_speed_variation, float time, std::string easing);
+
+  float get_rotation_acceleration();
+  void set_rotation_acceleration(float rotation_acceleration);
+  void fade_rotation_acceleration(float rotation_acceleration, float time);
+  void ease_rotation_acceleration(float rotation_acceleration, float time, std::string easing);
+
+  float get_rotation_decceleration();
+  void set_rotation_decceleration(float rotation_decceleration);
+  void fade_rotation_decceleration(float rotation_decceleration, float time);
+  void ease_rotation_decceleration(float rotation_decceleration, float time, std::string easing);
+
 };
 
 } // namespace scripting

--- a/src/scripting/custom_particles.hpp
+++ b/src/scripting/custom_particles.hpp
@@ -57,8 +57,6 @@ public:
   int get_max_amount();
   void set_max_amount(int amount);
 
-// TODO: Implement these
-/*
   std::string get_birth_mode();
   void set_birth_mode(std::string mode);
 
@@ -73,7 +71,7 @@ public:
 
   std::string get_offscreen_mode();
   void set_offscreen_mode(std::string mode);
-*/
+
   bool get_cover_screen();
   void set_cover_screen(bool cover);
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -4395,117 +4395,7 @@ static SQInteger CustomParticles_set_rotation_variation_wrapper(HSQUIRRELVM vm)
 
 }
 
-<<<<<<< HEAD
-static SQInteger Player_get_x_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'get_x' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-
-  try {
-    float return_value = _this->get_x();
-
-    sq_pushfloat(vm, return_value);
-    return 1;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_x'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Player_get_y_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'get_y' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-
-  try {
-    float return_value = _this->get_y();
-
-    sq_pushfloat(vm, return_value);
-    return 1;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_y'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Player_set_pos_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'set_pos' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-  SQFloat arg0;
-  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not a float"));
-    return SQ_ERROR;
-  }
-  SQFloat arg1;
-  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a float"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->set_pos(static_cast<float> (arg0), static_cast<float> (arg1));
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_pos'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Rain_release_hook(SQUserPointer ptr, SQInteger )
-{
-  auto _this = reinterpret_cast<scripting::Rain*> (ptr);
-  delete _this;
-  return 0;
-}
-
-static SQInteger Rain_set_enabled_wrapper(HSQUIRRELVM vm)
-=======
 static SQInteger CustomParticles_fade_rotation_variation_wrapper(HSQUIRRELVM vm)
->>>>>>> Added near-complete scripting support for custom particles
 {
   SQUserPointer data;
   if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
@@ -7637,6 +7527,105 @@ static SQInteger Player_get_velocity_y_wrapper(HSQUIRRELVM vm)
     return SQ_ERROR;
   } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_velocity_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_get_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_get_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_set_pos_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_pos' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_pos(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_pos'"));
     return SQ_ERROR;
   }
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -1311,128 +1311,6 @@ static SQInteger CustomParticles_get_enabled_wrapper(HSQUIRRELVM vm)
 
 }
 
-static SQInteger CustomParticles_fade_speed_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'fade_speed' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-  SQFloat arg0;
-  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not a float"));
-    return SQ_ERROR;
-  }
-  SQFloat arg1;
-  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a float"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->fade_speed(static_cast<float> (arg0), static_cast<float> (arg1));
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger CustomParticles_fade_amount_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'fade_amount' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-  SQInteger arg0;
-  if(SQ_FAILED(sq_getinteger(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not an integer"));
-    return SQ_ERROR;
-  }
-  SQFloat arg1;
-  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a float"));
-    return SQ_ERROR;
-  }
-  SQFloat arg2;
-  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
-    sq_throwerror(vm, _SC("Argument 3 not a float"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->fade_amount(static_cast<int> (arg0), static_cast<float> (arg1), static_cast<float> (arg2));
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_amount'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger CustomParticles_set_amount_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'set_amount' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-  SQInteger arg0;
-  if(SQ_FAILED(sq_getinteger(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not an integer"));
-    return SQ_ERROR;
-  }
-  SQFloat arg1;
-  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a float"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->set_amount(static_cast<int> (arg0), static_cast<float> (arg1));
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_amount'"));
-    return SQ_ERROR;
-  }
-
-}
-
 static SQInteger CustomParticles_clear_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -1457,6 +1335,3517 @@ static SQInteger CustomParticles_clear_wrapper(HSQUIRRELVM vm)
     return SQ_ERROR;
   } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'clear'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_spawn_particles_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'spawn_particles' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQInteger arg0;
+  if(SQ_FAILED(sq_getinteger(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not an integer"));
+    return SQ_ERROR;
+  }
+  SQBool arg1;
+  if(SQ_FAILED(sq_getbool(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a bool"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->spawn_particles(static_cast<int> (arg0), arg1 == SQTrue);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'spawn_particles'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_max_amount_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_max_amount' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    int return_value = _this->get_max_amount();
+
+    sq_pushinteger(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_max_amount'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_max_amount_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_max_amount' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQInteger arg0;
+  if(SQ_FAILED(sq_getinteger(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not an integer"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_max_amount(static_cast<int> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_max_amount'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_cover_screen_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_cover_screen' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    bool return_value = _this->get_cover_screen();
+
+    sq_pushbool(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_cover_screen'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_cover_screen_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_cover_screen' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQBool arg0;
+  if(SQ_FAILED(sq_getbool(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a bool"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_cover_screen(arg0 == SQTrue);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_cover_screen'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_delay_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_delay' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_delay();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_delay'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_delay_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_delay' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_delay(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_delay'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_delay_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_delay' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_delay(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_delay'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_delay_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_delay' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_delay(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_delay'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_lifetime_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_lifetime' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_lifetime();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_lifetime'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_lifetime_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_lifetime' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_lifetime(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_lifetime'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_lifetime_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_lifetime' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_lifetime(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_lifetime'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_lifetime_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_lifetime' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_lifetime(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_lifetime'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_lifetime_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_lifetime_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_lifetime_variation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_lifetime_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_lifetime_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_lifetime_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_lifetime_variation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_lifetime_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_lifetime_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_lifetime_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_lifetime_variation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_lifetime_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_lifetime_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_lifetime_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_lifetime_variation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_lifetime_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_birth_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_birth_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_birth_time();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_birth_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_birth_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_birth_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_birth_time(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_birth_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_birth_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_birth_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_birth_time(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_birth_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_birth_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_birth_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_birth_time(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_birth_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_birth_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_birth_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_birth_time_variation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_birth_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_birth_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_birth_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_birth_time_variation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_birth_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_birth_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_birth_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_birth_time_variation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_birth_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_birth_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_birth_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_birth_time_variation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_birth_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_death_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_death_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_death_time();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_death_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_death_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_death_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_death_time(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_death_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_death_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_death_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_death_time(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_death_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_death_time_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_death_time' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_death_time(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_death_time'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_death_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_death_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_death_time_variation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_death_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_death_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_death_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_death_time_variation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_death_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_death_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_death_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_death_time_variation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_death_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_death_time_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_death_time_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_death_time_variation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_death_time_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_speed_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_speed_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_speed_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_speed_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_speed_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_speed_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_speed_x(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_speed_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_speed_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_speed_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_speed_x(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_speed_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_speed_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_speed_x(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_speed_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_speed_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_speed_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_speed_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_speed_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_speed_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_speed_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_speed_y(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_speed_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_speed_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_speed_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_speed_y(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_speed_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_speed_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_speed_y(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_speed_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_speed_variation_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_speed_variation_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_speed_variation_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_speed_variation_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_speed_variation_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_speed_variation_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_speed_variation_x(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_speed_variation_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_speed_variation_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_speed_variation_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_speed_variation_x(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed_variation_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_speed_variation_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_speed_variation_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_speed_variation_x(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_speed_variation_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_speed_variation_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_speed_variation_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_speed_variation_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_speed_variation_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_speed_variation_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_speed_variation_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_speed_variation_y(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_speed_variation_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_speed_variation_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_speed_variation_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_speed_variation_y(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed_variation_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_speed_variation_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_speed_variation_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_speed_variation_y(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_speed_variation_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_acceleration_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_acceleration_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_acceleration_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_acceleration_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_acceleration_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_acceleration_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_acceleration_x(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_acceleration_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_acceleration_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_acceleration_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_acceleration_x(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_acceleration_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_acceleration_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_acceleration_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_acceleration_x(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_acceleration_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_acceleration_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_acceleration_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_acceleration_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_acceleration_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_acceleration_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_acceleration_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_acceleration_y(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_acceleration_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_acceleration_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_acceleration_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_acceleration_y(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_acceleration_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_acceleration_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_acceleration_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_acceleration_y(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_acceleration_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_friction_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_friction_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_friction_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_friction_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_friction_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_friction_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_friction_x(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_friction_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_friction_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_friction_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_friction_x(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_friction_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_friction_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_friction_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_friction_x(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_friction_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_friction_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_friction_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_friction_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_friction_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_friction_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_friction_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_friction_y(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_friction_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_friction_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_friction_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_friction_y(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_friction_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_friction_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_friction_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_friction_y(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_friction_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_feather_factor_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_feather_factor' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_feather_factor();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_feather_factor'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_feather_factor_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_feather_factor' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_feather_factor(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_feather_factor'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_feather_factor_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_feather_factor' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_feather_factor(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_feather_factor'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_feather_factor_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_feather_factor' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_feather_factor(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_feather_factor'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_rotation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation_variation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_variation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+<<<<<<< HEAD
+static SQInteger Player_get_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_get_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_y'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_set_pos_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_pos' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Player*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_pos(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_pos'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Rain_release_hook(SQUserPointer ptr, SQInteger )
+{
+  auto _this = reinterpret_cast<scripting::Rain*> (ptr);
+  delete _this;
+  return 0;
+}
+
+static SQInteger Rain_set_enabled_wrapper(HSQUIRRELVM vm)
+=======
+static SQInteger CustomParticles_fade_rotation_variation_wrapper(HSQUIRRELVM vm)
+>>>>>>> Added near-complete scripting support for custom particles
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation_variation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation_variation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation_speed();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_speed(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_rotation_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation_speed(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation_speed(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_speed_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_speed_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation_speed_variation();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_speed_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_speed_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_speed_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_speed_variation(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_speed_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_rotation_speed_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation_speed_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation_speed_variation(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation_speed_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_speed_variation_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation_speed_variation' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation_speed_variation(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation_speed_variation'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_acceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_acceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation_acceleration();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_acceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_acceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_acceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_acceleration(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_acceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_rotation_acceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation_acceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation_acceleration(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation_acceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_acceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation_acceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation_acceleration(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation_acceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_decceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_decceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_rotation_decceleration();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_decceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_decceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_decceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_decceleration(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_decceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_fade_rotation_decceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_rotation_decceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_rotation_decceleration(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_rotation_decceleration'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_ease_rotation_decceleration_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_rotation_decceleration' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_rotation_decceleration(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_rotation_decceleration'"));
     return SQ_ERROR;
   }
 
@@ -3923,105 +7312,6 @@ static SQInteger Player_get_velocity_y_wrapper(HSQUIRRELVM vm)
     return SQ_ERROR;
   } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_velocity_y'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Player_get_x_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'get_x' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-
-  try {
-    float return_value = _this->get_x();
-
-    sq_pushfloat(vm, return_value);
-    return 1;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_x'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Player_get_y_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'get_y' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-
-  try {
-    float return_value = _this->get_y();
-
-    sq_pushfloat(vm, return_value);
-    return 1;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_y'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Player_set_pos_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
-    sq_throwerror(vm, _SC("'set_pos' called without instance"));
-    return SQ_ERROR;
-  }
-  auto _this = reinterpret_cast<scripting::Player*> (data);
-
-  if (_this == nullptr) {
-    return SQ_ERROR;
-  }
-
-  SQFloat arg0;
-  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not a float"));
-    return SQ_ERROR;
-  }
-  SQFloat arg1;
-  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a float"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->set_pos(static_cast<float> (arg0), static_cast<float> (arg1));
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_pos'"));
     return SQ_ERROR;
   }
 
@@ -9644,32 +12934,662 @@ void register_supertux_wrapper(HSQUIRRELVM v)
     throw SquirrelError(v, "Couldn't register function 'get_enabled'");
   }
 
-  sq_pushstring(v, "fade_speed", -1);
-  sq_newclosure(v, &CustomParticles_fade_speed_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
-  if(SQ_FAILED(sq_createslot(v, -3))) {
-    throw SquirrelError(v, "Couldn't register function 'fade_speed'");
-  }
-
-  sq_pushstring(v, "fade_amount", -1);
-  sq_newclosure(v, &CustomParticles_fade_amount_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tinn");
-  if(SQ_FAILED(sq_createslot(v, -3))) {
-    throw SquirrelError(v, "Couldn't register function 'fade_amount'");
-  }
-
-  sq_pushstring(v, "set_amount", -1);
-  sq_newclosure(v, &CustomParticles_set_amount_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tin");
-  if(SQ_FAILED(sq_createslot(v, -3))) {
-    throw SquirrelError(v, "Couldn't register function 'set_amount'");
-  }
-
   sq_pushstring(v, "clear", -1);
   sq_newclosure(v, &CustomParticles_clear_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'clear'");
+  }
+
+  sq_pushstring(v, "spawn_particles", -1);
+  sq_newclosure(v, &CustomParticles_spawn_particles_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tib");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'spawn_particles'");
+  }
+
+  sq_pushstring(v, "get_max_amount", -1);
+  sq_newclosure(v, &CustomParticles_get_max_amount_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_max_amount'");
+  }
+
+  sq_pushstring(v, "set_max_amount", -1);
+  sq_newclosure(v, &CustomParticles_set_max_amount_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ti");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_max_amount'");
+  }
+
+  sq_pushstring(v, "get_cover_screen", -1);
+  sq_newclosure(v, &CustomParticles_get_cover_screen_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_cover_screen'");
+  }
+
+  sq_pushstring(v, "set_cover_screen", -1);
+  sq_newclosure(v, &CustomParticles_set_cover_screen_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tb");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_cover_screen'");
+  }
+
+  sq_pushstring(v, "get_delay", -1);
+  sq_newclosure(v, &CustomParticles_get_delay_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_delay'");
+  }
+
+  sq_pushstring(v, "set_delay", -1);
+  sq_newclosure(v, &CustomParticles_set_delay_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_delay'");
+  }
+
+  sq_pushstring(v, "fade_delay", -1);
+  sq_newclosure(v, &CustomParticles_fade_delay_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_delay'");
+  }
+
+  sq_pushstring(v, "ease_delay", -1);
+  sq_newclosure(v, &CustomParticles_ease_delay_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_delay'");
+  }
+
+  sq_pushstring(v, "get_lifetime", -1);
+  sq_newclosure(v, &CustomParticles_get_lifetime_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_lifetime'");
+  }
+
+  sq_pushstring(v, "set_lifetime", -1);
+  sq_newclosure(v, &CustomParticles_set_lifetime_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_lifetime'");
+  }
+
+  sq_pushstring(v, "fade_lifetime", -1);
+  sq_newclosure(v, &CustomParticles_fade_lifetime_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_lifetime'");
+  }
+
+  sq_pushstring(v, "ease_lifetime", -1);
+  sq_newclosure(v, &CustomParticles_ease_lifetime_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_lifetime'");
+  }
+
+  sq_pushstring(v, "get_lifetime_variation", -1);
+  sq_newclosure(v, &CustomParticles_get_lifetime_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_lifetime_variation'");
+  }
+
+  sq_pushstring(v, "set_lifetime_variation", -1);
+  sq_newclosure(v, &CustomParticles_set_lifetime_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_lifetime_variation'");
+  }
+
+  sq_pushstring(v, "fade_lifetime_variation", -1);
+  sq_newclosure(v, &CustomParticles_fade_lifetime_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_lifetime_variation'");
+  }
+
+  sq_pushstring(v, "ease_lifetime_variation", -1);
+  sq_newclosure(v, &CustomParticles_ease_lifetime_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_lifetime_variation'");
+  }
+
+  sq_pushstring(v, "get_birth_time", -1);
+  sq_newclosure(v, &CustomParticles_get_birth_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_birth_time'");
+  }
+
+  sq_pushstring(v, "set_birth_time", -1);
+  sq_newclosure(v, &CustomParticles_set_birth_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_birth_time'");
+  }
+
+  sq_pushstring(v, "fade_birth_time", -1);
+  sq_newclosure(v, &CustomParticles_fade_birth_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_birth_time'");
+  }
+
+  sq_pushstring(v, "ease_birth_time", -1);
+  sq_newclosure(v, &CustomParticles_ease_birth_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_birth_time'");
+  }
+
+  sq_pushstring(v, "get_birth_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_get_birth_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_birth_time_variation'");
+  }
+
+  sq_pushstring(v, "set_birth_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_set_birth_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_birth_time_variation'");
+  }
+
+  sq_pushstring(v, "fade_birth_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_fade_birth_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_birth_time_variation'");
+  }
+
+  sq_pushstring(v, "ease_birth_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_ease_birth_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_birth_time_variation'");
+  }
+
+  sq_pushstring(v, "get_death_time", -1);
+  sq_newclosure(v, &CustomParticles_get_death_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_death_time'");
+  }
+
+  sq_pushstring(v, "set_death_time", -1);
+  sq_newclosure(v, &CustomParticles_set_death_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_death_time'");
+  }
+
+  sq_pushstring(v, "fade_death_time", -1);
+  sq_newclosure(v, &CustomParticles_fade_death_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_death_time'");
+  }
+
+  sq_pushstring(v, "ease_death_time", -1);
+  sq_newclosure(v, &CustomParticles_ease_death_time_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_death_time'");
+  }
+
+  sq_pushstring(v, "get_death_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_get_death_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_death_time_variation'");
+  }
+
+  sq_pushstring(v, "set_death_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_set_death_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_death_time_variation'");
+  }
+
+  sq_pushstring(v, "fade_death_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_fade_death_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_death_time_variation'");
+  }
+
+  sq_pushstring(v, "ease_death_time_variation", -1);
+  sq_newclosure(v, &CustomParticles_ease_death_time_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_death_time_variation'");
+  }
+
+  sq_pushstring(v, "get_speed_x", -1);
+  sq_newclosure(v, &CustomParticles_get_speed_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_speed_x'");
+  }
+
+  sq_pushstring(v, "set_speed_x", -1);
+  sq_newclosure(v, &CustomParticles_set_speed_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_speed_x'");
+  }
+
+  sq_pushstring(v, "fade_speed_x", -1);
+  sq_newclosure(v, &CustomParticles_fade_speed_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_speed_x'");
+  }
+
+  sq_pushstring(v, "ease_speed_x", -1);
+  sq_newclosure(v, &CustomParticles_ease_speed_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_speed_x'");
+  }
+
+  sq_pushstring(v, "get_speed_y", -1);
+  sq_newclosure(v, &CustomParticles_get_speed_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_speed_y'");
+  }
+
+  sq_pushstring(v, "set_speed_y", -1);
+  sq_newclosure(v, &CustomParticles_set_speed_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_speed_y'");
+  }
+
+  sq_pushstring(v, "fade_speed_y", -1);
+  sq_newclosure(v, &CustomParticles_fade_speed_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_speed_y'");
+  }
+
+  sq_pushstring(v, "ease_speed_y", -1);
+  sq_newclosure(v, &CustomParticles_ease_speed_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_speed_y'");
+  }
+
+  sq_pushstring(v, "get_speed_variation_x", -1);
+  sq_newclosure(v, &CustomParticles_get_speed_variation_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_speed_variation_x'");
+  }
+
+  sq_pushstring(v, "set_speed_variation_x", -1);
+  sq_newclosure(v, &CustomParticles_set_speed_variation_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_speed_variation_x'");
+  }
+
+  sq_pushstring(v, "fade_speed_variation_x", -1);
+  sq_newclosure(v, &CustomParticles_fade_speed_variation_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_speed_variation_x'");
+  }
+
+  sq_pushstring(v, "ease_speed_variation_x", -1);
+  sq_newclosure(v, &CustomParticles_ease_speed_variation_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_speed_variation_x'");
+  }
+
+  sq_pushstring(v, "get_speed_variation_y", -1);
+  sq_newclosure(v, &CustomParticles_get_speed_variation_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_speed_variation_y'");
+  }
+
+  sq_pushstring(v, "set_speed_variation_y", -1);
+  sq_newclosure(v, &CustomParticles_set_speed_variation_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_speed_variation_y'");
+  }
+
+  sq_pushstring(v, "fade_speed_variation_y", -1);
+  sq_newclosure(v, &CustomParticles_fade_speed_variation_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_speed_variation_y'");
+  }
+
+  sq_pushstring(v, "ease_speed_variation_y", -1);
+  sq_newclosure(v, &CustomParticles_ease_speed_variation_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_speed_variation_y'");
+  }
+
+  sq_pushstring(v, "get_acceleration_x", -1);
+  sq_newclosure(v, &CustomParticles_get_acceleration_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_acceleration_x'");
+  }
+
+  sq_pushstring(v, "set_acceleration_x", -1);
+  sq_newclosure(v, &CustomParticles_set_acceleration_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_acceleration_x'");
+  }
+
+  sq_pushstring(v, "fade_acceleration_x", -1);
+  sq_newclosure(v, &CustomParticles_fade_acceleration_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_acceleration_x'");
+  }
+
+  sq_pushstring(v, "ease_acceleration_x", -1);
+  sq_newclosure(v, &CustomParticles_ease_acceleration_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_acceleration_x'");
+  }
+
+  sq_pushstring(v, "get_acceleration_y", -1);
+  sq_newclosure(v, &CustomParticles_get_acceleration_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_acceleration_y'");
+  }
+
+  sq_pushstring(v, "set_acceleration_y", -1);
+  sq_newclosure(v, &CustomParticles_set_acceleration_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_acceleration_y'");
+  }
+
+  sq_pushstring(v, "fade_acceleration_y", -1);
+  sq_newclosure(v, &CustomParticles_fade_acceleration_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_acceleration_y'");
+  }
+
+  sq_pushstring(v, "ease_acceleration_y", -1);
+  sq_newclosure(v, &CustomParticles_ease_acceleration_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_acceleration_y'");
+  }
+
+  sq_pushstring(v, "get_friction_x", -1);
+  sq_newclosure(v, &CustomParticles_get_friction_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_friction_x'");
+  }
+
+  sq_pushstring(v, "set_friction_x", -1);
+  sq_newclosure(v, &CustomParticles_set_friction_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_friction_x'");
+  }
+
+  sq_pushstring(v, "fade_friction_x", -1);
+  sq_newclosure(v, &CustomParticles_fade_friction_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_friction_x'");
+  }
+
+  sq_pushstring(v, "ease_friction_x", -1);
+  sq_newclosure(v, &CustomParticles_ease_friction_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_friction_x'");
+  }
+
+  sq_pushstring(v, "get_friction_y", -1);
+  sq_newclosure(v, &CustomParticles_get_friction_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_friction_y'");
+  }
+
+  sq_pushstring(v, "set_friction_y", -1);
+  sq_newclosure(v, &CustomParticles_set_friction_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_friction_y'");
+  }
+
+  sq_pushstring(v, "fade_friction_y", -1);
+  sq_newclosure(v, &CustomParticles_fade_friction_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_friction_y'");
+  }
+
+  sq_pushstring(v, "ease_friction_y", -1);
+  sq_newclosure(v, &CustomParticles_ease_friction_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_friction_y'");
+  }
+
+  sq_pushstring(v, "get_feather_factor", -1);
+  sq_newclosure(v, &CustomParticles_get_feather_factor_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_feather_factor'");
+  }
+
+  sq_pushstring(v, "set_feather_factor", -1);
+  sq_newclosure(v, &CustomParticles_set_feather_factor_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_feather_factor'");
+  }
+
+  sq_pushstring(v, "fade_feather_factor", -1);
+  sq_newclosure(v, &CustomParticles_fade_feather_factor_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_feather_factor'");
+  }
+
+  sq_pushstring(v, "ease_feather_factor", -1);
+  sq_newclosure(v, &CustomParticles_ease_feather_factor_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_feather_factor'");
+  }
+
+  sq_pushstring(v, "get_rotation", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation'");
+  }
+
+  sq_pushstring(v, "set_rotation", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation'");
+  }
+
+  sq_pushstring(v, "fade_rotation", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation'");
+  }
+
+  sq_pushstring(v, "ease_rotation", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation'");
+  }
+
+  sq_pushstring(v, "get_rotation_variation", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_variation'");
+  }
+
+  sq_pushstring(v, "set_rotation_variation", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_variation'");
+  }
+
+  sq_pushstring(v, "fade_rotation_variation", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation_variation'");
+  }
+
+  sq_pushstring(v, "ease_rotation_variation", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation_variation'");
+  }
+
+  sq_pushstring(v, "get_rotation_speed", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_speed'");
+  }
+
+  sq_pushstring(v, "set_rotation_speed", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_speed'");
+  }
+
+  sq_pushstring(v, "fade_rotation_speed", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation_speed'");
+  }
+
+  sq_pushstring(v, "ease_rotation_speed", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation_speed'");
+  }
+
+  sq_pushstring(v, "get_rotation_speed_variation", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_speed_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_speed_variation'");
+  }
+
+  sq_pushstring(v, "set_rotation_speed_variation", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_speed_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_speed_variation'");
+  }
+
+  sq_pushstring(v, "fade_rotation_speed_variation", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_speed_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation_speed_variation'");
+  }
+
+  sq_pushstring(v, "ease_rotation_speed_variation", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_speed_variation_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation_speed_variation'");
+  }
+
+  sq_pushstring(v, "get_rotation_acceleration", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_acceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_acceleration'");
+  }
+
+  sq_pushstring(v, "set_rotation_acceleration", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_acceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_acceleration'");
+  }
+
+  sq_pushstring(v, "fade_rotation_acceleration", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_acceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation_acceleration'");
+  }
+
+  sq_pushstring(v, "ease_rotation_acceleration", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_acceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation_acceleration'");
+  }
+
+  sq_pushstring(v, "get_rotation_decceleration", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_decceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_decceleration'");
+  }
+
+  sq_pushstring(v, "set_rotation_decceleration", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_decceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_decceleration'");
+  }
+
+  sq_pushstring(v, "fade_rotation_decceleration", -1);
+  sq_newclosure(v, &CustomParticles_fade_rotation_decceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_rotation_decceleration'");
+  }
+
+  sq_pushstring(v, "ease_rotation_decceleration", -1);
+  sq_newclosure(v, &CustomParticles_ease_rotation_decceleration_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_rotation_decceleration'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -1443,6 +1443,331 @@ static SQInteger CustomParticles_set_max_amount_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger CustomParticles_get_birth_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_birth_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    std::string return_value = _this->get_birth_mode();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_birth_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_birth_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_birth_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_birth_mode(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_birth_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_death_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_death_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    std::string return_value = _this->get_death_mode();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_death_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_death_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_death_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_death_mode(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_death_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_rotation_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_rotation_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    std::string return_value = _this->get_rotation_mode();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_rotation_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_rotation_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_rotation_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_rotation_mode(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_rotation_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_collision_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_collision_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    std::string return_value = _this->get_collision_mode();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_collision_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_collision_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_collision_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_collision_mode(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_collision_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_get_offscreen_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_offscreen_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    std::string return_value = _this->get_offscreen_mode();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_offscreen_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger CustomParticles_set_offscreen_mode_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_offscreen_mode' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::CustomParticles*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_offscreen_mode(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_offscreen_mode'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger CustomParticles_get_cover_screen_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -12960,6 +13285,76 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ti");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_max_amount'");
+  }
+
+  sq_pushstring(v, "get_birth_mode", -1);
+  sq_newclosure(v, &CustomParticles_get_birth_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_birth_mode'");
+  }
+
+  sq_pushstring(v, "set_birth_mode", -1);
+  sq_newclosure(v, &CustomParticles_set_birth_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_birth_mode'");
+  }
+
+  sq_pushstring(v, "get_death_mode", -1);
+  sq_newclosure(v, &CustomParticles_get_death_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_death_mode'");
+  }
+
+  sq_pushstring(v, "set_death_mode", -1);
+  sq_newclosure(v, &CustomParticles_set_death_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_death_mode'");
+  }
+
+  sq_pushstring(v, "get_rotation_mode", -1);
+  sq_newclosure(v, &CustomParticles_get_rotation_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_rotation_mode'");
+  }
+
+  sq_pushstring(v, "set_rotation_mode", -1);
+  sq_newclosure(v, &CustomParticles_set_rotation_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_rotation_mode'");
+  }
+
+  sq_pushstring(v, "get_collision_mode", -1);
+  sq_newclosure(v, &CustomParticles_get_collision_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_collision_mode'");
+  }
+
+  sq_pushstring(v, "set_collision_mode", -1);
+  sq_newclosure(v, &CustomParticles_set_collision_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_collision_mode'");
+  }
+
+  sq_pushstring(v, "get_offscreen_mode", -1);
+  sq_newclosure(v, &CustomParticles_get_offscreen_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_offscreen_mode'");
+  }
+
+  sq_pushstring(v, "set_offscreen_mode", -1);
+  sq_newclosure(v, &CustomParticles_set_offscreen_mode_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_offscreen_mode'");
   }
 
   sq_pushstring(v, "get_cover_screen", -1);


### PR DESCRIPTION
Exposed API to allow scripting to:
- Spawn particles (Any amount, instantly or with respect to the "delay-between-each-spawn" attribute, etc.)
- Clear all particles on screen
- Get and set almost any property, and fade and ease any property for which fading and easing are relevant