### PR TITLE
More lenient spike hitboxes

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -315,15 +315,27 @@ BadGuy::collision_tile(uint32_t tile_attributes)
     m_in_water = false;
   }
 
-  if (tile_attributes & Tile::HURTS && is_hurtable()) {
-    if (tile_attributes & Tile::FIRE) {
-      if (is_flammable()) ignite();
-    }
-    else if (tile_attributes & Tile::ICE) {
-      if (is_freezable()) freeze();
-    }
-    else {
-      kill_fall();
+  if (tile_attributes & Tile::HURTS && is_hurtable())
+  {
+    Rectf hurtbox = get_bbox();
+    hurtbox.set_left(m_col.m_bbox.get_left() + 6.f);
+    hurtbox.set_right(m_col.m_bbox.get_right() - 6.f);
+    hurtbox.set_top(m_col.m_bbox.get_top() + 6.f);
+    hurtbox.set_bottom(m_col.m_bbox.get_bottom() - 6.f);
+    if (!Sector::get().is_free_of_tiles(hurtbox, true, Tile::HURTS))
+    {
+      if (tile_attributes & Tile::FIRE)
+      {
+        if (is_flammable()) ignite();
+      }
+      else if (tile_attributes & Tile::ICE)
+      {
+        if (is_freezable()) freeze();
+      }
+      else
+      {
+        kill_fall();
+      }
     }
   }
 }

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -317,11 +317,7 @@ BadGuy::collision_tile(uint32_t tile_attributes)
 
   if (tile_attributes & Tile::HURTS && is_hurtable())
   {
-    Rectf hurtbox = get_bbox();
-    hurtbox.set_left(m_col.m_bbox.get_left() + 6.f);
-    hurtbox.set_right(m_col.m_bbox.get_right() - 6.f);
-    hurtbox.set_top(m_col.m_bbox.get_top() + 6.f);
-    hurtbox.set_bottom(m_col.m_bbox.get_bottom() - 6.f);
+    Rectf hurtbox = get_bbox().grown(-6.f);
     if (!Sector::get().is_free_of_tiles(hurtbox, true, Tile::HURTS))
     {
       if (tile_attributes & Tile::FIRE)

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1735,7 +1735,13 @@ Player::collision_tile(uint32_t tile_attributes)
 {
   if (tile_attributes & Tile::HURTS)
   {
-    kill(false);
+    Rectf hurtbox = get_bbox();
+    hurtbox.set_left(m_col.m_bbox.get_left() + 6.f);
+    hurtbox.set_right(m_col.m_bbox.get_right() - 6.f);
+    hurtbox.set_top(m_col.m_bbox.get_top() + 6.f);
+    hurtbox.set_bottom(m_col.m_bbox.get_bottom() - 6.f);
+    if (!Sector::get().is_free_of_tiles(hurtbox, true, Tile::HURTS))
+      kill(false);
   }
 
   if (tile_attributes & Tile::WALLJUMP)

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1735,11 +1735,7 @@ Player::collision_tile(uint32_t tile_attributes)
 {
   if (tile_attributes & Tile::HURTS)
   {
-    Rectf hurtbox = get_bbox();
-    hurtbox.set_left(m_col.m_bbox.get_left() + 6.f);
-    hurtbox.set_right(m_col.m_bbox.get_right() - 6.f);
-    hurtbox.set_top(m_col.m_bbox.get_top() + 6.f);
-    hurtbox.set_bottom(m_col.m_bbox.get_bottom() - 6.f);
+    Rectf hurtbox = get_bbox().grown(-6.f);
     if (!Sector::get().is_free_of_tiles(hurtbox, true, Tile::HURTS))
       kill(false);
   }


### PR DESCRIPTION
This is a little PR that adds a bit of leniency to when Tux and badguys hit spikes and are actually hurt by them.  This makes the game a little more comfortable to play, especially in cases when Tux is right up against spikes (See issues #1725 and #1175, which would be fixed by this PR).

Only thing is, there has got to be a better method to defining these "hitboxes"... but if that isn't an issue then don't consider it one.