### PR TITLE
Use Local Path Command Line Option

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -678,14 +678,8 @@ AddonManager::add_installed_archive(const std::string& archive, const std::strin
   else
   {
     std::string os_path = FileSystem::join(realdir, archive);
-
- if (g_config->use_local_path) {
-    PHYSFS_mount(os_path.c_str(), nullptr, 0);
-    } else {
- PHYSFS_mount(os_path.c_str(), nullptr, 1);
-    }
-
-
+    // check if we should use local file paths for addon overrides
+    PHYSFS_mount(os_path.c_str(), nullptr, !(g_config->use_local_path));
     std::string nfo_filename = scan_for_info(os_path);
 
     if (nfo_filename.empty())

--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -450,32 +450,32 @@ AddonManager::enable_addon(const AddonId& addon_id)
     {
       if (PHYSFS_mount(addon.get_install_filename().c_str(), mountpoint.c_str(), 0) == 0)
       {
-      log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
-                  << PHYSFS_getLastErrorCode() << std::endl;
-      }
-      else
-      {
-       if (addon.get_type() == Addon::LANGUAGEPACK)
-       {
-         PHYSFS_enumerate(addon.get_id().c_str(), add_to_dictionary_path, nullptr);
+        log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
+        << PHYSFS_getLastErrorCode() << std::endl;
        }
-      addon.set_enabled(true);
+       else
+      {
+        if (addon.get_type() == Addon::LANGUAGEPACK)
+          {
+             PHYSFS_enumerate(addon.get_id().c_str(), add_to_dictionary_path, nullptr);
+          }
+        addon.set_enabled(true);
       }
     }
-   else
+    else
    {
      if (PHYSFS_mount(addon.get_install_filename().c_str(), mountpoint.c_str(), 1) == 0)
-      {
-      log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
-                  << PHYSFS_getLastErrorCode() << std::endl;
-      }
-      else
-      {
-       if (addon.get_type() == Addon::LANGUAGEPACK)
-        {
-         PHYSFS_enumerate(addon.get_id().c_str(), add_to_dictionary_path, nullptr);
-         }
-       addon.set_enabled(true);
+       {
+         log_warning << "Could not add " << addon.get_install_filename() << " to search path: "
+         << PHYSFS_getLastErrorCode() << std::endl;
+       }
+       else
+       {
+         if (addon.get_type() == Addon::LANGUAGEPACK)
+           {
+           PHYSFS_enumerate(addon.get_id().c_str(), add_to_dictionary_path, nullptr);
+           }
+         addon.set_enabled(true);
       }
     }
   }
@@ -548,18 +548,18 @@ AddonManager::mount_old_addons()
       {
         if (g_config->use_local_path) 
         {
-                if (PHYSFS_mount(addon->get_install_filename().c_str(), mountpoint.c_str(), 0) == 0)
+          if (PHYSFS_mount(addon->get_install_filename().c_str(), mountpoint.c_str(), 0) == 0)
           {
-              log_warning << "Could not add " << addon->get_install_filename() << " to search path: "
-              << PHYSFS_getLastErrorCode() << std::endl;
+            log_warning << "Could not add " << addon->get_install_filename() << " to search path: "
+            << PHYSFS_getLastErrorCode() << std::endl;
           }
-        }
-        else
-        {
-        if (PHYSFS_mount(addon->get_install_filename().c_str(), mountpoint.c_str(), 1) == 0)
-        {
-                          log_warning << "Could not add " << addon->get_install_filename() << " to search path: "
-                          << PHYSFS_getLastErrorCode() << std::endl;
+       }
+       else
+       {
+         if (PHYSFS_mount(addon->get_install_filename().c_str(), mountpoint.c_str(), 1) == 0)
+           {
+             log_warning << "Could not add " << addon->get_install_filename() << " to search path: "
+             << PHYSFS_getLastErrorCode() << std::endl;
         }
       }
     }
@@ -570,12 +570,15 @@ void
 AddonManager::unmount_old_addons()
 {
   for (auto& addon : m_installed_addons) {
-    if (is_old_enabled_addon(addon)) {
+    if (is_old_enabled_addon(addon))
+    {
       if (g_config->use_local_path)
+      {
         if (PHYSFS_unmount(addon->get_install_filename().c_str()) == 0)
         {
           log_warning << "Could not remove " << addon->get_install_filename() << " from search path: "
-                     << PHYSFS_getLastErrorCode() << std::endl;
+          << PHYSFS_getLastErrorCode() << std::endl;
+        }
       }
     }
   }

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -53,7 +53,8 @@ CommandLineArguments::CommandLineArguments() :
   christmas_mode(),
   repository_url(),
   editor(),
-  resave()
+  resave(),
+  use_local_path()
 {
 }
 
@@ -131,6 +132,8 @@ CommandLineArguments::print_help(const char* arg0) const
     << _("Directory Options:") << "\n"
     << _("  --datadir DIR                Set the directory for the games datafiles") << "\n"
     << _("  --userdir DIR                Set the directory for user data (savegames, etc.)") << "\n"
+    << _("  --use-local-path             Set precedence for local addon file paths") << "\n"
+    << _("  --no-local-path              Unset precedence for local addon file paths") << "\n"
     << "\n"
     << _("Add-On Options:") << "\n"
     << _("  --repository-url URL         Set the URL to the Add-On repository") << "\n"
@@ -316,6 +319,14 @@ CommandLineArguments::parse_args(int argc, char** argv)
     {
       christmas_mode = false;
     }
+    else if (arg == "--use-local-path")
+    {
+      use_local_path = true;
+    }
+    else if (arg == "--no-local-path")
+    {
+      use_local_path = false;
+    }
     else if (arg == "--disable-sound" || arg == "--disable-sfx")
     {
       sound_enabled = false;
@@ -437,6 +448,7 @@ CommandLineArguments::merge_into(Config& config)
   merge_option(tux_spawn_pos)
   merge_option(developer_mode)
   merge_option(christmas_mode)
+  merge_option(use_local_path)
   merge_option(repository_url)
 
 #undef merge_option

--- a/src/supertux/command_line_arguments.hpp
+++ b/src/supertux/command_line_arguments.hpp
@@ -81,7 +81,7 @@ public:
 
   boost::optional<bool> editor;
   boost::optional<bool> resave;
-
+  boost::optional<bool> use_local_path;
   // boost::optional<std::string> locale;
 
 public:

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -218,7 +218,7 @@ Config::save()
 
   writer.start_list("integrations");
   {
-  writer.write("hide_editor_levelnames", hide_editor_levelnames);
+    writer.write("hide_editor_levelnames", hide_editor_levelnames);
 #ifdef ENABLE_DISCORD
     writer.write("enable_discord", enable_discord);
 #endif

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -65,6 +65,7 @@ Config::Config() :
   enable_discord(false),
 #endif
   hide_editor_levelnames(false),
+  use_local_path(false),
   editor_autosave_frequency(5),
   repository_url()
 {
@@ -89,6 +90,7 @@ Config::load()
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
   config_mapping.get("custom_mouse_cursor", custom_mouse_cursor);
+  config_mapping.get("use_local_path", use_local_path);
 
   boost::optional<ReaderMapping> config_integrations_mapping;
   if (config_mapping.get("integrations", config_integrations_mapping))
@@ -216,7 +218,7 @@ Config::save()
 
   writer.start_list("integrations");
   {
-    writer.write("hide_editor_levelnames", hide_editor_levelnames);
+  writer.write("hide_editor_levelnames", hide_editor_levelnames);
 #ifdef ENABLE_DISCORD
     writer.write("enable_discord", enable_discord);
 #endif

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -107,7 +107,7 @@ public:
   bool enable_discord;
 #endif
   bool hide_editor_levelnames;
-
+  bool use_local_path;
   int editor_autosave_frequency;
 
   std::string repository_url;

--- a/src/supertux/menu/integrations_menu.cpp
+++ b/src/supertux/menu/integrations_menu.cpp
@@ -46,7 +46,7 @@ enum IntegrationsMenuIDs {
 
 IntegrationsMenu::IntegrationsMenu()
 {
-  add_label(_("Integrations"));
+  add_label(_("Social Integrations"));
   add_hl();
   add_toggle(MNID_LEVELNAMES_EDITOR, _("Do not share level names when editing"), &g_config->hide_editor_levelnames)
     .set_help("Enable this if you want to work on secret levels and don't want the names to be spoiled");
@@ -56,9 +56,9 @@ IntegrationsMenu::IntegrationsMenu()
 #else
   add_inactive( _("Discord (disabled; not compiled)"));
 #endif
-  add_hl();
   add_back(_("Back"));
 }
+
 
 IntegrationsMenu::~IntegrationsMenu()
 {

--- a/src/supertux/menu/integrations_menu.cpp
+++ b/src/supertux/menu/integrations_menu.cpp
@@ -46,7 +46,7 @@ enum IntegrationsMenuIDs {
 
 IntegrationsMenu::IntegrationsMenu()
 {
-  add_label(_("Social Integrations"));
+  add_label(_("Integrations"));
   add_hl();
   add_toggle(MNID_LEVELNAMES_EDITOR, _("Do not share level names when editing"), &g_config->hide_editor_levelnames)
     .set_help("Enable this if you want to work on secret levels and don't want the names to be spoiled");
@@ -56,9 +56,9 @@ IntegrationsMenu::IntegrationsMenu()
 #else
   add_inactive( _("Discord (disabled; not compiled)"));
 #endif
+  add_hl();
   add_back(_("Back"));
 }
-
 
 IntegrationsMenu::~IntegrationsMenu()
 {


### PR DESCRIPTION
Directory Options:
--use-local-path

Sets the default path precedence for loading local game assets.

Add-on assets contained in the local SuperTux/addon home directory, that also match an expected game asset path, will take precedence.
 
This feature allows game hackers the ability to load their own game assets and add-on files.
 
 Example of addon home directory path, found on most Linux platforms: 
  ~/.local/share/supertux2/addons