### PR TITLE
Added scripting to rotating spotlight object + some changes

### DIFF
--- a/src/object/gradient.hpp
+++ b/src/object/gradient.hpp
@@ -17,8 +17,8 @@
 #ifndef HEADER_SUPERTUX_OBJECT_GRADIENT_HPP
 #define HEADER_SUPERTUX_OBJECT_GRADIENT_HPP
 
-#include "squirrel/exposed_object.hpp"
 #include "scripting/gradient.hpp"
+#include "squirrel/exposed_object.hpp"
 #include "supertux/game_object.hpp"
 #include "video/drawing_context.hpp"
 

--- a/src/object/spotlight.cpp
+++ b/src/object/spotlight.cpp
@@ -20,7 +20,38 @@
 #include "sprite/sprite_manager.hpp"
 #include "util/reader_mapping.hpp"
 
+Spotlight::Direction
+Spotlight::Direction_from_string(const std::string& s)
+{
+  if (s == "clockwise") {
+    return Direction::CLOCKWISE;
+  } else if (s == "counter-clockwise") {
+    return Direction::COUNTERCLOCKWISE;
+  } else if (s == "stopped") {
+    return Direction::STOPPED;
+  }
+
+  throw std::runtime_error("Invalid spotlight direction from string '" + s + "'");
+}
+
+std::string
+Spotlight::Direction_to_string(Direction dir)
+{
+  switch(dir) {
+    case Direction::CLOCKWISE:
+      return "clockwise";
+    case Direction::COUNTERCLOCKWISE:
+      return "counter-clockwise";
+    case Direction::STOPPED:
+      return "stopped";
+  }
+
+  throw std::runtime_error("Invalid spotlight direction '" + std::to_string(static_cast<int>(dir)) + "'");
+}
+
 Spotlight::Spotlight(const ReaderMapping& mapping) :
+  MovingObject(mapping),
+  ExposedObject<Spotlight, scripting::Spotlight>(this),
   angle(),
   center(SpriteManager::current()->create("images/objects/spotlight/spotlight_center.sprite")),
   base(SpriteManager::current()->create("images/objects/spotlight/spotlight_base.sprite")),
@@ -29,7 +60,7 @@ Spotlight::Spotlight(const ReaderMapping& mapping) :
   lightcone(SpriteManager::current()->create("images/objects/spotlight/lightcone.sprite")),
   color(1.0f, 1.0f, 1.0f),
   speed(50.0f),
