### PR TITLE
UI improvements

### DIFF
--- a/src/editor/particle_editor.cpp
+++ b/src/editor/particle_editor.cpp
@@ -112,7 +112,7 @@ ParticleEditor::reset_main_ui()
   // TODO: Use the addButton() command
   // Texture button start
   auto texture_btn = std::make_unique<ControlButton>("Change texture...  ->");
-  texture_btn.get()->m_on_change = new std::function<void()>([this](){
+  texture_btn.get()->m_on_change = std::function<void()>([this](){
     m_in_texture_tab = true;
   });
   float tmp_height = 0.f;
@@ -227,7 +227,7 @@ ParticleEditor::reset_main_ui()
 
   // TODO: add some ParticleEditor::addButton() function so that I don't have to put all that in here
   auto clear_btn = std::make_unique<ControlButton>("Clear");
-  clear_btn.get()->m_on_change = new std::function<void()>([this](){ m_particles->clear(); });
+  clear_btn.get()->m_on_change = std::function<void()>([this](){ m_particles->clear(); });
   float height = 0.f;
   for (const auto& control : m_controls) {
     height = std::max(height, control->get_rect().get_bottom() + 5.f);
@@ -243,7 +243,7 @@ ParticleEditor::reset_texture_ui()
   m_texture_rebinds.clear();
 
   auto return_btn = std::make_unique<ControlButton>("<- General settings");
-  return_btn.get()->m_on_change = new std::function<void()>([this](){
+  return_btn.get()->m_on_change = std::function<void()>([this](){
     m_in_texture_tab = false;
   });
   return_btn.get()->set_rect(Rectf(25.f, 0.f, 325.f, 20.f));
@@ -252,8 +252,8 @@ ParticleEditor::reset_texture_ui()
   auto likeliness_control = std::make_unique<ControlTextboxFloat>();
   likeliness_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->likeliness));
   likeliness_control.get()->set_rect(Rectf(150.f, 50.f, 350.f, 70.f));
-  likeliness_control.get()->m_label = new InterfaceLabel(Rectf(5.f, 50.f, 135.f, 70.f), "Likeliness");
-  likeliness_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  likeliness_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, 50.f, 135.f, 70.f), "Likeliness");
+  likeliness_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto likeliness_control_ptr = likeliness_control.get();
   m_texture_rebinds.push_back( [this, likeliness_control_ptr]{
     likeliness_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->likeliness));
@@ -263,8 +263,8 @@ ParticleEditor::reset_texture_ui()
   auto color_r_control = std::make_unique<ControlTextboxFloat>();
   color_r_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->color.red));
   color_r_control.get()->set_rect(Rectf(150.f, 80.f, 192.f, 100.f));
-  color_r_control.get()->m_label = new InterfaceLabel(Rectf(5.f, 80.f, 140.f, 100.f), "Color (RGBA)");
-  color_r_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  color_r_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, 80.f, 140.f, 100.f), "Color (RGBA)");
+  color_r_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   color_r_control.get()->m_validate_float = m_clamp_0_1;
   auto color_r_control_ptr = color_r_control.get();
   m_texture_rebinds.push_back( [this, color_r_control_ptr]{
@@ -275,7 +275,7 @@ ParticleEditor::reset_texture_ui()
   auto color_g_control = std::make_unique<ControlTextboxFloat>();
   color_g_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->color.green));
   color_g_control.get()->set_rect(Rectf(202.f, 80.f, 245.f, 100.f));
-  color_g_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  color_g_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   color_g_control.get()->m_validate_float = m_clamp_0_1;
   auto color_g_control_ptr = color_g_control.get();
   m_texture_rebinds.push_back( [this, color_g_control_ptr]{
@@ -286,7 +286,7 @@ ParticleEditor::reset_texture_ui()
   auto color_b_control = std::make_unique<ControlTextboxFloat>();
   color_b_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->color.blue));
   color_b_control.get()->set_rect(Rectf(255.f, 80.f, 297.f, 100.f));
-  color_b_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  color_b_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   color_b_control.get()->m_validate_float = m_clamp_0_1;
   auto color_b_control_ptr = color_b_control.get();
   m_texture_rebinds.push_back( [this, color_b_control_ptr]{
@@ -297,7 +297,7 @@ ParticleEditor::reset_texture_ui()
   auto color_a_control = std::make_unique<ControlTextboxFloat>();
   color_a_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->color.alpha));
   color_a_control.get()->set_rect(Rectf(307.f, 80.f, 350.f, 100.f));
