### PR TITLE
Refactored interface textbox

### DIFF
--- a/src/editor/particle_editor.cpp
+++ b/src/editor/particle_editor.cpp
@@ -697,11 +697,11 @@ ParticleEditor::update(float dt_sec, const Controller& controller)
 
   if (m_in_texture_tab) {
     for(const auto& control : m_controls_textures) {
-      control->update(dt_sec, controller);
+      control->update(dt_sec);
     }
   } else {
     for(const auto& control : m_controls) {
-      control->update(dt_sec, controller);
+      control->update(dt_sec);
     }
   }
 

--- a/src/interface/control.hpp
+++ b/src/interface/control.hpp
@@ -30,8 +30,6 @@ public:
   InterfaceControl();
   virtual ~InterfaceControl() {}
 
-  virtual void update(float dt_sec) override { throw std::runtime_error("Cannot call generic update() on interface control"); }
-  virtual void update(float dt_sec, const Controller& controller) {}
   virtual void draw(DrawingContext& context) override { if (m_label) m_label->draw(context); }
   virtual bool on_mouse_motion(const SDL_MouseMotionEvent& motion) override { if (m_label) m_label->on_mouse_motion(motion); return false; }
 

--- a/src/interface/control_textbox.cpp
+++ b/src/interface/control_textbox.cpp
@@ -27,17 +27,14 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
-// Shamelessly snatched values from src/gui/menu.cpp
-static const float CONTROL_REPEAT_INITIAL = 0.4f;
-static const float CONTROL_REPEAT_RATE    = 0.05f;
-static const float CONTROL_CURSOR_TIMER   = 0.5f;
+// The time for the caret to change visibility (when it flashes)
+static const float CONTROL_CURSOR_TIMER = 0.5f;
 
 ControlTextbox::ControlTextbox() :
   m_validate_string(),
   m_charlist(),
   m_string(nullptr),
   m_internal_string_backup(""),
-  m_backspace_remaining(CONTROL_REPEAT_INITIAL),
   m_cursor_timer(CONTROL_CURSOR_TIMER),
   m_caret_pos(),
   m_secondary_caret_pos(),
@@ -49,22 +46,8 @@ ControlTextbox::ControlTextbox() :
 }
 
 void