-  counter_clockwise(),
+  m_direction(),
   m_layer(0)
 {
   m_col.m_group = COLGROUP_DISABLED;
@@ -40,7 +71,14 @@ Spotlight::Spotlight(const ReaderMapping& mapping) :
 
   mapping.get("angle", angle, 0.0f);
   mapping.get("speed", speed, 50.0f);
-  mapping.get("counter-clockwise", counter_clockwise, false);
+
+  if (!mapping.get_custom("r-direction", m_direction, Direction_from_string))
+  {
+    // Retrocompatibility
+    bool counter_clockwise;
+    mapping.get("counter-clockwise", counter_clockwise, false);
+    m_direction = counter_clockwise ? Direction::COUNTERCLOCKWISE : Direction::CLOCKWISE;
+  }
 
   std::vector<float> vColor;
   if ( mapping.get( "color", vColor ) ){
@@ -62,7 +100,10 @@ Spotlight::get_settings()
   result.add_float(_("Angle"), &angle, "angle");
   result.add_color(_("Color"), &color, "color", Color::WHITE);
   result.add_float(_("Speed"), &speed, "speed", 50.0f);
-  result.add_bool(_("Counter-clockwise"), &counter_clockwise, "counter-clockwise", false);
+  result.add_enum(_("Direction"), reinterpret_cast<int*>(&m_direction),
+                  {_("Clockwise"), _("Counter-clockwise"), _("Stopped")},
+                  {"clockwise", "counter-clockwise", "stopped"},
+                  static_cast<int>(Direction::CLOCKWISE), "r-direction");
   result.add_int(_("Layer"), &m_layer, "layer", 0);
 
   result.reorder({"angle", "color", "layer", "x", "y"});
@@ -73,13 +114,20 @@ Spotlight::get_settings()
 void
 Spotlight::update(float dt_sec)
 {
-  if (counter_clockwise)
+  GameObject::update(dt_sec);
+
+  switch (m_direction)
   {
-    angle -= dt_sec * speed;
-  }
-  else
-  {
+  case Direction::CLOCKWISE:
     angle += dt_sec * speed;
+    break;
+
+  case Direction::COUNTERCLOCKWISE:
+    angle -= dt_sec * speed;
+    break;
+  
+  case Direction::STOPPED:
+    break;
   }
 }
 

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -17,14 +17,27 @@
 #ifndef HEADER_SUPERTUX_OBJECT_SPOTLIGHT_HPP
 #define HEADER_SUPERTUX_OBJECT_SPOTLIGHT_HPP
 
+#include "scripting/spotlight.hpp"
 #include "sprite/sprite_ptr.hpp"
+#include "squirrel/exposed_object.hpp"
 #include "supertux/moving_object.hpp"
 #include "video/color.hpp"
 
 class ReaderMapping;
 
-class Spotlight final : public MovingObject
+class Spotlight final : public MovingObject,
+                        public ExposedObject<Spotlight, scripting::Spotlight>
 {
+public:
+  enum class Direction {
+    CLOCKWISE,
+    COUNTERCLOCKWISE,
+    STOPPED
+  };
+
+  static Direction Direction_from_string(const std::string& s);
+  static std::string Direction_to_string(Direction dir);
+
 public:
   Spotlight(const ReaderMapping& reader);
   virtual ~Spotlight();
@@ -39,6 +52,29 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
+  void set_angle(float angle_) { angle = angle_; };
+  void set_speed(float speed_) { speed = speed_; };
+  void set_color(Color color_) { color = color_; };
+  void set_direction(Direction dir) { m_direction = dir; };
+
+  void ease_angle(float time, float target, EasingMode ease = EasingMode::EaseNone)
+  {
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&angle, time, target, getEasingByName(ease)));
+  }
+
+  void ease_speed(float time, float target, EasingMode ease = EasingMode::EaseNone)
+  {
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&speed, time, target, getEasingByName(ease)));
+  }
+
+  void ease_color(float time, Color target, EasingMode ease = EasingMode::EaseNone)
+  {
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&color.red,   time, target.red,   getEasingByName(ease)));
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&color.green, time, target.green, getEasingByName(ease)));
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&color.blue,  time, target.blue,  getEasingByName(ease)));
+    m_fade_helpers.push_back(std::make_unique<FadeHelper>(&color.alpha, time, target.alpha, getEasingByName(ease)));
+  }
+
 private:
   float   angle;
   SpritePtr center;
@@ -52,8 +88,8 @@ private:
   /** Speed that the spotlight is rotating with */
   float speed;
 
-  /** If true, the spotlight will rotate counter-clockwise */
-  bool counter_clockwise;
+  /** The direction of the spotlight */
+  Direction m_direction;
 
   /** The layer (z-pos) of the spotlight. */
   int m_layer;

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -52,10 +52,10 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
-  void set_angle(float angle_) { angle = angle_; };
-  void set_speed(float speed_) { speed = speed_; };
-  void set_color(Color color_) { color = color_; };
-  void set_direction(Direction dir) { m_direction = dir; };
+  void set_angle(float angle_) { angle = angle_; }
+  void set_speed(float speed_) { speed = speed_; }
+  void set_color(Color color_) { color = color_; }
+  void set_direction(Direction dir) { m_direction = dir; }
 
   void ease_angle(float time, float target, EasingMode ease = EasingMode::EaseNone)
   {

--- a/src/scripting/spotlight.cpp
+++ b/src/scripting/spotlight.cpp
@@ -1,0 +1,96 @@
+//  SuperTux
+//  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "scripting/spotlight.hpp"
+
+#include "object/spotlight.hpp"
+
+namespace scripting {
+
+void
+Spotlight::set_direction(std::string direction)
+{
+  SCRIPT_GUARD_VOID;
+  object.set_direction(::Spotlight::Direction_from_string(direction));
+}
+
+void
+Spotlight::set_speed(float speed)
+{
+  SCRIPT_GUARD_VOID;
+  object.set_speed(speed);
+}
+
+void
+Spotlight::fade_speed(float speed, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_speed(time, speed);
+}
+
+void
+Spotlight::ease_speed(float speed, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_speed(time, speed, EasingMode_from_string(easing));
+}
+
+void
+Spotlight::set_angle(float angle)
+{
+  SCRIPT_GUARD_VOID;
+  object.set_angle(angle);
+}
+
+void
+Spotlight::fade_angle(float angle, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_angle(time, angle);
+}
+
+void
+Spotlight::ease_angle(float angle, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_angle(time, angle, EasingMode_from_string(easing));
+}
+
+void
+Spotlight::set_color_rgba(float r, float g, float b, float a)
+{
+  SCRIPT_GUARD_VOID;
+  object.set_color(Color(r, g, b, a));
+}
+
+void
+Spotlight::fade_color_rgba(float r, float g, float b, float a, float time)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_color(time, Color(r, g, b, a));
+}
+
+void
+Spotlight::ease_color_rgba(float r, float g, float b, float a, float time, std::string easing)
+{
+  SCRIPT_GUARD_VOID;
+  object.ease_color(time, Color(r, g, b, a), EasingMode_from_string(easing));
+}
+
+
+} // namespace scripting
+
+/* EOF */