-  color_a_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  color_a_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   color_a_control.get()->m_validate_float = m_clamp_0_1;
   auto color_a_control_ptr = color_a_control.get();
   m_texture_rebinds.push_back( [this, color_a_control_ptr]{
@@ -308,8 +308,8 @@ ParticleEditor::reset_texture_ui()
   auto scale_x_control = std::make_unique<ControlTextboxFloat>();
   scale_x_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->scale.x));
   scale_x_control.get()->set_rect(Rectf(150.f, 110.f, 240.f, 130.f));
-  scale_x_control.get()->m_label = new InterfaceLabel(Rectf(5.f, 110.f, 150.f, 130.f), "Scale (x, y)");
-  scale_x_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  scale_x_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, 110.f, 150.f, 130.f), "Scale (x, y)");
+  scale_x_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto scale_x_control_ptr = scale_x_control.get();
   m_texture_rebinds.push_back( [this, scale_x_control_ptr]{
     scale_x_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->scale.x));
@@ -319,7 +319,7 @@ ParticleEditor::reset_texture_ui()
   auto scale_y_control = std::make_unique<ControlTextboxFloat>();
   scale_y_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->scale.y));
   scale_y_control.get()->set_rect(Rectf(260.f, 110.f, 350.f, 130.f));
-  scale_y_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  scale_y_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto scale_y_control_ptr = scale_y_control.get();
   m_texture_rebinds.push_back( [this, scale_y_control_ptr]{
     scale_y_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->scale.y));
@@ -329,8 +329,8 @@ ParticleEditor::reset_texture_ui()
   auto hb_scale_x_control = std::make_unique<ControlTextboxFloat>();
   hb_scale_x_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_scale.x));
   hb_scale_x_control.get()->set_rect(Rectf(150.f, 140.f, 240.f, 160.f));
-  hb_scale_x_control.get()->m_label = new InterfaceLabel(Rectf(5.f, 140.f, 150.f, 160.f), "Hitbox scale (x, y)");
-  hb_scale_x_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  hb_scale_x_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, 140.f, 150.f, 160.f), "Hitbox scale (x, y)");
+  hb_scale_x_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto hb_scale_x_control_ptr = hb_scale_x_control.get();
   m_texture_rebinds.push_back( [this, hb_scale_x_control_ptr]{
     hb_scale_x_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_scale.x));
@@ -340,7 +340,7 @@ ParticleEditor::reset_texture_ui()
   auto hb_scale_y_control = std::make_unique<ControlTextboxFloat>();
   hb_scale_y_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_scale.y));
   hb_scale_y_control.get()->set_rect(Rectf(260.f, 140.f, 350.f, 160.f));
-  hb_scale_y_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  hb_scale_y_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto hb_scale_y_control_ptr = hb_scale_y_control.get();
   m_texture_rebinds.push_back( [this, hb_scale_y_control_ptr]{
     hb_scale_y_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_scale.y));
@@ -350,8 +350,8 @@ ParticleEditor::reset_texture_ui()
   auto hb_offset_x_control = std::make_unique<ControlTextboxFloat>();
   hb_offset_x_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_offset.x));
   hb_offset_x_control.get()->set_rect(Rectf(150.f, 170.f, 240.f, 190.f));
-  hb_offset_x_control.get()->m_label = new InterfaceLabel(Rectf(5.f, 170.f, 150.f, 190.f), "Hitbox offset relative to scale");
-  hb_offset_x_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  hb_offset_x_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, 170.f, 150.f, 190.f), "Hitbox offset relative to scale");
+  hb_offset_x_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto hb_offset_x_control_ptr = hb_offset_x_control.get();
   m_texture_rebinds.push_back( [this, hb_offset_x_control_ptr]{
     hb_offset_x_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_offset.x));
@@ -361,7 +361,7 @@ ParticleEditor::reset_texture_ui()
   auto hb_offset_y_control = std::make_unique<ControlTextboxFloat>();
   hb_offset_y_control.get()->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_offset.y));
   hb_offset_y_control.get()->set_rect(Rectf(260.f, 170.f, 350.f, 190.f));
