### PR TITLE
Added workflow for 32-bit Linux (i386,x86)

### DIFF
--- a/.ci_scripts/build_appimage.sh
+++ b/.ci_scripts/build_appimage.sh
@@ -6,8 +6,7 @@
 # For more information, see http://appimage.org/
 ########################################################################
 
-export ARCH=$(arch)
-
+export ARCH=$ARCH
 APP=SuperTux
 LOWERAPP=supertux2
 

--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -8,7 +8,7 @@ if [ "$OS_NAME" = "macos-latest" ] && [ "$PACKAGE" = "ON" ]; then
 fi
 
 # make only one source package
-if [ "$OS_NAME" = "ubuntu-latest" ] && [ "$COMPILER_NAME" = "gcc" ] && [ "$BUILD_NAME" = "Debug" ] && [ "$PACKAGE" = "ON" ]; then
+if [ "$OS_NAME" = "ubuntu-latest" ] && [ "$COMPILER_NAME" = "gcc" ] && [ "$BUILD_NAME" = "Debug" ] && [ "$ARCH" = "64" ] && [ "$PACKAGE" = "ON" ]; then
     cpack --config CPackSourceConfig.cmake -G TGZ;
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           sudo apt install -y gcc-multilib g++-multilib libogg-dev:i386 libvorbis-dev:i386 libopenal-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-locale-dev:i386 libsdl2-dev:i386 libsdl2-image-dev:i386 libfreetype6-dev:i386 libcurl4-openssl-dev:i386 libharfbuzz-dev:i386 libfribidi-dev:i386
           # Nethier GLEW nor glbinding exist in 32-bit for Ubuntu 20.04, so snatch the debs from 16.04 instead
           wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew1.13_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
-          wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew-dev_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
+          wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew-dev_1.13.0-2_i386.deb && sudo dpkg -i libglew-dev_1.13.0-2_i386.deb
       - name: Install macos dependencies
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update 
-          sudo apt install -y cmake build-essential automake clang-6.0 g++-8 gtk-doc-tools rpm sshpass
+          sudo apt install -y cmake build-essential automake gtk-doc-tools rpm sshpass
           sudo apt install -y gcc-multilib g++-multilib libogg-dev:i386 libvorbis-dev:i386 libopenal-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-locale-dev:i386 libsdl2-dev:i386 libsdl2-image-dev:i386 libfreetype6-dev:i386 libcurl4-openssl-dev:i386 libharfbuzz-dev:i386 libfribidi-dev:i386
           # Nethier GLEW nor glbinding exist in 32-bit for Ubuntu 20.04, so snatch the debs from 16.04 instead
           wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew1.13_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
@@ -91,13 +91,13 @@ jobs:
       - name: Set compiler (gcc)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' }}
         run: |
-          echo "CXX=g++-8" >> $GITHUB_ENV
-          echo "CC=gcc-8" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+          echo "CC=gcc" >> $GITHUB_ENV
       - name: Set compiler (clang)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.compiler == 'clang' }}
         run: |
-          echo "CXX=clang++-6.0" >> $GITHUB_ENV
-          echo "CC=clang-6.0" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CC=clang" >> $GITHUB_ENV
       - name: Set compiler (macos)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,16 +31,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [32, 64]
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, clang]
         build_type: [Debug, Release]
         exclude:
           - os: macos-latest
             compiler: gcc
+          - os: macos-latest
+            arch: 32
         include:
           - os: ubuntu-latest
             build_type: Release
             compiler: gcc
+            arch: 32
+            release: 'ON'
+          - os: ubuntu-latest
+            build_type: Release
+            compiler: gcc
+            arch: 64
             release: 'ON'
           - os: macos-latest
             build_type: Release
@@ -53,14 +62,25 @@ jobs:
           # Fetch the whole tree so git describe works
           fetch-depth: 0
           submodules: true
-      - name: Install linux dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Install 64-bit linux dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 64 }}
         run: |
           sudo apt-get update 
-          sudo apt install -y cmake build-essential automake clang-6.0 g++-8 libc++-dev libogg-dev \
-                libvorbis-dev libopenal-dev libboost-all-dev libsdl2-dev libsdl2-image-dev \
-                libfreetype6-dev libharfbuzz-dev libfribidi-dev libglib2.0-dev gtk-doc-tools \
-                rpm sshpass libraqm-dev libglew-dev libcurl4-openssl-dev
+          sudo apt install -y gcc-multilib g++-multilib cmake build-essential \
+                automake clang-6.0 g++-8 libc++-dev libogg-dev libvorbis-dev \
+                libopenal-dev libboost-all-dev libsdl2-dev libsdl2-image-dev \
+                libfreetype6-dev libharfbuzz-dev libfribidi-dev libglib2.0-dev \
+                gtk-doc-tools rpm sshpass libraqm-dev libglew-dev libcurl4-openssl-dev
+      - name: Install 32-bit linux dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 32 }}
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update 
+          sudo apt install -y cmake build-essential automake clang-6.0 g++-8 gtk-doc-tools rpm sshpass
+          sudo apt install -y gcc-multilib g++-multilib libogg-dev:i386 libvorbis-dev:i386 libopenal-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-locale-dev:i386 libsdl2-dev:i386 libsdl2-image-dev:i386 libfreetype6-dev:i386 libcurl4-openssl-dev:i386 libharfbuzz-dev:i386 libfribidi-dev:i386
+          # Nethier GLEW nor glbinding exist in 32-bit for Ubuntu 20.04, so snatch the debs from 16.04 instead
+          wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew1.13_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
+          wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew-dev_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
       - name: Install macos dependencies
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
@@ -89,13 +109,14 @@ jobs:
       - name: Configure bulid
         env:
           BUILD_TYPE: ${{ matrix.build_type }}
