### PR TITLE
avoid tiles out-of-bounds read

### DIFF
--- a/src/video/texture_manager.cpp
+++ b/src/video/texture_manager.cpp
@@ -325,7 +325,7 @@ TextureManager::create_image_texture_raw(const std::string& filename, const Rect
   bottom = std::min(rect.top + rect.get_height(), surface.h);
 
   SDL_Rect srcrect = SDL_Rect{rect.left, rect.top, right - rect.left, bottom - rect.top};
-  SDL_BlitSurface(&surface, &srcrect, subimage.get(), NULL);
+  SDL_BlitSurface(&surface, &srcrect, subimage.get(), nullptr);
 
   return VideoSystem::current()->new_texture(*subimage, sampler);
 }


### PR DESCRIPTION
Closes #1726

An out-of-bounds read in the texture manager causes supertux to segfault on
startup on OpenBSD with SDL >=2.0.10. This happens when processing the
bottom-right tile of images/tiles/doodads/tux-statue.png.

Source surface has insufficient pixels data for the tile destination
surface we are blitting to. tux-statue.png has 93 rows, but the bottom
right tile at (32, 64) would try to blit a 32x32 tile's worth of pixel
data. However, tux-statue.png only extends from row 64 to 93.

To resolve this truncate rectangles at the bottom tiles. Use
SDL_CreateRGBSurface + SDL_BlitSurface instead of
SDL_CreateRGBSurfaceFrom.

Thanks to Sylvain Becker (@1bsyl) for the cluestick.