### PR TITLE
Replace value copying with std::move and const references

### DIFF
--- a/src/editor/button_widget.hpp
+++ b/src/editor/button_widget.hpp
@@ -31,7 +31,7 @@ private:
 public:
   ButtonWidget(SpritePtr sprite, const Vector& pos, std::function<void()> m_sig_click = {});
   ButtonWidget(const std::string& path, const Vector& pos, std::function<void()> callback = {}) :
-    ButtonWidget(SpriteManager::current()->create(path), pos, callback)
+    ButtonWidget(SpriteManager::current()->create(path), pos, std::move(callback))
   {
   }
 

--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -17,6 +17,8 @@
 #include "editor/object_option.hpp"
 
 #include <string>
+#include <utility>
+
 #include <vector>
 #include <sstream>
 
@@ -55,7 +57,7 @@ BoolObjectOption::BoolObjectOption(const std::string& text, bool* pointer, const
                                    unsigned int flags) :
   ObjectOption(text, key, flags),
   m_pointer(pointer),
-  m_default_value(default_value)
+  m_default_value(std::move(default_value))
 {
 }
 
@@ -88,7 +90,7 @@ IntObjectOption::IntObjectOption(const std::string& text, int* pointer, const st
                                  unsigned int flags) :
   ObjectOption(text, key, flags),
   m_pointer(pointer),
-  m_default_value(default_value)
+  m_default_value(std::move(default_value))
 {
 }
 
@@ -154,7 +156,7 @@ FloatObjectOption::FloatObjectOption(const std::string& text, float* pointer, co
                                      unsigned int flags) :
   ObjectOption(text, key, flags),
   m_pointer(pointer),
-  m_default_value(default_value)
+  m_default_value(std::move(default_value))
 {
 }
 