+          ARCH: ${{ matrix.arch == 32 && '-DCMAKE_C_FLASG=-m32 -DCMAKE_CXX_FLAGS=-m32' || '' }}
         run: |
           cmake --version
           $CXX --version
           mkdir "build"
           cd "build"
           # TODO add -DGLBINDING_ENABLED=$USE_GLBINDING
-          cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DWARNINGS=ON -DWERROR=ON -DBUILD_TESTS=ON -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=/usr -DINSTALL_SUBDIR_BIN=bin -DINSTALL_SUBDIR_SHARE=share/supertux2
+          cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${ARCH} -DWARNINGS=ON -DWERROR=ON -DBUILD_TESTS=ON -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=/usr -DINSTALL_SUBDIR_BIN=bin -DINSTALL_SUBDIR_SHARE=share/supertux2
       - name: Build and install
         working-directory: build
         run: |
@@ -107,6 +128,7 @@ jobs:
       - name: Package
         env:
           OS_NAME: ${{ matrix.os }}
+          ARCH: ${{ matrix.arch }}
           COMPILER_NAME: ${{ matrix.compiler }}
           BUILD_NAME: ${{ matrix.build_type }}
           PACKAGE: 'ON'
@@ -115,7 +137,7 @@ jobs:
       # Github actions is dumb and won't let you download single files from artifacts, so break up the artifacts instead
       - uses: actions/upload-artifact@v2
         with:
-          name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-appimage"
+          name: "${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.build_type }}-appimage"
           path: build/upload/*.AppImage
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v2
@@ -138,13 +160,13 @@ jobs:
           aws_key_id: ${{ secrets.CI_DOWNLOAD_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.CI_DOWNLOAD_SECRET_ACCESS_KEY }}
           source_dir: 'build/upload'
-          destination_dir: "${{ github.sha }}/gh-actions/${{ matrix.os }}/${{ github.run_id }}"              
+          destination_dir: "${{ github.sha }}/gh-actions/${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}"              
       - name: Post uploaded file
         if: matrix.release == 'ON' && env.DOWNLOAD_APIKEY != null
         working-directory: build
         run: ../.ci_scripts/deploy.sh
         env:
-          PREFIX: "${{ github.sha }}/gh-actions/${{ matrix.os }}/${{ github.run_id }}"
+          PREFIX: "${{ github.sha }}/gh-actions/${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}"
           DOWNLOAD_APIKEY: ${{ secrets.DOWNLOAD_APIKEY }}
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/') && matrix.release == 'ON' && github.repository_owner == 'supertux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Configure bulid
         env:
           BUILD_TYPE: ${{ matrix.build_type }}
-          ARCH: ${{ matrix.arch == 32 && '-DCMAKE_C_FLASG=-m32 -DCMAKE_CXX_FLAGS=-m32' || '' }}
+          ARCH: ${{ matrix.arch == 32 && '-DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32' || '' }}
         run: |
           cmake --version
           $CXX --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,24 @@ if(WIN32)
   endif(VCPKG_BUILD)
 
 else(WIN32)
-  include(FindPkgConfig)
-  pkg_search_module(SDL2 REQUIRED sdl2>=2.0.1)
-  pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
+
+  if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+    # 32-bit
+    find_library(SDL2_LIBRARIES SDL2)
+    find_library(SDL2IMAGE_LIBRARIES SDL2_image)
+    find_path(SDL2_INCLUDE_DIRS SDL2/SDL.h)
+    find_path(SDL2IMAGE_INCLUDE_DIRS SDL2/SDL_image.h)
+    set(SDL2_INCLUDE_DIRS ${SDL2_INCLUDE_DIRS}/SDL2)
+    set(SDL2IMAGE_INCLUDE_DIRS ${SDL2IMAGE_INCLUDE_DIRS}/SDL2)
+    message(STATUS "SDL LIBS: ${SDL2_LIBRARIES}")
+    message(STATUS "SDL INCL: ${SDL2_INCLUDE_DIRS}")
+  else()
+    # 64-bit
+    include(FindPkgConfig)
+    pkg_search_module(SDL2 REQUIRED sdl2>=2.0.1)
+    pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
+  endif()
+
 endif(WIN32)
 set(HAVE_SDL TRUE)
 


### PR DESCRIPTION
Note for whoever wishes to maintain the CMakeLists.txt file, the find_package module that is used to find the SDL installs seems to be a bottleneck in portability (It hit me as well when making the android port). Feel free to change the check for 32-bit/64-bit to something different, it isn't a "true" condition, as in, find_package isn't systematically the way to pick when using any 64-bit system.