### PR TITLE
Fix for 32-bit CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install 64-bit linux dependencies
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 64 }}
         run: |
-          sudo apt-get update 
+          sudo apt-get update
           sudo apt install -y gcc-multilib g++-multilib cmake build-essential \
                 automake clang-6.0 g++-8 libc++-dev libogg-dev libvorbis-dev \
                 libopenal-dev libboost-all-dev libsdl2-dev libsdl2-image-dev \
@@ -75,9 +75,9 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 32 }}
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt-get update 
+          sudo apt-get update
           sudo apt install -y cmake build-essential automake gtk-doc-tools rpm sshpass
-          sudo apt install -y gcc-multilib g++-multilib libogg-dev:i386 libvorbis-dev:i386 libopenal-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-locale-dev:i386 libsdl2-dev:i386 libsdl2-image-dev:i386 libfreetype6-dev:i386 libcurl4-openssl-dev:i386 libharfbuzz-dev:i386 libfribidi-dev:i386
+          sudo apt install -yf gcc-multilib g++-multilib libogg-dev:i386 libvorbis-dev:i386 libopenal-dev:i386 libboost-date-time-dev:i386 libboost-filesystem-dev:i386 libboost-locale-dev:i386 libsdl2-dev:i386 libsdl2-image-dev:i386 libfreetype6-dev:i386 libcurl4-openssl-dev:i386 libharfbuzz-dev:i386 libfribidi-dev:i386
           # Nethier GLEW nor glbinding exist in 32-bit for Ubuntu 20.04, so snatch the debs from 16.04 instead
           wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew1.13_1.13.0-2_i386.deb && sudo dpkg -i libglew1.13_1.13.0-2_i386.deb
           wget archive.ubuntu.com/ubuntu/pool/main/g/glew/libglew-dev_1.13.0-2_i386.deb && sudo dpkg -i libglew-dev_1.13.0-2_i386.deb
@@ -126,6 +126,7 @@ jobs:
         working-directory: build
         run: ./test_supertux2
       - name: Package
+        if: ${{ matrix.os != 'ubuntu-latest' || matrix.arch != '32' }}
         env:
           OS_NAME: ${{ matrix.os }}
           ARCH: ${{ matrix.arch }}
@@ -134,6 +135,16 @@ jobs:
           PACKAGE: 'ON'
         working-directory: build
         run: ../.ci_scripts/package.sh
+      - name: Package (Linux 32-bit)
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == '32' }}
+        env:
+          OS_NAME: ${{ matrix.os }}
+          ARCH: ${{ matrix.arch }}
+          COMPILER_NAME: ${{ matrix.compiler }}
+          BUILD_NAME: ${{ matrix.build_type }}
+          PACKAGE: 'ON'
+        working-directory: build
+        run: cpack -G TGZ
       # Github actions is dumb and won't let you download single files from artifacts, so break up the artifacts instead
       - uses: actions/upload-artifact@v2
         with:
@@ -143,7 +154,12 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: "source"
-          path: build/upload/*.tar.gz
+          path: build/upload/*Source.tar.gz
+          if-no-files-found: ignore
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.build_type }}-tgz"
+          path: build/upload/*Linux.tar.gz
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
- Builds properly
- Packages as `.tar.gz`, since AppImages poorly support 32-bit