### PR TITLE
Editor: Put tiles without holes when holding the left mouse button

### DIFF
--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_EDITOR_OVERLAY_WIDGET_HPP
 
 #include <SDL.h>
+#include <chrono>
 
 #include "control/input_manager.hpp"
 #include "editor/tile_selection.hpp"
@@ -76,7 +77,8 @@ private:
   void input_autotile(const Vector& pos, uint32_t tile);
   void autotile_corner(const Vector& pos, uint32_t tile, TileMap::AutotileCornerOperation op);
   void input_autotile_corner(const Vector& corner, uint32_t tile, const Vector& override_pos = Vector(-1.f, -1.f));
-  void put_tile();
+  void put_tile(const Vector& target_tile);
+  void put_next_tiles();
   void draw_rectangle();
   void preview_rectangle();
   bool check_tiles_for_fill(uint32_t replace_tile, uint32_t target_tile, uint32_t third_tile) const;
@@ -119,10 +121,12 @@ private:
 private:
   Editor& m_editor;
   Vector m_hovered_tile;
-  Vector m_hovered_corner;
+  Vector m_hovered_tile_prev;
   Vector m_sector_pos;
   Vector m_mouse_pos;
   Vector m_previous_mouse_pos;
+
+  std::chrono::steady_clock::time_point m_time_prev_put_tile;
 
   bool m_dragging;
   bool m_dragging_right;


### PR DESCRIPTION
When the user puts many single tiles while holding the left mouse button and moves the cursor quickly, tiles are now also put at positions between two successive cursor positions.
The line interpolation is disabled when there's a relatively long time between two successive movements to avoid undesired behaviour when the frame rate is very low or the user scrolls around without releasing the left mouse button.

Current master branch:
https://user-images.githubusercontent.com/3192173/114600623-d81ffd00-9c94-11eb-84ad-2034053496f1.mp4

Proposed changes (without the time check):
https://user-images.githubusercontent.com/3192173/114600651-deae7480-9c94-11eb-9219-404adb06f6a9.mp4

To do:
* Test it thoroughly
* Code style related changes if needed