### PR TITLE
Added usage of skippable cutscenes in cutscene levels

### DIFF
--- a/data/levels/world1/castle_cutscene.nut
+++ b/data/levels/world1/castle_cutscene.nut
@@ -117,6 +117,7 @@ function outdoor()
   wait(2);
   Effect.fade_out(2);
   wait(2);
+  end_cutscene();
   Level.finish(true);
 }
 

--- a/data/levels/world1/castle_cutscene.stl
+++ b/data/levels/world1/castle_cutscene.stl
@@ -6,6 +6,7 @@
   (sector
     (name "main")
     (init-script "import(\"levels/world1/castle_cutscene.nut\");
+start_cutscene();
 trigger_state(\"start\");")
     (ambient-light
       (color 0.8 0.8 0.8999998)

--- a/data/levels/world1/intro.nut
+++ b/data/levels/world1/intro.nut
@@ -194,7 +194,11 @@ Tux.do_duck();
   Text.fade_in(1);
   wait(5);
   Text.fade_out(1);
-  wait(1);
+  wait(3);
+  Effect.fade_out(2);
+  wait(2.1);
+  end_cutscene();
+  Level.finish(true);
 }
 
 function shake_bush()

--- a/data/levels/world1/intro.nut
+++ b/data/levels/world1/intro.nut
@@ -236,6 +236,7 @@ function end_level()
   //end intro sequence
   Effect.fade_out(2);
   wait(2.1);
+  end_cutscene();
   Level.finish(true);
 }
 

--- a/data/levels/world1/intro.stl
+++ b/data/levels/world1/intro.stl
@@ -7,6 +7,7 @@
     (name "main")
     (init-script "import(\"levels/world1/intro.nut\");
 logo <- FloatingImage(\"images/objects/logo/logo_final.sprite\");
+start_cutscene();
 trigger_state(\"start\");")
     (ambient-light
       (color 1 1 1)

--- a/data/levels/world1/yeti_cutscene.nut
+++ b/data/levels/world1/yeti_cutscene.nut
@@ -67,6 +67,7 @@ function initialize()
   wait(2);
   Effect.fade_out(2);
   wait(3.5);
+  end_cutscene();
   Level.finish(true);
 }
 

--- a/data/levels/world1/yeti_cutscene.stl
+++ b/data/levels/world1/yeti_cutscene.stl
@@ -6,6 +6,7 @@
   (sector
     (name "main")
     (init-script "import(\"levels/world1/yeti_cutscene.nut\");
+start_cutscene();
 trigger_state(\"start\");")
     (ambient-light
       (color 1 1 1)

--- a/data/levels/world2/forest_intro.stl
+++ b/data/levels/world2/forest_intro.stl
@@ -28,6 +28,7 @@
     )
     (scripttrigger
       (script "Tux.deactivate();
+start_cutscene();
 Effect.sixteen_to_nine(0);
 Tux.walk(150);
 Effect.fade_in(1.5);
@@ -56,6 +57,7 @@ Text.fade_out(1);
 wait(4);
 Effect.fade_out(2);
 wait(3.5);
+end_cutscene();
 Level.finish(true);")
       (button #f)
       (width 96)

--- a/data/levels/world2/ghost_cutscene.stl
+++ b/data/levels/world2/ghost_cutscene.stl
@@ -41,6 +41,7 @@
     )
     (scripttrigger
       (script "Tux.deactivate();
+start_cutscene();
 Effect.sixteen_to_nine(0);
 Effect.fade_in(1.5);
 Tux.walk(200);
@@ -52,6 +53,7 @@ Tux.walk(250);
 wait(3);
 Effect.fade_out(2);
 wait(3.5);
+end_cutscene();
 Level.finish(true);")
       (button #f)
       (width 96)


### PR DESCRIPTION
Cutscene levels will now be iinstantly skipped on escape press.

I intend to re-add in-level small cutscenes and make them skippable with escape key in the same way.