@@ -222,7 +224,7 @@ StringSelectObjectOption::StringSelectObjectOption(const std::string& text, int*
   ObjectOption(text, key, flags),
   m_pointer(pointer),
   m_select(select),
-  m_default_value(default_value)
+  m_default_value(std::move(default_value))
 {
 }
 
@@ -268,7 +270,7 @@ EnumObjectOption::EnumObjectOption(const std::string& text, int* pointer,
   m_pointer(pointer),
   m_labels(labels),
   m_symbols(symbols),
-  m_default_value(default_value)
+  m_default_value(std::move(default_value))
 {
 }
 
@@ -600,9 +602,9 @@ ParticleEditorOption::add_to_menu(Menu& menu) const
   menu.add_entry(ObjectMenu::MNID_OPEN_PARTICLE_EDITOR, get_text());
 }
 
-ButtonOption::ButtonOption(const std::string& text, const std::function<void()> callback) :
+ButtonOption::ButtonOption(const std::string& text, std::function<void()> callback) :
   ObjectOption(text, "", 0),
-  m_callback(callback)
+  m_callback(std::move(callback))
 {
 }
 

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -412,7 +412,7 @@ private:
 class ButtonOption : public ObjectOption
 {
 public:
-  ButtonOption(const std::string& text, const std::function<void()> callback);
+  ButtonOption(const std::string& text, std::function<void()> callback);
 
   virtual void save(Writer& write) const override {}
   virtual std::string to_string() const override;

--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -44,7 +44,7 @@ ObjectSettings::add_badguy(const std::string& text, std::vector<std::string>* va
 void
 ObjectSettings::add_color(const std::string& text, Color* value_ptr,
                           const std::string& key,
-                          boost::optional<Color> default_value,
+                          const boost::optional<Color>& default_value,
                           unsigned int flags)
 {
   add_option(std::make_unique<ColorObjectOption>(text, value_ptr, key, default_value, true, flags));
@@ -53,7 +53,7 @@ ObjectSettings::add_color(const std::string& text, Color* value_ptr,
 void
 ObjectSettings::add_rgba(const std::string& text, Color* value_ptr,
                          const std::string& key,
-                         boost::optional<Color> default_value,
+                         const boost::optional<Color>& default_value,
                          unsigned int flags)
 {
   add_option(std::make_unique<ColorObjectOption>(text, value_ptr, key, default_value, true, flags));
@@ -62,7 +62,7 @@ ObjectSettings::add_rgba(const std::string& text, Color* value_ptr,
 void
 ObjectSettings::add_rgb(const std::string& text, Color* value_ptr,
                         const std::string& key,
-                        boost::optional<Color> default_value,
+                        const boost::optional<Color>& default_value,
                         unsigned int flags)
 {
   add_option(std::make_unique<ColorObjectOption>(text, value_ptr, key, default_value, false, flags));
@@ -71,7 +71,7 @@ ObjectSettings::add_rgb(const std::string& text, Color* value_ptr,
 void
 ObjectSettings::add_bool(const std::string& text, bool* value_ptr,
                          const std::string& key,
-                         boost::optional<bool> default_value,
+                         const boost::optional<bool>& default_value,
                          unsigned int flags)
 {
   add_option(std::make_unique<BoolObjectOption>(text, value_ptr, key, default_value, flags));
@@ -80,7 +80,7 @@ ObjectSettings::add_bool(const std::string& text, bool* value_ptr,
 void
 ObjectSettings::add_float(const std::string& text, float* value_ptr,
                           const std::string& key,
-                          boost::optional<float> default_value,
+                          const boost::optional<float>& default_value,
                           unsigned int flags)
 {
   add_option(std::make_unique<FloatObjectOption>(text, value_ptr, key, default_value, flags));
@@ -89,7 +89,7 @@ ObjectSettings::add_float(const std::string& text, float* value_ptr,
 void
 ObjectSettings::add_int(const std::string& text, int* value_ptr,
                         const std::string& key,
-                        boost::optional<int> default_value,
+                        const boost::optional<int>& default_value,
                         unsigned int flags)
 {
   add_option(std::make_unique<IntObjectOption>(text, value_ptr, key, default_value, flags));
@@ -129,7 +129,7 @@ ObjectSettings::add_worldmap_direction(const std::string& text, worldmap::Direct
 
 void
 ObjectSettings::add_walk_mode(const std::string& text, WalkMode* value_ptr,
-                              boost::optional<WalkMode> default_value,
+                              const boost::optional<WalkMode>& default_value,
                               const std::string& key, unsigned int flags)
 {
   add_option(std::make_unique<StringSelectObjectOption>(
@@ -154,7 +154,7 @@ ObjectSettings::add_script(const std::string& text, std::string* value_ptr,
 void
 ObjectSettings::add_text(const std::string& text, std::string* value_ptr,
                          const std::string& key,
-                         boost::optional<std::string> default_value,
+                         const boost::optional<std::string>& default_value,
                          unsigned int flags)
 {
   add_option(std::make_unique<StringObjectOption>(text, value_ptr, key, default_value, flags));
@@ -163,7 +163,7 @@ ObjectSettings::add_text(const std::string& text, std::string* value_ptr,
 void
 ObjectSettings::add_translatable_text(const std::string& text, std::string* value_ptr,
                                       const std::string& key,
-                                      boost::optional<std::string> default_value,
+                                      const boost::optional<std::string>& default_value,
                                       unsigned int flags)
 {
   add_option(std::make_unique<StringObjectOption>(text, value_ptr, key, default_value,
@@ -172,7 +172,7 @@ ObjectSettings::add_translatable_text(const std::string& text, std::string* valu
 
 void
 ObjectSettings::add_string_select(const std::string& text, int* value_ptr, const std::vector<std::string>& select,
-                                  boost::optional<int> default_value,
+                                  const boost::optional<int>& default_value,
                                   const std::string& key, unsigned int flags)
 {
   add_option(std::make_unique<StringSelectObjectOption>(text, value_ptr, select, default_value, key, flags));
@@ -182,7 +182,7 @@ void
 ObjectSettings::add_enum(const std::string& text, int* value_ptr,
                          const std::vector<std::string>& labels,
                          const std::vector<std::string>& symbols,
-                         boost::optional<int> default_value,
+                         const boost::optional<int>& default_value,
                          const std::string& key, unsigned int flags)
 {
   add_option(std::make_unique<EnumObjectOption>(text, value_ptr, labels, symbols, default_value, key, flags));
@@ -191,7 +191,7 @@ ObjectSettings::add_enum(const std::string& text, int* value_ptr,
 void
 ObjectSettings::add_file(const std::string& text, std::string* value_ptr,
                          const std::string& key,
-                         boost::optional<std::string> default_value,
+                         const boost::optional<std::string>& default_value,
                          const std::vector<std::string>& filter,
                          const std::string& basedir,
                          unsigned int flags)
@@ -298,7 +298,7 @@ ObjectSettings::add_particle_editor()
 }
 
 void
-ObjectSettings::add_button(const std::string& text, const std::function<void()> callback)
+ObjectSettings::add_button(const std::string& text, const std::function<void()>& callback)
 {
   add_option(std::make_unique<ButtonOption>(text, callback));
 }

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -44,15 +44,15 @@ public:
 
   void add_bool(const std::string& text, bool* value_ptr,
                 const std::string& key = {},
-                boost::optional<bool> default_value = {},
+                const boost::optional<bool>& default_value = {},
                 unsigned int flags = 0);
   void add_float(const std::string& text, float* value_ptr,
                  const std::string& key = {},
-                 boost::optional<float> default_value = {},
+                 const boost::optional<float>& default_value = {},
                  unsigned int flags = 0);
   void add_int(const std::string& text, int* value_ptr,
                const std::string& key = {},
-               boost::optional<int> default_value = {},
+               const boost::optional<int>& default_value = {},
                unsigned int flags = 0);
   void add_rectf(const std::string& text, Rectf* value_ptr,
                  const std::string& key = {},
@@ -64,40 +64,40 @@ public:
                      boost::optional<Direction> default_value = {},
                      const std::string& key = {}, unsigned int flags = 0);
   void add_walk_mode(const std::string& text, WalkMode* value_ptr,
-                     boost::optional<WalkMode> default_value = {},
+                     const boost::optional<WalkMode>& default_value = {},
                      const std::string& key = {}, unsigned int flags = 0);
   void add_badguy(const std::string& text, std::vector<std::string>* value_ptr,
                   const std::string& key = {}, unsigned int flags = 0);
   void add_color(const std::string& text, Color* value_ptr,
                  const std::string& key = {},
-                 boost::optional<Color> default_value = {},
+                 const boost::optional<Color>& default_value = {},
                  unsigned int flags = 0);
   void add_rgba(const std::string& text, Color* value_ptr,
                 const std::string& key = {},
-                boost::optional<Color> default_value = {},
+                const boost::optional<Color>& default_value = {},
                 unsigned int flags = 0);
   void add_rgb(const std::string& text, Color* value_ptr,
                const std::string& key = {},
-               boost::optional<Color> default_value = {},
+               const boost::optional<Color>& default_value = {},
                unsigned int flags = 0);
   void add_remove();
   void add_script(const std::string& text, std::string* value_ptr,
                   const std::string& key = {}, unsigned int flags = 0);
   void add_text(const std::string& text, std::string* value_ptr,
                 const std::string& key = {},
-                boost::optional<std::string> default_value = {},
+                const boost::optional<std::string>& default_value = {},
                 unsigned int flags = 0);
   void add_translatable_text(const std::string& text, std::string* value_ptr,
                              const std::string& key = {},
-                             boost::optional<std::string> default_value = {},
+                             const boost::optional<std::string>& default_value = {},
                              unsigned int flags = 0);
   void add_string_select(const std::string& text, int* value_ptr, const std::vector<std::string>& select,
-                         boost::optional<int> default_value = {},
+                         const boost::optional<int>& default_value = {},
                          const std::string& key = {}, unsigned int flags = 0);
   void add_enum(const std::string& text, int* value_ptr,
                 const std::vector<std::string>& labels,
                 const std::vector<std::string>& symbols,
-                boost::optional<int> default_value = {},
+                const boost::optional<int>& default_value = {},
                 const std::string& key = {}, unsigned int flags = 0);
 
   void add_sprite(const std::string& text, std::string* value_ptr,
@@ -129,7 +129,7 @@ public:
                     unsigned int flags = 0);
   void add_file(const std::string& text, std::string* value_ptr,
                 const std::string& key = {},
-                boost::optional<std::string> default_value = {},
+                const boost::optional<std::string>& default_value = {},
                 const std::vector<std::string>& filter = {},
                 const std::string& basedir = {},
                 unsigned int flags = 0);
@@ -139,7 +139,7 @@ public:
   void add_particle_editor();
 
   // VERY UNSTABLE - use with care   ~ Semphris (author of that option)
-  void add_button(const std::string& text, const std::function<void()> callback);
+  void add_button(const std::string& text, const std::function<void()>& callback);
 
   const std::vector<std::unique_ptr<ObjectOption> >& get_options() const { return m_options; }
 

--- a/src/editor/particle_editor.cpp
+++ b/src/editor/particle_editor.cpp
@@ -376,7 +376,7 @@ ParticleEditor::reset_texture_ui()
       nullptr,
       filter,
       "/",
-      [this](std::string new_filename) {
+      [this](const std::string& new_filename) {
         (m_particles->m_textures.begin() + m_texture_current)->texture = Surface::from_file(new_filename);
         m_particles->reinit_textures();
         this->push_version();
@@ -437,7 +437,8 @@ ParticleEditor::reset_texture_ui()
 }
 
 void
-ParticleEditor::addTextboxFloat(std::string name, float* bind, bool (*float_validator)(ControlTextboxFloat*, float))
+ParticleEditor::addTextboxFloat(const std::string& name, float* bind,
+  bool (*float_validator)(ControlTextboxFloat*, float))
 {
   auto float_control = std::make_unique<ControlTextboxFloat>();
   float_control.get()->bind_value(bind);
@@ -446,7 +447,7 @@ ParticleEditor::addTextboxFloat(std::string name, float* bind, bool (*float_vali
 }
 
 void
-ParticleEditor::addTextboxFloatWithImprecision(std::string name, float* bind,
+ParticleEditor::addTextboxFloatWithImprecision(const std::string& name, float* bind,
                                       float* imprecision_bind,
                                       bool (*float_validator)(ControlTextboxFloat*, float),
                                       bool (*imp_validator)(ControlTextboxFloat*, float))
@@ -479,7 +480,7 @@ ParticleEditor::addTextboxFloatWithImprecision(std::string name, float* bind,
 }
 
 void
-ParticleEditor::addTextboxInt(std::string name, int* bind, bool (*int_validator)(ControlTextboxInt*, int))
+ParticleEditor::addTextboxInt(const std::string& name, int* bind, bool (*int_validator)(ControlTextboxInt*, int))
 {
   auto int_control = std::make_unique<ControlTextboxInt>();
   int_control.get()->bind_value(bind);
@@ -493,7 +494,7 @@ ParticleEditor::addCheckbox(std::string name, bool* bind)
   auto bool_control = std::make_unique<ControlCheckbox>();
   bool_control.get()->bind_value(bind);
   bool_control.get()->set_rect(Rectf(240.f, 0.f, 260.f, 20.f));
-  addControl(name, std::move(bool_control));
+  addControl(std::move(name), std::move(bool_control));
 }
 
 void
@@ -533,7 +534,7 @@ ParticleEditor::addEasingEnum(std::string name, EasingMode* bind)
   ease_ctrl.get()->add_option(EaseBounceOut, _(getEasingName(EaseBounceOut)));
   ease_ctrl.get()->add_option(EaseBounceInOut, _(getEasingName(EaseBounceInOut)));
   ease_ctrl.get()->bind_value(bind);
-  addControl(name, std::move(ease_ctrl));
+  addControl(std::move(name), std::move(ease_ctrl));
 }
 
 void
@@ -553,7 +554,7 @@ ParticleEditor::addControl(std::string name, std::unique_ptr<InterfaceControl> n
                                       height + new_control.get()->get_rect().get_height()));
   }
 
-  new_control.get()->m_label = new InterfaceLabel(Rectf(5.f, height, 135.f, height + 20.f), name);
+  new_control.get()->m_label = new InterfaceLabel(Rectf(5.f, height, 135.f, height + 20.f), std::move(name));
   new_control.get()->m_on_change = new std::function<void()>([this](){ this->push_version(); });
   m_controls.push_back(std::move(new_control));
 }
@@ -630,7 +631,8 @@ ParticleEditor::save(Writer& writer)
 }
 
 void
-ParticleEditor::request_save(bool is_save_as, std::function<void(bool)> callback)
+ParticleEditor::request_save(bool is_save_as,
+  const std::function<void(bool)>& callback)
 {
   if (is_save_as || m_filename == "")
   {

--- a/src/editor/particle_editor.hpp
+++ b/src/editor/particle_editor.hpp
@@ -71,7 +71,8 @@ public:
   // saves the particle to file
   void save(const std::string& filename, bool retry = false);
   void save(Writer& writer);
-  void request_save(bool is_save_as = false, std::function<void(bool)> callback = [](bool was_saved){});
+  void request_save(bool is_save_as = false,
+    const std::function<void(bool)>& callback = [](bool was_saved){});
   void open(const std::string& filename) { m_filename = filename; reload(); }
   void new_file() { m_filename = ""; reload(); }
 
@@ -85,16 +86,16 @@ private:
   void reset_main_ui();
   void reset_texture_ui();
 
-  void addTextboxFloat(std::string name, float* bind,
+  void addTextboxFloat(const std::string& name, float* bind,
                        bool (*float_validator)(ControlTextboxFloat*,
                                                float) = nullptr);
-  void addTextboxFloatWithImprecision(std::string name, float* bind,
+  void addTextboxFloatWithImprecision(const std::string& name, float* bind,
                                       float* imprecision_bind,
                                       bool (*float_validator)(ControlTextboxFloat*,
                                                               float) = nullptr,
                                       bool (*imp_validator)(ControlTextboxFloat*,
                                                             float) = nullptr);
-  void addTextboxInt(std::string name, int* bind,
+  void addTextboxInt(const std::string& name, int* bind,
                      bool (*int_validator)(ControlTextboxInt*,
                                            int) = nullptr);
   void addCheckbox(std::string name, bool* bind);

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -217,7 +217,7 @@ Menu::add_entry(int id, const std::string& text)
 }
 
 ItemAction&
-Menu::add_entry(const std::string& text, std::function<void()> callback)
+Menu::add_entry(const std::string& text, const std::function<void()>& callback)
 {
   auto item = std::make_unique<ItemAction>(text, -1, callback);
   auto item_ptr = item.get();
@@ -245,8 +245,8 @@ Menu::add_toggle(int id, const std::string& text, bool* toggled)
 
 ItemToggle&
 Menu::add_toggle(int id, const std::string& text,
-                 std::function<bool()> get_func,
-                 std::function<void(bool)> set_func)
+                 const std::function<bool()>& get_func,
+                 const std::function<void(bool)>& set_func)
 {
   auto item = std::make_unique<ItemToggle>(text, get_func, set_func, id);
   auto item_ptr = item.get();

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -68,11 +68,11 @@ public:
   ItemHorizontalLine& add_hl();
   ItemLabel& add_label(const std::string& text);
   ItemAction& add_entry(int id, const std::string& text);
-  ItemAction& add_entry(const std::string& text, std::function<void()> callback);
+  ItemAction& add_entry(const std::string& text, const std::function<void()>& callback);
   ItemToggle& add_toggle(int id, const std::string& text, bool* toggled);
   ItemToggle& add_toggle(int id, const std::string& text,
-                         std::function<bool()> get_func,
-                         std::function<void(bool)> set_func);
+                         const std::function<bool()>& get_func,
+                         const std::function<void(bool)>& set_func);
   ItemInactive& add_inactive(const std::string& text);
   ItemBack& add_back(const std::string& text, int id = -1);
   ItemGoTo& add_submenu(const std::string& text, int submenu, int id = -1);

--- a/src/gui/menu_filesystem.cpp
+++ b/src/gui/menu_filesystem.cpp
@@ -37,7 +37,7 @@ FileSystemMenu::FileSystemMenu(std::string* filename, const std::vector<std::str
   m_basedir(basedir),
   m_directories(),
   m_files(),
-  m_callback(callback)
+  m_callback(std::move(callback))
 {
   AddonManager::current()->unmount_old_addons();
 

--- a/src/interface/control.hpp
+++ b/src/interface/control.hpp
@@ -38,7 +38,7 @@ public:
   void set_focus(bool focus) { m_has_focus = focus; }
   bool has_focus() const { return m_has_focus; }
 
-  void set_rect(Rectf rect) { m_rect = rect; }
+  void set_rect(const Rectf& rect) { m_rect = rect; }
   Rectf get_rect() const { return m_rect; }
 
 public:

--- a/src/interface/control_button.cpp
+++ b/src/interface/control_button.cpp
@@ -22,7 +22,7 @@
 #include "video/viewport.hpp"
 
 ControlButton::ControlButton(std::string label) :
-  m_btn_label(label),
+  m_btn_label(std::move(label)),
   m_mouse_down(false)
 {
 }
@@ -38,7 +38,7 @@ ControlButton::draw(DrawingContext& context)
                                    LAYER_GUI);
 
   context.color().draw_text(Resources::control_font,
-                            m_btn_label, 
+                            m_btn_label,
                             Vector((m_rect.get_left() + m_rect.get_right()) / 2,
                                    (m_rect.get_top() + m_rect.get_bottom()) / 2 - Resources::control_font->get_height() / 2),
                             FontAlignment::ALIGN_CENTER,

--- a/src/interface/control_enum.hpp
+++ b/src/interface/control_enum.hpp
@@ -100,7 +100,7 @@ ControlEnum<T>::draw(DrawingContext& context)
   }
 
   context.color().draw_text(Resources::control_font,
-                            label, 
+                            label,
                             Vector(m_rect.get_left() + 5.f,
                                    (m_rect.get_top() + m_rect.get_bottom()) / 2 -
                                     Resources::control_font->get_height() / 2),
@@ -109,7 +109,7 @@ ControlEnum<T>::draw(DrawingContext& context)
                             Color::BLACK);
   int i = 0;
   if (m_open_list) {
-    for (auto option : m_options) {
+    for (const auto& option : m_options) {
       i++;
       Rectf box = m_rect.moved(Vector(0.f, m_rect.get_height() * float(i)));
       context.color().draw_filled_rect(box.grown(2.f).moved(Vector(0,4.f)), Color(0.f, 0.f, 0.f, 0.1f), 2.f, LAYER_GUI + 4);
@@ -125,7 +125,7 @@ ControlEnum<T>::draw(DrawingContext& context)
       std::string label2 = option.second;
 
       context.color().draw_text(Resources::control_font,
-                                label2, 
+                                label2,
                                 Vector(m_rect.get_left() + 5.f,
                                        (m_rect.get_top() + m_rect.get_bottom()) / 2 -
                                         Resources::control_font->get_height() / 2 +
@@ -180,7 +180,7 @@ ControlEnum<T>::on_mouse_button_down(const SDL_MouseButtonEvent& button)
         if (pos >= 0 && pos < int(m_options.size())) {
           // Yes. We need this. Because I can't acced by numerical index.
           // There's probably a way, but I'm too bored to investigate.
-          for (auto option : m_options) {
+          for (const auto& option : m_options) {
             if (--pos != -1) continue;
             *m_value = option.first;
 
@@ -239,7 +239,7 @@ ControlEnum<T>::on_key_down(const SDL_KeyboardEvent& key)
   if (key.keysym.sym == SDLK_DOWN) {
     bool is_next = false;
     // Hacky way to get the next one in the list
-    for (auto option : m_options) {
+    for (const auto& option : m_options) {
       if (is_next) {
         *m_value = option.first;
         is_next = false;
@@ -250,13 +250,8 @@ ControlEnum<T>::on_key_down(const SDL_KeyboardEvent& key)
     }
 
     // if we're at the last index, loop back to the beginning
-    if (is_next) {
-      // Hacky way to get the first one in the list
-      for (auto option : m_options) {
-        *m_value = option.first;
-        break;
-      }
-    }
+    if (is_next && !m_options.empty())
+      *m_value = m_options.begin()->first;
 
     if (m_on_change)
       (*m_on_change)();
@@ -269,7 +264,7 @@ ControlEnum<T>::on_key_down(const SDL_KeyboardEvent& key)
     T last_value = *m_value; // must assign a value else clang will complain
 
     // Hacky way to get the preceeding one in the list
-    for (auto option : m_options) {
+    for (const auto& option : m_options) {
       if (option.first == *m_value) {
         if (currently_on_first) {
           is_last = true;

--- a/src/interface/control_textbox.cpp
+++ b/src/interface/control_textbox.cpp
@@ -137,7 +137,7 @@ ControlTextbox::draw(DrawingContext& context)
   }
 
   context.color().draw_text(Resources::control_font,
-                            get_contents_visible(), 
+                            get_contents_visible(),
                             Vector(m_rect.get_left() + 5.f,
                                    (m_rect.get_top() + m_rect.get_bottom()) / 2 -
                                     Resources::control_font->get_height() / 2),
@@ -417,11 +417,11 @@ ControlTextbox::get_first_chars_visible(int amount) const
 }
 
 int
-ControlTextbox::get_text_position(Vector pos) const
+ControlTextbox::get_text_position(const Vector& pos) const
 {
   float dist = pos.x - m_rect.get_left();
   int i = 0;
-  
+
   while (Resources::control_font->get_text_width(get_first_chars_visible(i)) < dist
          && i <= int(m_charlist.size()))
     i++;
@@ -442,7 +442,7 @@ ControlTextbox::get_truncated_text(std::string text) const
 }
 
 bool
-ControlTextbox::fits(std::string text) const
+ControlTextbox::fits(const std::string& text) const
 {
   return Resources::control_font->get_text_width(text) <= m_rect.get_width() - 10.f;
 }
@@ -483,14 +483,14 @@ ControlTextbox::paste()
 {
   if (!SDL_HasClipboardText())
     return false;
-  
+
   char* txt = SDL_GetClipboardText();
 
   if (txt)
     put_text(std::string(txt));
   else
     log_warning << "Couldn't paste text from clipboard: " << SDL_GetError() << std::endl;
-  
+
   return txt != nullptr;
 }
 
@@ -518,7 +518,7 @@ ControlTextbox::get_selected_text() const
 }
 
 bool
-ControlTextbox::put_text(std::string text)
+ControlTextbox::put_text(const std::string& text)
 {
   bool has_erased_text = erase_selected_text();
 

--- a/src/interface/control_textbox.hpp
+++ b/src/interface/control_textbox.hpp
@@ -45,23 +45,23 @@ public:
   std::string get_string() const;
 
   /** Gets at which (absolute) index, in the text, corresponds an on-screen point */
-  int get_text_position(Vector pos) const;
+  int get_text_position(const Vector& pos) const;
 
   /** Returns true if the given text would fit inside the box */
-  bool fits(std::string text) const;
+  bool fits(const std::string& text) const;
 
   /**
-   * Copies the current selected text to the clipboard. If no text is selected, 
+   * Copies the current selected text to the clipboard. If no text is selected,
    * does nothing and returns false.
-   * 
+   *
    * @returns true if copied successfully, false if error OR nothing was selected.
    */
   bool copy() const;
 
   /**
-   * Pastes the text from the clipboard. If the clipboard doesn't have text, 
+   * Pastes the text from the clipboard. If the clipboard doesn't have text,
    * does nothing and returns false.
-   * 
+   *
    * @returns true if pasted successfully, false if error OR cliboard was empty/non-text
    */
   bool paste();
@@ -75,10 +75,10 @@ public:
   /**
    * Puts the given text at the currently selected position, replacing the text
    * that was selected, if any.
-   * 
+   *
    * @returns true if some text was deleted; false if no text was replaced.
    */
-  bool put_text(std::string text);
+  bool put_text(const std::string& text);
 
 protected:
   /** Transfers the string into the binded variable, if any. Can be overridden
@@ -116,7 +116,7 @@ protected:
 
   /** Converts the internal char vector to an actual string and returns it. */
   std::string get_contents() const;
-  
+
   /** Returns first "amount" chars held in m_charlist */
   std::string get_first_chars(int amount) const;
 
@@ -166,7 +166,7 @@ protected:
   bool m_shift_pressed, m_ctrl_pressed;
   bool m_mouse_pressed;
 
-  /** 
+  /**
    * If the string is too long to be contained in the box,
    * use this offset to select which characters will be
    * displayed on the screen

--- a/src/interface/label.cpp
+++ b/src/interface/label.cpp
@@ -27,9 +27,9 @@ InterfaceLabel::InterfaceLabel() :
 {
 }
 
-InterfaceLabel::InterfaceLabel(Rectf rect, std::string label) :
+InterfaceLabel::InterfaceLabel(const Rectf& rect, std::string label) :
   m_rect(rect),
-  m_label(label),
+  m_label(std::move(label)),
   m_mouse_pos()
 {
 }
@@ -45,7 +45,7 @@ void
 InterfaceLabel::draw(DrawingContext& context)
 {
   context.color().draw_text(Resources::control_font,
-                            get_truncated_text(), 
+                            get_truncated_text(),
                             Vector(m_rect.get_left() + 5.f,
                                    (m_rect.get_top() + m_rect.get_bottom()) / 2 -
                                     Resources::control_font->get_height() / 2 + 1.f),
@@ -69,7 +69,7 @@ InterfaceLabel::draw(DrawingContext& context)
                                      Color(1.f, 1.f, 1.f, 0.1f),
                                      LAYER_GUI + 10);
     context.color().draw_text(Resources::control_font,
-                              m_label, 
+                              m_label,
                               m_mouse_pos + Vector(0, 33.f),
                               FontAlignment::ALIGN_LEFT,
                               LAYER_GUI + 11,
@@ -78,7 +78,7 @@ InterfaceLabel::draw(DrawingContext& context)
 }
 
 bool
-InterfaceLabel::fits(std::string text) const
+InterfaceLabel::fits(const std::string& text) const
 {
   return Resources::control_font->get_text_width(text) <= m_rect.get_width();
 }

--- a/src/interface/label.hpp
+++ b/src/interface/label.hpp
@@ -26,19 +26,19 @@ class InterfaceLabel : public Widget
 {
 public:
   InterfaceLabel();
-  InterfaceLabel(Rectf rect, std::string label);
+  InterfaceLabel(const Rectf& rect, std::string label);
   virtual ~InterfaceLabel() {}
 
   virtual void draw(DrawingContext& context) override;
   virtual bool on_mouse_motion(const SDL_MouseMotionEvent& motion) override;
 
-  void set_rect(Rectf rect) { m_rect = rect; }
+  void set_rect(const Rectf& rect) { m_rect = rect; }
   Rectf get_rect() const { return m_rect; }
 
-  void set_label(std::string label) { m_label = label; }
+  void set_label(const std::string& label) { m_label = label; }
   std::string get_label() const { return m_label; }
 
-  bool fits(std::string text) const;
+  bool fits(const std::string& text) const;
   std::string get_truncated_text() const;
 
 protected:

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -166,7 +166,7 @@ CustomParticleSystem::CustomParticleSystem(const ReaderMapping& reader) :
                  mapping.get_doc().get_filename() << ", skipping" << std::endl;
         continue;
       }
-      
+
       float likeliness;
       if (!mapping.get("likeliness", likeliness))
       {
@@ -174,7 +174,7 @@ CustomParticleSystem::CustomParticleSystem(const ReaderMapping& reader) :
                  mapping.get_doc().get_filename() << ", skipping" << std::endl;
         continue;
       }
-      
+
       float scale_x, scale_y;
       if (!mapping.get("scale_x", scale_x))
       {
@@ -386,7 +386,7 @@ CustomParticleSystem::reinit_textures()
   }
 
   texture_sum_odds = 0.f;
-  for (auto texture : m_textures)
+  for (const auto& texture : m_textures)
   {
     texture_sum_odds += texture.likeliness;
   }
@@ -395,7 +395,7 @@ CustomParticleSystem::reinit_textures()
 void
 CustomParticleSystem::save(Writer& writer)
 {
-  for (auto tex : m_textures)
+  for (const auto& tex : m_textures)
   {
     writer.start_list("texture");
     writer.write("surface", tex.texture->get_filename());
@@ -1111,7 +1111,7 @@ CustomParticleSystem::get_abs_y()
  *    no check regarding the maximum amount of total particles.
  * @param lifetime The time elapsed since the moment the particle should have been born
  */
-void 
+void
 CustomParticleSystem::add_particle(float lifetime, float x, float y)
 {
   auto particle = std::make_unique<CustomParticle>();
@@ -1148,7 +1148,7 @@ CustomParticleSystem::add_particle(float lifetime, float x, float y)
 
   particle->birth_easing = m_particle_birth_easing;
   particle->death_easing = m_particle_death_easing;
-  
+
   switch(particle->birth_mode) {
   case FadeMode::Shrink:
     particle->scale = 0.f;

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -72,7 +72,7 @@ private:
 
   float get_abs_x();
   float get_abs_y();
-  
+
   float texture_sum_odds;
   float time_last_remaining;
 
@@ -129,7 +129,7 @@ private:
     {
     }
 
-    SpriteProperties(SurfacePtr surface) :
+    SpriteProperties(const SurfacePtr& surface) :
       likeliness(1.f),
       color(1.f, 1.f, 1.f, 1.f),
       texture(surface),
@@ -343,7 +343,7 @@ public:
   {
     std::unique_ptr<ParticleProps> props = std::make_unique<ParticleProps>();
 
-    for (auto texture : m_textures)
+    for (auto& texture : m_textures)
       props->m_textures.push_back(texture);
     props->m_particle_main_texture = m_particle_main_texture;
     props->m_max_amount = m_max_amount;
@@ -384,7 +384,7 @@ public:
   void set_props(ParticleProps* props)
   {
     m_textures.clear();
-    for (auto texture : props->m_textures)
+    for (auto& texture : props->m_textures)
       m_textures.push_back(texture);
     m_particle_main_texture = props->m_particle_main_texture;
     m_max_amount = props->m_max_amount;

--- a/src/object/decal.cpp
+++ b/src/object/decal.cpp
@@ -87,7 +87,7 @@ Decal::fade_out(float fade_time)
 }
 
 void
-Decal::fade_sprite(std::string new_sprite, float fade_time)
+Decal::fade_sprite(const std::string& new_sprite, float fade_time)
 {
   m_fade_sprite = SpriteManager::current()->create(new_sprite);
   m_sprite.swap(m_fade_sprite);

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -46,7 +46,7 @@ public:
 
   void fade_in(float fade_time);
   void fade_out(float fade_time);
-  void fade_sprite(const std::string new_sprite, float fade_time);
+  void fade_sprite(const std::string& new_sprite, float fade_time);
 
   void set_visible(bool v) { m_visible = v; }
   bool is_visible() const { return m_visible; }

--- a/src/object/particle_zone.hpp
+++ b/src/object/particle_zone.hpp
@@ -40,7 +40,7 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual ObjectSettings get_settings() override;
-  
+
   Rectf get_rect() {return m_col.m_bbox;}
 
   enum class ParticleZoneType {
@@ -104,8 +104,8 @@ public:
     ParticleZoneType m_type;
     Rectf m_rect;
 
-    ZoneDetails(std::string name, ParticleZoneType type, Rectf rect) :
-      m_particle_name(name),
+    ZoneDetails(std::string name, ParticleZoneType type, const Rectf& rect) :
+      m_particle_name(std::move(name)),
       m_type(type),
       m_rect(rect)
     {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -286,9 +286,9 @@ Player::adjust_height(float new_height, float bottom_offset)
 
 
   if (new_height > m_col.m_bbox.get_height()) {
-    Rectf additional_space = bbox2;
+    //Rectf additional_space = bbox2;
     //additional_space.set_height(new_height - m_col.m_bbox.get_height());
-    if (!Sector::get().is_free_of_statics(additional_space, this, true))
+    if (!Sector::get().is_free_of_statics(bbox2, this, true))
       return false;
   }
 
@@ -366,9 +366,9 @@ Player::update(float dt_sec)
 
   // extend/shrink tux collision rectangle so that we fall through/walk over 1
   // tile holes
-  
+
   //wallclinging and walljumping
-  
+
   Rectf wallclingleft = get_bbox();
   wallclingleft.set_left(wallclingleft.get_left() - 8.f);
   m_on_left_wall = !Sector::get().is_free_of_statics(wallclingleft);
@@ -1036,7 +1036,7 @@ Player::handle_vertical_input()
     SoundManager::current()->play((is_big()) ? "sounds/bigjump.wav" : "sounds/jump.wav");
     m_physic.set_velocity(m_on_left_wall ? 400.f : -400.f, -520.f);
   }
-  
+
  m_physic.set_acceleration_y(0);
 }
 
@@ -1693,7 +1693,7 @@ Player::collision_tile(uint32_t tile_attributes)
     }
   }
 #endif
-  
+
   if (tile_attributes & Tile::WALLJUMP)
   {
     m_in_walljump_tile = true;

--- a/src/scripting/camera.cpp
+++ b/src/scripting/camera.cpp
@@ -99,7 +99,7 @@ Camera::scale(float scale, float time)
 }
 
 void
-Camera::ease_scale(float scale, float time, std::string ease)
+Camera::ease_scale(float scale, float time, const std::string& ease)
 {
   SCRIPT_GUARD_VOID;
   BIND_SECTOR(::Sector::get());

--- a/src/scripting/camera.hpp
+++ b/src/scripting/camera.hpp
@@ -60,7 +60,7 @@ public:
   /** Fade the scale factor over time */
   void scale(float scale, float time);
   /** Fade the scale factor over time with easing (smooth movement) */
-  void ease_scale(float scale, float time, std::string ease);
+  void ease_scale(float scale, float time, const std::string& ease);
 };
 
 } // namespace scripting

--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -88,7 +88,7 @@ void start_cutscene()
     log_info << "No game session" << std::endl;
     return;
   }
-  
+
   if (session->get_current_level().m_is_in_cutscene)
   {
     log_warning << "start_cutscene(): starting a new cutscene above another one, ending preceeding cutscene (use end_cutscene() in scripts!)" << std::endl;
@@ -106,7 +106,7 @@ void end_cutscene()
     log_info << "No game session" << std::endl;
     return;
   }
-  
+
   if (!session->get_current_level().m_is_in_cutscene)
   {
     log_warning << "end_cutscene(): no cutscene to end, resetting status anyways" << std::endl;
@@ -124,7 +124,7 @@ bool check_cutscene()
     log_info << "No game session" << std::endl;
     return false;
   }
-  
+
   return session->get_current_level().m_is_in_cutscene;
 }
 
@@ -325,17 +325,17 @@ void stop_music(float fadetime)
   SoundManager::current()->stop_music(fadetime);
 }
 
-void fade_in_music(const std::string& filename, float fadetime) 
+void fade_in_music(const std::string& filename, float fadetime)
 {
   SoundManager::current()->play_music(filename, fadetime);
 }
 
-void resume_music(float fadetime) 
+void resume_music(float fadetime)
 {
   SoundManager::current()->resume_music(fadetime);
 }
 
-void pause_music(float fadetime) 
+void pause_music(float fadetime)
 {
   SoundManager::current()->pause_music(fadetime);
 }
@@ -442,7 +442,7 @@ void set_game_speed(float speed)
     // executing transitions would take an unreaonably long time if we allow
     // game speeds like 0.00001
     log_warning << "Cannot set game speed to less than 0.05" << std::endl;
-    throw new std::runtime_error("Cannot set game speed to less than 0.05");
+    throw std::runtime_error("Cannot set game speed to less than 0.05");
   }
 
   ::g_debug.set_game_speed_multiplier(speed);

--- a/src/scripting/rain.cpp
+++ b/src/scripting/rain.cpp
@@ -44,7 +44,7 @@ void Rain::fade_amount(float amount, float time)
   object.fade_amount(amount, time);
 }
 
-void Rain::fade_angle(float angle, float time, std::string ease)
+void Rain::fade_angle(float angle, float time, const std::string& ease)
 {
   SCRIPT_GUARD_VOID;
   object.fade_angle(angle, time, getEasingByName(EasingMode_from_string(ease)));

--- a/src/scripting/rain.hpp
+++ b/src/scripting/rain.hpp
@@ -50,7 +50,7 @@ public:
   void fade_amount(float amount, float time);
 
   /** Smoothly changes the angle of the rain according to the easing function */
-  void fade_angle(float angle, float time, std::string ease);
+  void fade_angle(float angle, float time, const std::string& ease);
 };
 
 } // namespace scripting

--- a/src/sdk/integration.hpp
+++ b/src/sdk/integration.hpp
@@ -34,8 +34,8 @@ public:
   {
   }
 
-  bool operator !=(const IntegrationStatus is) { return !operator==(is); }
-  bool operator ==(const IntegrationStatus is) {
+  bool operator !=(const IntegrationStatus& is) { return !operator==(is); }
+  bool operator ==(const IntegrationStatus& is) {
     if (m_details.size() != is.m_details.size())
       return false;
 
@@ -54,35 +54,35 @@ public:
   /**
    * A list of lines describing what the player is doing.
    * Should go from general to specific.
-   * 
+   *
    * A good first line should hint other people whether or not
    * the user is available to play with them. For example, stating
    * whether the user is playing online or offline, and if they're
    * playing or if they're in the menus/level select screens.
-   * 
+   *
    * The second line can give more details, such as which level
    * is being played (or edited if in the level editor).
-   * 
+   *
    * The lines should be short (max 100 characters). There shouldn't
    * be more than 3 lines in total. Keep in mind that integrations
    * don't display many lines: Discord displays two; Steam, just one.
-   * 
+   *
    * ================================================================
-   * 
+   *
    * A good example looks like:
    *   Playing (single player)
    *   In level: Welcome to Antartica
    *   Worldmap: Icy island
-   * 
+   *
    * Or:
    *   Racing worldmap (online)
    *   Worldmap: LatestAddon's worldmap [custom]
-   * 
+   *
    * (keep in mind party details have their own variables!)
-   * 
+   *
    * Or even just:
    *   In menu
-   * 
+   *
    */
   std::vector<std::string> m_details;
 

--- a/src/supertux/autotile.cpp
+++ b/src/supertux/autotile.cpp
@@ -44,8 +44,8 @@ AutotileMask::get_mask() const
 
 Autotile::Autotile(uint32_t tile_id, std::vector<std::pair<uint32_t, float>> alt_tiles, std::vector<AutotileMask*> masks, bool solid) :
   m_tile_id(tile_id),
-  m_alt_tiles(alt_tiles),
-  m_masks(masks),
+  m_alt_tiles(std::move(alt_tiles)),
+  m_masks(std::move(masks)),
   m_solid(solid)
 {
 }
@@ -138,9 +138,9 @@ Autotile::is_solid() const
 std::vector<AutotileSet*>* AutotileSet::m_autotilesets = new std::vector<AutotileSet*>();
 
 AutotileSet::AutotileSet(std::vector<Autotile*> tiles, uint32_t default_tile, std::string name, bool corner) :
-  m_autotiles(tiles),
+  m_autotiles(std::move(tiles)),
   m_default(default_tile),
-  m_name(name),
+  m_name(std::move(name)),
   m_corner(corner)
 {
 }

--- a/src/supertux/menu/menu_storage.cpp
+++ b/src/supertux/menu/menu_storage.cpp
@@ -159,7 +159,7 @@ MenuStorage::create(MenuId menu_id)
 
     case EDITOR_LEVELSET_MENU:
       return std::make_unique<EditorLevelsetMenu>();
-      
+
     case INTEGRATIONS_MENU:
       return std::make_unique<IntegrationsMenu>();
 
@@ -167,7 +167,10 @@ MenuStorage::create(MenuId menu_id)
       return std::make_unique<ParticleEditorMenu>();
 
     case PARTICLE_EDITOR_SAVE_AS:
-      throw new std::runtime_error("Cannot instantiate ParticleEditorSaveAs dialog from MenuStorage::create() or MenuManager::set_menu(), as it needs to be bound to a callback. Please instantiate ParticleEditorSaveAs directly");
+      throw std::runtime_error("Cannot instantiate ParticleEditorSaveAs dialog "
+        "from MenuStorage::create() or MenuManager::set_menu(), "
+        "as it needs to be bound to a callback. "
+        "Please instantiate ParticleEditorSaveAs directly");
       //return std::make_unique<ParticleEditorSaveAs>();
 
     case PARTICLE_EDITOR_OPEN:

--- a/src/supertux/menu/particle_editor_menu.cpp
+++ b/src/supertux/menu/particle_editor_menu.cpp
@@ -105,8 +105,8 @@ ParticleEditorMenu::menu_action(MenuItem& item)
         &ParticleEditor::current()->m_filename,
         filter,
         "/particles",
-        [](std::string new_filename) {
-          ParticleEditor::current()->open("/particles/" + 
+        [](const std::string& new_filename) {
+          ParticleEditor::current()->open("/particles/" +
                                         ParticleEditor::current()->m_filename);
           MenuManager::instance().clear_menu_stack();
         }

--- a/src/supertux/menu/particle_editor_save_as.cpp
+++ b/src/supertux/menu/particle_editor_save_as.cpp
@@ -28,7 +28,7 @@
 
 ParticleEditorSaveAs::ParticleEditorSaveAs(std::function<void(bool)> callback) :
   m_filename("/particles/custom/"),
-  m_callback(callback)
+  m_callback(std::move(callback))
 {
   add_label(_("Save particle as"));
 


### PR DESCRIPTION
I've applied many changes suggested by clang-tidy.