-ControlTextbox::update(float dt_sec, const Controller& controller)
+ControlTextbox::update(float dt_sec)
 {
-  if (controller.pressed(Control::REMOVE)) {
-    on_backspace();
-  }
-
-  if (controller.hold(Control::REMOVE)) {
-    m_backspace_remaining -= dt_sec;
-    while (m_backspace_remaining < 0) {
-      on_backspace();
-      m_backspace_remaining += CONTROL_REPEAT_RATE;
-    }
-  } else {
-    m_backspace_remaining = CONTROL_REPEAT_INITIAL;
-  }
-
   m_cursor_timer -= dt_sec;
   if (m_cursor_timer < -CONTROL_CURSOR_TIMER) {
     m_cursor_timer = CONTROL_CURSOR_TIMER;
@@ -75,31 +58,16 @@ ControlTextbox::update(float dt_sec, const Controller& controller)
 }
 
 void
-ControlTextbox::on_backspace()
+ControlTextbox::delete_char_before_caret()
 {
   if (m_charlist.size()) {
-    if (m_caret_pos != m_secondary_caret_pos) {
+    m_caret_pos--;
+    m_secondary_caret_pos = m_caret_pos;
+    m_cursor_timer = CONTROL_CURSOR_TIMER;
 
-      m_cursor_timer = CONTROL_CURSOR_TIMER;
-
-      auto it = m_charlist.begin();
-      advance(it, std::min(m_caret_pos, m_secondary_caret_pos));
-      auto it2 = m_charlist.begin();
-      advance(it2, std::max(m_caret_pos, m_secondary_caret_pos));
-      m_charlist.erase(it, it2);
-
-      m_caret_pos = std::min(m_caret_pos, m_secondary_caret_pos);
-      m_secondary_caret_pos = m_caret_pos;
-
-    } else if (m_caret_pos > 0) {
-      m_caret_pos--;
-      m_secondary_caret_pos = m_caret_pos;
-      m_cursor_timer = CONTROL_CURSOR_TIMER;
-
-      auto it = m_charlist.begin();
-      advance(it, m_caret_pos);
-      m_charlist.erase(it);
-    }
+    auto it = m_charlist.begin();
+    advance(it, m_caret_pos);
+    m_charlist.erase(it);
 
     recenter_offset();
   }
@@ -229,12 +197,44 @@ ControlTextbox::on_key_down(const SDL_KeyboardEvent& key)
 
   if (key.keysym.sym == SDLK_LEFT && m_caret_pos > 0)
   {
-    m_caret_pos--;
-    m_cursor_timer = CONTROL_CURSOR_TIMER;
-    if (!m_shift_pressed)
-      m_secondary_caret_pos = m_caret_pos;
+    if (!m_shift_pressed && m_secondary_caret_pos != m_caret_pos)
+    {
+      m_secondary_caret_pos = m_caret_pos = std::min(m_secondary_caret_pos, m_caret_pos);
+    }
+    else
+    {
+      m_caret_pos--;
+      m_cursor_timer = CONTROL_CURSOR_TIMER;
+      if (!m_shift_pressed)
+        m_secondary_caret_pos = m_caret_pos;
+    }
 
     recenter_offset();
+    return true;
+  }
+  else if (key.keysym.sym == SDLK_RIGHT && m_caret_pos < int(m_charlist.size()))
+  {
+    if (!m_shift_pressed && m_secondary_caret_pos != m_caret_pos)
+    {
+      m_secondary_caret_pos = m_caret_pos = std::max(m_secondary_caret_pos, m_caret_pos);
+    }
+    else
+    {
+      m_caret_pos++;
+      m_cursor_timer = CONTROL_CURSOR_TIMER;
+      if (!m_shift_pressed)
+        m_secondary_caret_pos = m_caret_pos;
+    }
+
+    recenter_offset();
+    return true;
+  }
+  else if (key.keysym.sym == SDLK_BACKSPACE)
+  {
+    if (!erase_selected_text() && m_caret_pos > 0)
+    {
+      delete_char_before_caret();
+    }
     return true;
   }
   else if (key.keysym.sym == SDLK_DELETE)
@@ -242,18 +242,8 @@ ControlTextbox::on_key_down(const SDL_KeyboardEvent& key)
     if (!erase_selected_text() && static_cast<int>(m_charlist.size()) > m_caret_pos)
     {
       m_caret_pos++;
-      on_backspace();
+      delete_char_before_caret();
     }
-    return true;
-  }
-  else if (key.keysym.sym == SDLK_RIGHT && m_caret_pos < int(m_charlist.size()))
-  {
-    m_caret_pos++;
-    m_cursor_timer = CONTROL_CURSOR_TIMER;
-    if (!m_shift_pressed)
-      m_secondary_caret_pos = m_caret_pos;
-
-    recenter_offset();
     return true;
   }
   else if (key.keysym.sym == SDLK_HOME)

--- a/src/interface/control_textbox.hpp
+++ b/src/interface/control_textbox.hpp
@@ -36,7 +36,7 @@ public:
   virtual bool on_key_down(const SDL_KeyboardEvent& key) override;
   virtual bool event(const SDL_Event& ev) override;
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   /** Binds a string to the textbox */
   void bind_string(std::string* value) { m_string = value; }
@@ -159,7 +159,6 @@ protected:
    */
   std::string m_internal_string_backup;
 
-  float m_backspace_remaining;
   float m_cursor_timer;
   int m_caret_pos;
   int m_secondary_caret_pos; /**< Used for selections */
@@ -174,7 +173,7 @@ protected:
   int m_current_offset;
 
 protected:
-  void on_backspace();
+  void delete_char_before_caret();
 
   /** Returns the largest string fitting in the box. */
   std::string get_truncated_text(std::string text) const;

--- a/src/interface/control_textbox_float.cpp
+++ b/src/interface/control_textbox_float.cpp
@@ -27,9 +27,9 @@ ControlTextboxFloat::ControlTextboxFloat() :
 }
 
 void
-ControlTextboxFloat::update(float dt_sec, const Controller& controller)
+ControlTextboxFloat::update(float dt_sec)
 {
-  ControlTextbox::update(dt_sec, controller);
+  ControlTextbox::update(dt_sec);
   if (!m_has_focus)
     revert_value();
 }

--- a/src/interface/control_textbox_float.hpp
+++ b/src/interface/control_textbox_float.hpp
@@ -24,7 +24,7 @@ class ControlTextboxFloat : public ControlTextbox
 public:
   ControlTextboxFloat();
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   float get_value() const { return *m_value; }
   void set_value(float value) { *m_value = value; revert_value(); }

--- a/src/interface/control_textbox_int.cpp
+++ b/src/interface/control_textbox_int.cpp
@@ -27,9 +27,9 @@ ControlTextboxInt::ControlTextboxInt() :
 }
 
 void
-ControlTextboxInt::update(float dt_sec, const Controller& controller)
+ControlTextboxInt::update(float dt_sec)
 {
-  ControlTextbox::update(dt_sec, controller);
+  ControlTextbox::update(dt_sec);
   if (!m_has_focus)
     revert_value();
 }

--- a/src/interface/control_textbox_int.hpp
+++ b/src/interface/control_textbox_int.hpp
@@ -24,7 +24,7 @@ class ControlTextboxInt : public ControlTextbox
 public:
   ControlTextboxInt();
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   int get_value() const { return *m_value; }
   void set_value(int value) { *m_value = value; revert_value(); }


### PR DESCRIPTION
- Improved selection: pressing left or right while having text selected will move the caret to the beginning or the end of the text selection, respectively (and clear the selection)
- Refactored the handling of the backspace key to make it similar to the handling of the delete key. This allows the usage of the regular update() function and makes controls compatible with Widgets again, in addition to make the code generally cleaner.