### PR TITLE
[QoL] Native cursor option

### DIFF
--- a/src/gui/mousecursor.cpp
+++ b/src/gui/mousecursor.cpp
@@ -18,6 +18,8 @@
 
 #include <SDL.h>
 
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "sprite/sprite.hpp"
 #include "video/drawing_context.hpp"
 #include "video/renderer.hpp"
@@ -77,6 +79,7 @@ MouseCursor::apply_state(MouseCursorState state)
 void
 MouseCursor::draw(DrawingContext& context)
 {
+  if (!g_config->custom_mouse_cursor) return;
   if (m_state != MouseCursorState::HIDE)
   {
     int x, y;

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -57,6 +57,7 @@ Config::Config() :
   transitions_enabled(true),
   confirmation_dialog(false),
   pause_on_focusloss(true),
+  custom_mouse_cursor(true),
 #ifdef ENABLE_DISCORD
   enable_discord(false),
 #endif
@@ -84,6 +85,7 @@ Config::load()
   config_mapping.get("developer", developer_mode);
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
+  config_mapping.get("custom_mouse_cursor", custom_mouse_cursor);
 
   boost::optional<ReaderMapping> config_integrations_mapping;
   if (config_mapping.get("integrations", config_integrations_mapping))
@@ -203,7 +205,8 @@ Config::save()
   writer.write("developer", developer_mode);
   writer.write("confirmation_dialog", confirmation_dialog);
   writer.write("pause_on_focusloss", pause_on_focusloss);
-  
+  writer.write("custom_mouse_cursor", custom_mouse_cursor);
+
   writer.start_list("integrations");
   {
     writer.write("hide_editor_levelnames", hide_editor_levelnames);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -97,6 +97,7 @@ public:
   bool transitions_enabled;
   bool confirmation_dialog;
   bool pause_on_focusloss;
+  bool custom_mouse_cursor;
 
 #ifdef ENABLE_DISCORD
   bool enable_discord;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -364,7 +364,7 @@ Main::init_video()
   SDLSurfacePtr icon = SDLSurface::from_file(icon_fname);
   VideoSystem::current()->set_icon(*icon);
 
-  SDL_ShowCursor(0);
+  SDL_ShowCursor(g_config->custom_mouse_cursor ? 0 : 1);
 
   log_info << (g_config->use_fullscreen?"fullscreen ":"window ")
            << " Window: "     << g_config->window_size

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -63,7 +63,8 @@ enum OptionsMenuIDs {
   MNID_CHRISTMAS_MODE,
   MNID_TRANSITIONS,
   MNID_CONFIRMATION_DIALOG,
-  MNID_PAUSE_ON_FOCUSLOSS
+  MNID_PAUSE_ON_FOCUSLOSS,
+  MNID_CUSTOM_CURSOR
 };
 
 OptionsMenu::OptionsMenu(bool complete) :
@@ -399,8 +400,9 @@ OptionsMenu::OptionsMenu(bool complete) :
   }
 
   add_toggle(MNID_CONFIRMATION_DIALOG, _("Confirmation Dialog"), &g_config->confirmation_dialog).set_help(_("Confirm aborting level"));
-  add_toggle(MNID_CONFIRMATION_DIALOG, _("Pause on focus loss"), &g_config->pause_on_focusloss)
+  add_toggle(MNID_PAUSE_ON_FOCUSLOSS, _("Pause on focus loss"), &g_config->pause_on_focusloss)
     .set_help("Automatically pause the game when the window loses focus");
+  add_toggle(MNID_CUSTOM_CURSOR, _("Use custom mouse cursor"), &g_config->custom_mouse_cursor).set_help(_("Whether the game renders its own cursor or uses the system's cursor"));
 
   add_submenu(_("Integrations and presence"), MenuStorage::INTEGRATIONS_MENU)
       .set_help(_("Manage whether SuperTux should display the levels you play on your social media profiles (Discord)"));
@@ -560,6 +562,10 @@ OptionsMenu::menu_action(MenuItem& item)
         SoundManager::current()->set_music_volume(g_config->music_volume);
         g_config->save();
       }
+      break;
+
+    case MNID_CUSTOM_CURSOR:
+      SDL_ShowCursor(g_config->custom_mouse_cursor ? 0 : 1);
       break;
 
     default:


### PR DESCRIPTION
This PR adds a small QoL option that turns off the game's cursor to render the system's cursor instead.

This was originally made to try to address an issue reported on the ST Discord server, but I was unable to compile on Windows to test with the magnifier.
Here are an image and the attached video of said issue
https://user-images.githubusercontent.com/37770353/107215136-34ec0680-6a0b-11eb-9754-bad221367020.mp4
![magnifier bug](https://user-images.githubusercontent.com/37770353/107215139-35849d00-6a0b-11eb-958b-32447cba1339.png)

(this also comes with a very minor fix in the options menu file where an enumeration element was not used)