-  hb_offset_y_control.get()->m_on_change = new std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
+  hb_offset_y_control.get()->m_on_change = std::function<void()>([this](){ m_particles->reinit_textures(); this->push_version(); });
   auto hb_offset_y_control_ptr = hb_offset_y_control.get();
   m_texture_rebinds.push_back( [this, hb_offset_y_control_ptr]{
     hb_offset_y_control_ptr->bind_value(&((m_particles->m_textures.begin() + m_texture_current)->hb_offset.y));
@@ -370,7 +370,7 @@ ParticleEditor::reset_texture_ui()
 
   // Texture button start
   auto chg_texture_btn = std::make_unique<ControlButton>("Change texture...");
-  chg_texture_btn.get()->m_on_change = new std::function<void()>([this](){
+  chg_texture_btn.get()->m_on_change = std::function<void()>([this](){
     const std::vector<std::string>& filter = {".jpg", ".png", ".surface"};
     MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>(
       nullptr,
@@ -388,7 +388,7 @@ ParticleEditor::reset_texture_ui()
   // Texture button end
 
   auto prev_btn = std::make_unique<ControlButton>("<");
-  prev_btn.get()->m_on_change = new std::function<void()>([this](){
+  prev_btn.get()->m_on_change = std::function<void()>([this](){
     m_texture_current--;
     if (m_texture_current < 0) m_texture_current = 0;
     for (const auto& refresh : m_texture_rebinds)
@@ -398,7 +398,7 @@ ParticleEditor::reset_texture_ui()
   m_controls_textures.push_back(std::move(prev_btn));
 
   auto del_btn = std::make_unique<ControlButton>("-");
-  del_btn.get()->m_on_change = new std::function<void()>([this](){
+  del_btn.get()->m_on_change = std::function<void()>([this](){
     if (m_particles->m_textures.size() < 1)
       return;
     m_particles->m_textures.erase(m_particles->m_textures.begin() + m_texture_current);
@@ -413,7 +413,7 @@ ParticleEditor::reset_texture_ui()
   m_controls_textures.push_back(std::move(del_btn));
 
   auto add_btn = std::make_unique<ControlButton>("+");
-  add_btn.get()->m_on_change = new std::function<void()>([this](){
+  add_btn.get()->m_on_change = std::function<void()>([this](){
     m_particles->m_textures.push_back(CustomParticleSystem::SpriteProperties());
     m_texture_current = static_cast<int>(m_particles->m_textures.size()) - 1;
     for (const auto& refresh : m_texture_rebinds)
@@ -425,7 +425,7 @@ ParticleEditor::reset_texture_ui()
   m_controls_textures.push_back(std::move(add_btn));
 
   auto next_btn = std::make_unique<ControlButton>(">");
-  next_btn.get()->m_on_change = new std::function<void()>([this](){
+  next_btn.get()->m_on_change = std::function<void()>([this](){
     m_texture_current++;
     if (m_texture_current > static_cast<int>(m_particles->m_textures.size()) - 1)
       m_texture_current = static_cast<int>(m_particles->m_textures.size()) - 1;
@@ -469,11 +469,11 @@ ParticleEditor::addTextboxFloatWithImprecision(const std::string& name, float* b
   float_control.get()->set_rect(Rectf(150.f, height, 235.f, height + 20.f));
   imp_control.get()->set_rect(Rectf(265.f, height, 350.f, height + 20.f));
 
-  float_control.get()->m_label = new InterfaceLabel(Rectf(5.f, height, 145.f, height + 20.f), name);
-  imp_control.get()->m_label = new InterfaceLabel(Rectf(240.f, height, 260.f, height + 20.f), "±");
+  float_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, height, 145.f, height + 20.f), name);
+  imp_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(240.f, height, 260.f, height + 20.f), "±");
 
-  float_control.get()->m_on_change = new std::function<void()>([this](){ this->push_version(); });
-  imp_control.get()->m_on_change = new std::function<void()>([this](){ this->push_version(); });
+  float_control.get()->m_on_change = std::function<void()>([this](){ this->push_version(); });
+  imp_control.get()->m_on_change = std::function<void()>([this](){ this->push_version(); });
 
   m_controls.push_back(std::move(float_control));
   m_controls.push_back(std::move(imp_control));
@@ -554,8 +554,8 @@ ParticleEditor::addControl(std::string name, std::unique_ptr<InterfaceControl> n
                                       height + new_control.get()->get_rect().get_height()));
   }
 
-  new_control.get()->m_label = new InterfaceLabel(Rectf(5.f, height, 135.f, height + 20.f), std::move(name));
-  new_control.get()->m_on_change = new std::function<void()>([this](){ this->push_version(); });
+  new_control.get()->m_label = std::make_unique<InterfaceLabel>(Rectf(5.f, height, 135.f, height + 20.f), std::move(name));
+  new_control.get()->m_on_change = std::function<void()>([this](){ this->push_version(); });
   m_controls.push_back(std::move(new_control));
 }
 

--- a/src/editor/particle_editor.cpp
+++ b/src/editor/particle_editor.cpp
@@ -697,11 +697,11 @@ ParticleEditor::update(float dt_sec, const Controller& controller)
 
   if (m_in_texture_tab) {
     for(const auto& control : m_controls_textures) {
-      control->update(dt_sec, controller);
+      control->update(dt_sec);
     }
   } else {
     for(const auto& control : m_controls) {
-      control->update(dt_sec, controller);
+      control->update(dt_sec);
     }
   }
 

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -1,0 +1,53 @@
+//  SuperTux
+//  Copyright (C) 2021 A. Semphris <semphris@protonmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "interface/container.hpp"
+
+InterfaceContainer::InterfaceContainer() :
+  InterfaceControl(),
+  m_children()
+{
+}
+
+bool
+InterfaceContainer::event(const SDL_Event& ev)
+{
+  for (auto& child : m_children)
+    if (child.event(ev))
+      return true;
+  
+  return false;
+}
+
+void
+InterfaceContainer::update(float dt_sec)
+{
+  for (auto& child : m_children)
+    child.update(dt_sec);
+}
+
+void
+InterfaceContainer::draw(DrawingContext& context)
+{
+  context.push_transform();
+  context.set_translation(context.get_translation() + m_rect.p1());
+  context.set_viewport(Rect(m_rect));
+
+  for (auto& child : m_children)
+    child.draw(context);
+
+  context.pop_transform();
+}

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -1,0 +1,47 @@
+//  SuperTux
+//  Copyright (C) 2021 A. Semphris <semphris@protonmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_INTERFACE_CONTAINER_HPP
+#define HEADER_SUPERTUX_INTERFACE_CONTAINER_HPP
+
+#include <SDL.h>
+
+#include "interface/control.hpp"
+#include "math/rectf.hpp"
+#include "video/drawing_context.hpp"
+
+/** Class that's designed to contain other controls */
+class InterfaceContainer final : public InterfaceControl
+{
+public:
+  InterfaceContainer();
+  virtual ~InterfaceContainer() {}
+
+  virtual bool event(const SDL_Event& ev) override;
+  virtual void update(float dt_sec) override;
+  virtual void draw(DrawingContext& context) override;
+
+public:
+  std::vector<InterfaceControl> m_children;
+
+private:
+  InterfaceContainer(const InterfaceContainer&) = delete;
+  InterfaceContainer& operator=(const InterfaceContainer&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/interface/control.cpp
+++ b/src/interface/control.cpp
@@ -20,7 +20,8 @@ InterfaceControl::InterfaceControl() :
   m_on_change(),
   m_label(),
   m_has_focus(),
-  m_rect()
+  m_rect(),
+  m_parent(nullptr)
 {
 }
 

--- a/src/interface/control.hpp
+++ b/src/interface/control.hpp
@@ -53,6 +53,8 @@ protected:
   bool m_has_focus;
   /** The rectangle where the InterfaceControl should be rendered */
   Rectf m_rect;
+  /** A pointer to the parent container, or null if not in any container. */
+  InterfaceControl* m_parent;
 
 private:
   InterfaceControl(const InterfaceControl&) = delete;

--- a/src/interface/control.hpp
+++ b/src/interface/control.hpp
@@ -43,10 +43,10 @@ public:
   /** Optional; a function that will be called each time the bound value
    *  is modified.
    */
-  std::function<void()> *m_on_change;
+  std::function<void()> m_on_change;
 
   /** Optional; the label associated with the control */
-  InterfaceLabel* m_label;
+  std::unique_ptr<InterfaceLabel> m_label;
 
 protected:
   /** Whether or not the user has this InterfaceControl as focused */

--- a/src/interface/control.hpp
+++ b/src/interface/control.hpp
@@ -30,8 +30,6 @@ public:
   InterfaceControl();
   virtual ~InterfaceControl() {}
 
-  virtual void update(float dt_sec) override { throw std::runtime_error("Cannot call generic update() on interface control"); }
-  virtual void update(float dt_sec, const Controller& controller) {}
   virtual void draw(DrawingContext& context) override { if (m_label) m_label->draw(context); }
   virtual bool on_mouse_motion(const SDL_MouseMotionEvent& motion) override { if (m_label) m_label->on_mouse_motion(motion); return false; }
 

--- a/src/interface/control_button.cpp
+++ b/src/interface/control_button.cpp
@@ -61,7 +61,7 @@ ControlButton::on_mouse_button_up(const SDL_MouseButtonEvent& button)
   m_mouse_down = false;
 
   if (m_on_change)
-    (*m_on_change)();
+    m_on_change();
 
   m_has_focus = true;
 
@@ -91,7 +91,7 @@ ControlButton::on_key_up(const SDL_KeyboardEvent& key)
 
   if (key.keysym.sym == SDLK_SPACE) {
     if (m_on_change)
-      (*m_on_change)();
+      m_on_change();
     m_mouse_down = false;
     return true;
   }

--- a/src/interface/control_checkbox.cpp
+++ b/src/interface/control_checkbox.cpp
@@ -59,7 +59,7 @@ ControlCheckbox::on_mouse_button_up(const SDL_MouseButtonEvent& button)
   *m_value = !*m_value;
 
   if (m_on_change)
-    (*m_on_change)();
+    m_on_change();
 
   m_has_focus = true;
 
@@ -85,7 +85,7 @@ ControlCheckbox::on_key_up(const SDL_KeyboardEvent& key)
   *m_value = !*m_value;
 
   if (m_on_change)
-    (*m_on_change)();
+    m_on_change();
 
   return true;
 }

--- a/src/interface/control_enum.hpp
+++ b/src/interface/control_enum.hpp
@@ -185,7 +185,7 @@ ControlEnum<T>::on_mouse_button_down(const SDL_MouseButtonEvent& button)
             *m_value = option.first;
 
             if (m_on_change)
-              (*m_on_change)();
+              m_on_change();
 
             break;
           }
@@ -254,7 +254,7 @@ ControlEnum<T>::on_key_down(const SDL_KeyboardEvent& key)
       *m_value = m_options.begin()->first;
 
     if (m_on_change)
-      (*m_on_change)();
+      m_on_change();
 
     return true;
   } else if (key.keysym.sym == SDLK_UP) {
@@ -280,7 +280,7 @@ ControlEnum<T>::on_key_down(const SDL_KeyboardEvent& key)
       *m_value = last_value;
 
     if (m_on_change)
-      (*m_on_change)();
+      m_on_change();
 
     return true;
   }

--- a/src/interface/control_textbox.cpp
+++ b/src/interface/control_textbox.cpp
@@ -332,7 +332,7 @@ ControlTextbox::parse_value(bool call_on_change /* = true  (see header)*/)
       *m_string = new_str;
 
     if (call_on_change && m_on_change)
-      (*m_on_change)();
+      m_on_change();
   }
 
   return true;

--- a/src/interface/control_textbox.cpp
+++ b/src/interface/control_textbox.cpp
@@ -27,17 +27,14 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
-// Shamelessly snatched values from src/gui/menu.cpp
-static const float CONTROL_REPEAT_INITIAL = 0.4f;
-static const float CONTROL_REPEAT_RATE    = 0.05f;
-static const float CONTROL_CURSOR_TIMER   = 0.5f;
+// The time for the caret to change visibility (when it flashes)
+static const float CONTROL_CURSOR_TIMER = 0.5f;
 
 ControlTextbox::ControlTextbox() :
   m_validate_string(),
   m_charlist(),
   m_string(nullptr),
   m_internal_string_backup(""),
-  m_backspace_remaining(CONTROL_REPEAT_INITIAL),
   m_cursor_timer(CONTROL_CURSOR_TIMER),
   m_caret_pos(),
   m_secondary_caret_pos(),
@@ -49,22 +46,8 @@ ControlTextbox::ControlTextbox() :
 }
 
 void
-ControlTextbox::update(float dt_sec, const Controller& controller)
+ControlTextbox::update(float dt_sec)
 {
-  if (controller.pressed(Control::REMOVE)) {
-    on_backspace();
-  }
-
-  if (controller.hold(Control::REMOVE)) {
-    m_backspace_remaining -= dt_sec;
-    while (m_backspace_remaining < 0) {
-      on_backspace();
-      m_backspace_remaining += CONTROL_REPEAT_RATE;
-    }
-  } else {
-    m_backspace_remaining = CONTROL_REPEAT_INITIAL;
-  }
-
   m_cursor_timer -= dt_sec;
   if (m_cursor_timer < -CONTROL_CURSOR_TIMER) {
     m_cursor_timer = CONTROL_CURSOR_TIMER;
@@ -75,31 +58,16 @@ ControlTextbox::update(float dt_sec, const Controller& controller)
 }
 
 void
-ControlTextbox::on_backspace()
+ControlTextbox::delete_char_before_caret()
 {
   if (m_charlist.size()) {
-    if (m_caret_pos != m_secondary_caret_pos) {
+    m_caret_pos--;
+    m_secondary_caret_pos = m_caret_pos;
+    m_cursor_timer = CONTROL_CURSOR_TIMER;
 
-      m_cursor_timer = CONTROL_CURSOR_TIMER;
-
-      auto it = m_charlist.begin();
-      advance(it, std::min(m_caret_pos, m_secondary_caret_pos));
-      auto it2 = m_charlist.begin();
-      advance(it2, std::max(m_caret_pos, m_secondary_caret_pos));
-      m_charlist.erase(it, it2);
-
-      m_caret_pos = std::min(m_caret_pos, m_secondary_caret_pos);
-      m_secondary_caret_pos = m_caret_pos;
-
-    } else if (m_caret_pos > 0) {
-      m_caret_pos--;
-      m_secondary_caret_pos = m_caret_pos;
-      m_cursor_timer = CONTROL_CURSOR_TIMER;
-
-      auto it = m_charlist.begin();
-      advance(it, m_caret_pos);
-      m_charlist.erase(it);
-    }
+    auto it = m_charlist.begin();
+    advance(it, m_caret_pos);
+    m_charlist.erase(it);
 
     recenter_offset();
   }
@@ -229,12 +197,44 @@ ControlTextbox::on_key_down(const SDL_KeyboardEvent& key)
 
   if (key.keysym.sym == SDLK_LEFT && m_caret_pos > 0)
   {
-    m_caret_pos--;
-    m_cursor_timer = CONTROL_CURSOR_TIMER;
-    if (!m_shift_pressed)
-      m_secondary_caret_pos = m_caret_pos;
+    if (!m_shift_pressed && m_secondary_caret_pos != m_caret_pos)
+    {
+      m_secondary_caret_pos = m_caret_pos = std::min(m_secondary_caret_pos, m_caret_pos);
+    }
+    else
+    {
+      m_caret_pos--;
+      m_cursor_timer = CONTROL_CURSOR_TIMER;
+      if (!m_shift_pressed)
+        m_secondary_caret_pos = m_caret_pos;
+    }
 
     recenter_offset();
+    return true;
+  }
+  else if (key.keysym.sym == SDLK_RIGHT && m_caret_pos < int(m_charlist.size()))
+  {
+    if (!m_shift_pressed && m_secondary_caret_pos != m_caret_pos)
+    {
+      m_secondary_caret_pos = m_caret_pos = std::max(m_secondary_caret_pos, m_caret_pos);
+    }
+    else
+    {
+      m_caret_pos++;
+      m_cursor_timer = CONTROL_CURSOR_TIMER;
+      if (!m_shift_pressed)
+        m_secondary_caret_pos = m_caret_pos;
+    }
+
+    recenter_offset();
+    return true;
+  }
+  else if (key.keysym.sym == SDLK_BACKSPACE)
+  {
+    if (!erase_selected_text() && m_caret_pos > 0)
+    {
+      delete_char_before_caret();
+    }
     return true;
   }
   else if (key.keysym.sym == SDLK_DELETE)
@@ -242,18 +242,8 @@ ControlTextbox::on_key_down(const SDL_KeyboardEvent& key)
     if (!erase_selected_text() && static_cast<int>(m_charlist.size()) > m_caret_pos)
     {
       m_caret_pos++;
-      on_backspace();
+      delete_char_before_caret();
     }
-    return true;
-  }
-  else if (key.keysym.sym == SDLK_RIGHT && m_caret_pos < int(m_charlist.size()))
-  {
-    m_caret_pos++;
-    m_cursor_timer = CONTROL_CURSOR_TIMER;
-    if (!m_shift_pressed)
-      m_secondary_caret_pos = m_caret_pos;
-
-    recenter_offset();
     return true;
   }
   else if (key.keysym.sym == SDLK_HOME)

--- a/src/interface/control_textbox.hpp
+++ b/src/interface/control_textbox.hpp
@@ -36,7 +36,7 @@ public:
   virtual bool on_key_down(const SDL_KeyboardEvent& key) override;
   virtual bool event(const SDL_Event& ev) override;
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   /** Binds a string to the textbox */
   void bind_string(std::string* value) { m_string = value; }
@@ -159,7 +159,6 @@ protected:
    */
   std::string m_internal_string_backup;
 
-  float m_backspace_remaining;
   float m_cursor_timer;
   int m_caret_pos;
   int m_secondary_caret_pos; /**< Used for selections */
@@ -174,7 +173,7 @@ protected:
   int m_current_offset;
 
 protected:
-  void on_backspace();
+  void delete_char_before_caret();
 
   /** Returns the largest string fitting in the box. */
   std::string get_truncated_text(std::string text) const;

--- a/src/interface/control_textbox_float.cpp
+++ b/src/interface/control_textbox_float.cpp
@@ -71,7 +71,7 @@ ControlTextboxFloat::parse_value(bool call_on_change /* = true (see header */)
     revert_value();
 
     if (call_on_change && m_on_change)
-      (*m_on_change)();
+      m_on_change();
   }
 
   return true;

--- a/src/interface/control_textbox_float.cpp
+++ b/src/interface/control_textbox_float.cpp
@@ -27,9 +27,9 @@ ControlTextboxFloat::ControlTextboxFloat() :
 }
 
 void
-ControlTextboxFloat::update(float dt_sec, const Controller& controller)
+ControlTextboxFloat::update(float dt_sec)
 {
-  ControlTextbox::update(dt_sec, controller);
+  ControlTextbox::update(dt_sec);
   if (!m_has_focus)
     revert_value();
 }

--- a/src/interface/control_textbox_float.hpp
+++ b/src/interface/control_textbox_float.hpp
@@ -24,7 +24,7 @@ class ControlTextboxFloat : public ControlTextbox
 public:
   ControlTextboxFloat();
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   float get_value() const { return *m_value; }
   void set_value(float value) { *m_value = value; revert_value(); }

--- a/src/interface/control_textbox_int.cpp
+++ b/src/interface/control_textbox_int.cpp
@@ -27,9 +27,9 @@ ControlTextboxInt::ControlTextboxInt() :
 }
 
 void
-ControlTextboxInt::update(float dt_sec, const Controller& controller)
+ControlTextboxInt::update(float dt_sec)
 {
-  ControlTextbox::update(dt_sec, controller);
+  ControlTextbox::update(dt_sec);
   if (!m_has_focus)
     revert_value();
 }

--- a/src/interface/control_textbox_int.cpp
+++ b/src/interface/control_textbox_int.cpp
@@ -71,7 +71,7 @@ ControlTextboxInt::parse_value(bool call_on_change /* = true (see header */)
     revert_value();
 
     if (call_on_change && m_on_change)
-      (*m_on_change)();
+      m_on_change();
   }
 
   return true;

--- a/src/interface/control_textbox_int.hpp
+++ b/src/interface/control_textbox_int.hpp
@@ -24,7 +24,7 @@ class ControlTextboxInt : public ControlTextbox
 public:
   ControlTextboxInt();
 
-  virtual void update(float dt_sec, const Controller& controller) override;
+  virtual void update(float dt_sec) override;
 
   int get_value() const { return *m_value; }
   void set_value(int value) { *m_value = value; revert_value(); }


### PR DESCRIPTION
Includes #1659 and #1660.

List of changes:
- Added containers for UI components.
- Some places in the custom interface controls used raw pointers. I replaced those with smart pointers, or no pointers at all where relevant.
- Improved text selection: pressing left or right while having text selected will move the caret to the beginning or the end of the text selection, respectively (and clear the selection)
- Refactored the handling of the backspace key to make it similar to the handling of the delete key. This allows the usage of the regular update() function and makes controls compatible with Widgets again, in addition to make the code generally cleaner.
