### PR TITLE
Bugfixes in the particle editor

### DIFF
--- a/src/supertux/menu/particle_editor_open.cpp
+++ b/src/supertux/menu/particle_editor_open.cpp
@@ -58,6 +58,7 @@ ParticleEditorOpen::menu_action(MenuItem& item)
   switch (item.get_id())
   {
     case MNID_OPEN:
+      std::replace(m_filename.begin(), m_filename.end(), '\\', '/');
       ParticleEditor::current()->open("/particles/" + m_filename);
       MenuManager::instance().clear_menu_stack();
       break;


### PR DESCRIPTION
- [x] Fixed bug mixing slashes and backslashes in Particle Editor filenames
- [ ] ~~Investigate on the particles not spawning under specific circumstances~~