### PR TITLE
Level editor tile grid shadow and constant-width lines

### DIFF
--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -99,7 +99,7 @@ private:
   void add_path_node();
 
   void draw_tile_tip(DrawingContext&);
-  void draw_tile_grid(DrawingContext&, const Color& line_color, int tile_size = 32);
+  void draw_tile_grid(DrawingContext&, int tile_size, bool draw_shadow) const;
   void draw_tilemap_border(DrawingContext&);
   void draw_path(DrawingContext&);
   void draw_rectangle_preview(DrawingContext& context);

--- a/src/video/gl/gl_painter.cpp
+++ b/src/video/gl/gl_painter.cpp
@@ -392,6 +392,7 @@ GLPainter::draw_line(const LineRequest& request)
 {
   assert_gl();
 
+  Vector viewport_scale = m_video_system.get_viewport().get_scale();
   const float x1 = request.pos.x;
   const float y1 = request.pos.y;
   const float x2 = request.dest_pos.x;
@@ -399,19 +400,16 @@ GLPainter::draw_line(const LineRequest& request)
 
   // OpenGL3.3 doesn't have GL_LINES anymore, so instead we transform
   // the line into a quad and draw it as triangle strip.
-  // triangle strip
   float x_step = (y2 - y1);
   float y_step = -(x2 - x1);
 
   const float step_norm = sqrtf(x_step * x_step + y_step * y_step);
-  x_step /= step_norm;
-  y_step /= step_norm;
+  x_step /= step_norm * viewport_scale.x;
+  y_step /= step_norm * viewport_scale.y;
 
   x_step *= 0.5f;
   y_step *= 0.5f;
 
-  // FIXME: this results in lines of not quite consistant width when
-  // the window is scaled
   const float vertices[] = {
     (x1 - x_step), (y1 - y_step),
     (x2 - x_step), (y2 - y_step),


### PR DESCRIPTION
The grid in the Level Editor is currently white, so it is invisible when the background is white, too.
For this reason, I added a subtle drop shadow to the full-tile grid. I also fixed the inconsistent line widths.
#
16x16 grid, before:
![master_16](https://user-images.githubusercontent.com/3192173/110255759-9e711d80-7f95-11eb-95d8-494bed4ea14f.png)
16x16 grid, after:
![this_16](https://user-images.githubusercontent.com/3192173/110256020-e9d7fb80-7f96-11eb-9652-c9e69f5a4a5a.png)
#
32x32 grid, before:
![master_32](https://user-images.githubusercontent.com/3192173/110255633-06733400-7f95-11eb-9c08-0f5c6e96f2bd.png)
32x32 grid, after:
![this_32](https://user-images.githubusercontent.com/3192173/110256026-ee041900-7f96-11eb-9ba8-9094f8fa3ee7.png)
#
close-up comparison:
![master_16_excerpt](https://user-images.githubusercontent.com/3192173/110255632-05420700-7f95-11eb-8357-eaf832800afe.png)
![this_16_excerpt](https://user-images.githubusercontent.com/3192173/110256058-17bd4000-7f97-11eb-8826-055a5a3e3999.png)

