### PR TITLE
Added bonus lightboxes that are on by default

### DIFF
--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -159,9 +159,12 @@ BonusBlock::BonusBlock(const ReaderMapping& mapping) :
     }
   }
 
-  if (m_contents == Content::LIGHT) {
+  if (m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON) {
     SoundManager::current()->preload("sounds/switch.ogg");
     m_lightsprite = Surface::from_file("/images/objects/lightmap_light/bonusblock_light.png");
+    if (m_contents == Content::LIGHT_ON) {
+      m_sprite->set_action("on");
+    }
   }
 }
 
@@ -185,6 +188,7 @@ BonusBlock::get_content_by_data(int tile_data) const
     case 12: return Content::CUSTOM; // Red potion
     case 13: return Content::AIRGROW;
     case 14: return Content::EARTHGROW;
+    case 15: return Content::LIGHT_ON;
     default:
       log_warning << "Invalid box contents" << std::endl;
       return Content::COIN;
@@ -204,10 +208,10 @@ BonusBlock::get_settings()
   result.add_int(_("Count"), &m_hit_counter, "count", 1);
   result.add_enum(_("Content"), reinterpret_cast<int*>(&m_contents),
                   {_("Coin"), _("Growth (fire flower)"), _("Growth (ice flower)"), _("Growth (air flower)"),
-                   _("Growth (earth flower)"), _("Star"), _("Tux doll"), _("Custom"), _("Script"), _("Light"),
+                   _("Growth (earth flower)"), _("Star"), _("Tux doll"), _("Custom"), _("Script"), _("Light"), _("Light (On)"),
                    _("Trampoline"), _("Coin rain"), _("Coin explosion")},
                   {"coin", "firegrow", "icegrow", "airgrow", "earthgrow", "star",
-                   "1up", "custom", "script", "light", "trampoline", "rain", "explode"},
+                   "1up", "custom", "script", "light", "light-on", "trampoline", "rain", "explode"},
                   static_cast<int>(Content::COIN), "contents");
   result.add_sexp(_("Custom Content"), "custom-contents", m_custom_sx);
 
@@ -326,6 +330,7 @@ BonusBlock::try_open(Player* player)
     { break; } // because scripts always run, this prevents default contents from being assumed
 
     case Content::LIGHT:
+    case Content::LIGHT_ON:
     {
       if (m_sprite->get_action() == "on")
         m_sprite->set_action("off");
@@ -364,7 +369,7 @@ BonusBlock::try_open(Player* player)
   }
 
   start_bounce(player);
-  if (m_hit_counter <= 0 || m_contents == Content::LIGHT) { //use 0 to allow infinite hits
+  if (m_hit_counter <= 0 || m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON) { //use 0 to allow infinite hits
   } else if (m_hit_counter == 1) {
     m_sprite->set_action("empty");
   } else {
@@ -467,6 +472,7 @@ BonusBlock::try_drop(Player *player)
     } // because scripts always run, this prevents default contents from being assumed
 
     case Content::LIGHT:
+    case Content::LIGHT_ON:
     case Content::TRAMPOLINE:
     case Content::RAIN:
     {
@@ -557,6 +563,8 @@ BonusBlock::get_content_from_string(const std::string& contentstring) const
     return Content::SCRIPT;
   } else if (contentstring == "light") {
     return Content::LIGHT;
+  } else if (contentstring == "light-on") {
+    return Content::LIGHT_ON;
   } else if (contentstring == "trampoline") {
     return Content::TRAMPOLINE;
   } else if (contentstring == "rain") {
@@ -584,6 +592,7 @@ BonusBlock::contents_to_string(const BonusBlock::Content& content) const
     case Content::CUSTOM: return "custom";
     case Content::SCRIPT: return "script";
     case Content::LIGHT: return "light";
+    case Content::LIGHT_ON: return "light-on";
     case Content::TRAMPOLINE: return "trampoline";
     case Content::RAIN: return "rain";
     case Content::EXPLODE: return "explode";
@@ -597,6 +606,7 @@ BonusBlock::preload_contents(int d)
   switch (d)
   {
     case 6: // Light
+    case 15: // Light (On)
       SoundManager::current()->preload("sounds/switch.ogg");
       m_lightsprite=Surface::from_file("/images/objects/lightmap_light/bonusblock_light.png");
       break;

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -37,6 +37,7 @@ public:
     CUSTOM,
     SCRIPT,
     LIGHT,
+    LIGHT_ON,
     TRAMPOLINE,
     RAIN,
     EXPLODE


### PR DESCRIPTION
Minor addition, lightboxes that are on by default. I also added the data 15 to represent this type of bonus block, but I haven't added any tile that corresponds to it.