### PR TITLE
[QoL] Climbable small tweak

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2079,7 +2079,7 @@ Player::handle_input_climbing()
     m_dir = Direction::RIGHT;
     vx += MAX_CLIMB_XM;
   }
-  if (m_controller->hold(Control::UP)) {
+  if (m_controller->hold(Control::UP) && m_col.m_bbox.get_top() > m_climbing->get_bbox().get_top()) {
     vy -= MAX_CLIMB_YM;
   }
   if (m_controller->hold(Control::DOWN)) {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -37,6 +37,7 @@
 #include "supertux/gameconfig.hpp"
 #include "supertux/sector.hpp"
 #include "supertux/tile.hpp"
+#include "trigger/climbable.hpp"
 #include "trigger/trigger_base.hpp"
 #include "video/surface.hpp"
 

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -26,6 +26,7 @@
 #include "supertux/player_status.hpp"
 #include "supertux/sequence.hpp"
 #include "supertux/timer.hpp"
+#include "trigger/climbable.hpp"
 #include "video/surface_ptr.hpp"
 
 class BadGuy;

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -26,7 +26,6 @@
 #include "supertux/player_status.hpp"
 #include "supertux/sequence.hpp"
 #include "supertux/timer.hpp"
-#include "trigger/climbable.hpp"
 #include "video/surface_ptr.hpp"
 
 class BadGuy;


### PR DESCRIPTION
This PR adds a limit for when Tux reaches the top of a climbable area, where he will stop before jumping out of the area.

This was originally made for ladders to make it easier to jump off the top, but this applies to every climbable zone.
Possible improvement: make this an option to all climbable zones to restrict *some* boundaries