--- a/src/scripting/spotlight.cpp
+++ b/src/scripting/spotlight.cpp
@@ -1,5 +1,5 @@
 //  SuperTux
-//  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//  Copyright (C) 2021 A. Semphris <semphris@protonmail.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/src/scripting/spotlight.hpp
+++ b/src/scripting/spotlight.hpp
@@ -1,5 +1,5 @@
-//  SuperTux - Sector scripting
-//  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//  SuperTux
+//  Copyright (C) 2021 A. Semphris <semphris@protonmail.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/src/scripting/spotlight.hpp
+++ b/src/scripting/spotlight.hpp
@@ -1,0 +1,64 @@
+//  SuperTux - Sector scripting
+//  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SCRIPTING_SPOTLIGHT_HPP
+#define HEADER_SUPERTUX_SCRIPTING_SPOTLIGHT_HPP
+
+#ifndef SCRIPTING_API
+#include <string>
+
+#include "scripting/game_object.hpp"
+
+class Spotlight;
+#endif
+
+namespace scripting {
+
+class Spotlight final
+#ifndef SCRIPTING_API
+  : public GameObject<::Spotlight>
+#endif
+{
+#ifndef SCRIPTING_API
+private:
+  using GameObject::GameObject;
+
+private:
+  Spotlight(const Spotlight&) = delete;
+  Spotlight& operator=(const Spotlight&) = delete;
+#endif
+
+public:
+  void set_direction(std::string direction);
+
+  void set_angle(float angle);
+  void fade_angle(float angle, float time);
+  void ease_angle(float angle, float time, std::string easing);
+
+  void set_speed(float speed);
+  void fade_speed(float speed, float time);
+  void ease_speed(float speed, float time, std::string easing);
+
+  void set_color_rgba(float r, float g, float b, float a);
+  void fade_color_rgba(float r, float g, float b, float a, float time);
+  void ease_color_rgba(float r, float g, float b, float a, float time, std::string easing);
+};
+
+} // namespace scripting
+
+#endif
+
+/* EOF */

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -8621,6 +8621,443 @@ static SQInteger Sector_set_music_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Spotlight_release_hook(SQUserPointer ptr, SQInteger )
+{
+  auto _this = reinterpret_cast<scripting::Spotlight*> (ptr);
+  delete _this;
+  return 0;
+}
+
+static SQInteger Spotlight_set_direction_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_direction' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_direction(arg0);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_direction'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_set_angle_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_angle' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_angle(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_angle'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_fade_angle_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_angle' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_angle(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_angle'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_ease_angle_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_angle' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_angle(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_angle'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_set_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_speed(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_fade_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_speed(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_ease_speed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_speed' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_speed(static_cast<float> (arg0), static_cast<float> (arg1), arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_speed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_set_color_rgba_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'set_color_rgba' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_color_rgba(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_color_rgba'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_fade_color_rgba_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'fade_color_rgba' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg4;
+  if(SQ_FAILED(sq_getfloat(vm, 6, &arg4))) {
+    sq_throwerror(vm, _SC("Argument 5 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->fade_color_rgba(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3), static_cast<float> (arg4));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'fade_color_rgba'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Spotlight_ease_color_rgba_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'ease_color_rgba' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Spotlight*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg4;
+  if(SQ_FAILED(sq_getfloat(vm, 6, &arg4))) {
+    sq_throwerror(vm, _SC("Argument 5 not a float"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg5;
+  if(SQ_FAILED(sq_getstring(vm, 7, &arg5))) {
+    sq_throwerror(vm, _SC("Argument 6 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->ease_color_rgba(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3), static_cast<float> (arg4), arg5);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'ease_color_rgba'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Text_release_hook(SQUserPointer ptr, SQInteger )
 {
   auto _this = reinterpret_cast<scripting::Text*> (ptr);
@@ -12265,6 +12702,32 @@ void create_squirrel_instance(HSQUIRRELVM v, scripting::Sector* object, bool set
   sq_remove(v, -2); // remove root table
 }
 
+void create_squirrel_instance(HSQUIRRELVM v, scripting::Spotlight* object, bool setup_releasehook)
+{
+  using namespace wrapper;
+
+  sq_pushroottable(v);
+  sq_pushstring(v, "Spotlight", -1);
+  if(SQ_FAILED(sq_get(v, -2))) {
+    std::ostringstream msg;
+    msg << "Couldn't resolved squirrel type 'Spotlight'";
+    throw SquirrelError(v, msg.str());
+  }
+
+  if(SQ_FAILED(sq_createinstance(v, -1)) || SQ_FAILED(sq_setinstanceup(v, -1, object))) {
+    std::ostringstream msg;
+    msg << "Couldn't setup squirrel instance for object of type 'Spotlight'";
+    throw SquirrelError(v, msg.str());
+  }
+  sq_remove(v, -2); // remove object name
+
+  if(setup_releasehook) {
+    sq_setreleasehook(v, -1, Spotlight_release_hook);
+  }
+
+  sq_remove(v, -2); // remove root table
+}
+
 void create_squirrel_instance(HSQUIRRELVM v, scripting::Text* object, bool setup_releasehook)
 {
   using namespace wrapper;
@@ -14810,6 +15273,87 @@ void register_supertux_wrapper(HSQUIRRELVM v)
 
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register class 'Sector'");
+  }
+
+  // Register class Spotlight
+  sq_pushstring(v, "Spotlight", -1);
+  if(sq_newclass(v, SQFalse) < 0) {
+    std::ostringstream msg;
+    msg << "Couldn't create new class 'Spotlight'";
+    throw SquirrelError(v, msg.str());
+  }
+  sq_pushstring(v, "set_direction", -1);
+  sq_newclosure(v, &Spotlight_set_direction_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_direction'");
+  }
+
+  sq_pushstring(v, "set_angle", -1);
+  sq_newclosure(v, &Spotlight_set_angle_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_angle'");
+  }
+
+  sq_pushstring(v, "fade_angle", -1);
+  sq_newclosure(v, &Spotlight_fade_angle_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_angle'");
+  }
+
+  sq_pushstring(v, "ease_angle", -1);
+  sq_newclosure(v, &Spotlight_ease_angle_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_angle'");
+  }
+
+  sq_pushstring(v, "set_speed", -1);
+  sq_newclosure(v, &Spotlight_set_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_speed'");
+  }
+
+  sq_pushstring(v, "fade_speed", -1);
+  sq_newclosure(v, &Spotlight_fade_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_speed'");
+  }
+
+  sq_pushstring(v, "ease_speed", -1);
+  sq_newclosure(v, &Spotlight_ease_speed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_speed'");
+  }
+
+  sq_pushstring(v, "set_color_rgba", -1);
+  sq_newclosure(v, &Spotlight_set_color_rgba_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_color_rgba'");
+  }
+
+  sq_pushstring(v, "fade_color_rgba", -1);
+  sq_newclosure(v, &Spotlight_fade_color_rgba_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'fade_color_rgba'");
+  }
+
+  sq_pushstring(v, "ease_color_rgba", -1);
+  sq_newclosure(v, &Spotlight_ease_color_rgba_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnnns");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'ease_color_rgba'");
+  }
+
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register class 'Spotlight'");
   }
 
   // Register class Text

--- a/src/scripting/wrapper.hpp
+++ b/src/scripting/wrapper.hpp
@@ -52,6 +52,8 @@ class ScriptedObject;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::ScriptedObject* object, bool setup_releasehook = false);
 class Sector;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::Sector* object, bool setup_releasehook = false);
+class Spotlight;
+void create_squirrel_instance(HSQUIRRELVM v, scripting::Spotlight* object, bool setup_releasehook = false);
 class Text;
 void create_squirrel_instance(HSQUIRRELVM v, scripting::Text* object, bool setup_releasehook = false);
 class TextArray;

--- a/src/scripting/wrapper.interface.hpp
+++ b/src/scripting/wrapper.interface.hpp
@@ -22,6 +22,7 @@
 #include "scripting/rock.hpp"
 #include "scripting/scripted_object.hpp"
 #include "scripting/sector.hpp"
+#include "scripting/spotlight.hpp"
 #include "scripting/text.hpp"
 #include "scripting/text_array.hpp"
 #include "scripting/thunderstorm.hpp"

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -25,6 +25,7 @@
 
 GameObject::GameObject() :
   m_name(),
+  m_fade_helpers(),
   m_uid(),
   m_scheduled_for_removal(false),
   m_components(),
@@ -34,6 +35,7 @@ GameObject::GameObject() :
 
 GameObject::GameObject(const std::string& name) :
   m_name(name),
+  m_fade_helpers(),
   m_uid(),
   m_scheduled_for_removal(false),
   m_components(),
@@ -87,6 +89,21 @@ GameObject::get_settings()
   ObjectSettings result(get_display_name());
   result.add_text(_("Name"), &m_name, "name", std::string());
   return result;
+}
+
+void
+GameObject::update(float dt_sec)
+{
+  for (auto& h : m_fade_helpers)
+  {
+    h->update(dt_sec);
+  }
+
+  auto new_end = std::remove_if(m_fade_helpers.begin(), m_fade_helpers.end(), [](const std::unique_ptr<FadeHelper>& h) {
+    return h->completed();
+  });
+
+  m_fade_helpers.erase(new_end, m_fade_helpers.end());
 }
 
 /* EOF */

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -22,6 +22,7 @@
 
 #include "editor/object_settings.hpp"
 #include "supertux/game_object_component.hpp"
+#include "util/fade_helper.hpp"
 #include "util/gettext.hpp"
 #include "util/uid.hpp"
 
@@ -166,6 +167,9 @@ protected:
   /** a name for the gameobject, this is mostly a hint for scripts and
       for debugging, don't rely on names being set or being unique */
   std::string m_name;
+
+  /** Fade Helpers are for easing/fading script functions */
+  std::vector<std::unique_ptr<FadeHelper>> m_fade_helpers;
 
 private:
   /** A unique id for the object to safely refer to it. This will be

--- a/src/util/fade_helper.cpp
+++ b/src/util/fade_helper.cpp
@@ -55,9 +55,8 @@ FadeHelper::update(float dt_sec)
   // If at some point in development, floats are changed to doubles, or the
   // ease funciton return type change from double to float, remove the casts
   // here (it takes a lot of space).               ~ Semphris
-  float progress = static_cast<float>(m_ease(static_cast<double>(
-                      m_start + (m_target - m_start) * (m_time / m_total_time)
-                      )));
+  float progress = m_start + (m_target - m_start) * static_cast<float>(m_ease(
+                                  static_cast<double>(m_time / m_total_time)));
   if (m_value)
     *m_value = progress;
   return progress;


### PR DESCRIPTION
Fixes #768 

Added setters, faders, and easers for angle, rotation speed, and light color.

Also changed the direction variable to consider not rotating at all.

Also changed GameObjects to handle FadeHelpers globally. This will require a refactor of all GameObject-inheriting classes to call GameObject::update(float) where necessary.

Consideration: Although the "direction" property seems needless (as clockwise/counter-clockwise rotation can be achieved using positive or negative values), I chose to leave it there so that scripters can easily change the direction of a spotlight - or stop it completely - without having to know/remember its original speed in some way if they want to reset it at a later point.