### PR TITLE
 Bumper: push the player only if it moves against the bumper 

### DIFF
--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -33,11 +33,11 @@ Bumper::Bumper(const ReaderMapping& reader) :
   physic(),
   left()
 {
-	reader.get("left", left);
+  reader.get("left", left);
   m_sprite->set_action(left ? "left-normal" : "right-normal");
-	physic.enable_gravity(false);
+  physic.enable_gravity(false);
 }
-  
+
 ObjectSettings
 Bumper::get_settings()
 {
@@ -49,7 +49,7 @@ Bumper::get_settings()
 
   return result;
 }
-  
+
 void
 Bumper::update(float dt_sec)
 {
@@ -66,18 +66,18 @@ Bumper::collision(GameObject& other, const CollisionHit& hit)
   auto player = dynamic_cast<Player*> (&other);
   if (player)
   {
-	  float BOUNCE_DIR = left ? -BOUNCE_X : BOUNCE_X;
-	  player->get_physic().set_velocity(BOUNCE_DIR, BOUNCE_Y);
+    float BOUNCE_DIR = left ? -BOUNCE_X : BOUNCE_X;
+    player->get_physic().set_velocity(BOUNCE_DIR, BOUNCE_Y);
     SoundManager::current()->play(TRAMPOLINE_SOUND);
     m_sprite->set_action((left ? "left-swinging" : "right-swinging"), 1);
   }
-	
-	auto bumper = dynamic_cast<Bumper*> (&other);
-	if (bumper)
+
+  auto bumper = dynamic_cast<Bumper*> (&other);
+  if (bumper)
   {
     physic.set_velocity_y(0);
-	  return FORCE_MOVE;
-	}
+    return FORCE_MOVE;
+  }
   return ABORT_MOVE;
 }
 

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -66,6 +66,9 @@ Bumper::collision(GameObject& other, const CollisionHit& hit)
   auto player = dynamic_cast<Player*> (&other);
   if (player)
   {
+    float vel_x = player->get_physic().get_velocity_x();
+    if ((left && vel_x < -0.1f) || (!left && vel_x > 0.1f))
+      return ABORT_MOVE;
     float BOUNCE_DIR = left ? -BOUNCE_X : BOUNCE_X;
     player->get_physic().set_velocity(BOUNCE_DIR, BOUNCE_Y);
     SoundManager::current()->play(TRAMPOLINE_SOUND);


### PR DESCRIPTION
I changed the bumper so that it only pushes the player if he/she moves against it:
https://user-images.githubusercontent.com/3192173/109016663-ab992d00-76b6-11eb-956b-065835691d66.mp4

This fixes a problem where the player is sometimes bumped many times by one bumper and somehow looses its new velocity. It also changes the general behaviour of bumpers. 