### PR TITLE
Fix trampoline bug

### DIFF
--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -384,6 +384,17 @@ CollisionSystem::collision_static(collision::Constraints* constraints,
       collision::Constraints new_constraints = check_collisions(
         movement, dest, static_object->m_dest, &object, static_object);
 
+      // If collisions occurred, objects must be notified now, because their
+      // destination could have changed so that they don't collide anymore.
+      if (new_constraints.has_constraints()) {
+        object.collision(*static_object, new_constraints.hit);
+        std::swap(new_constraints.hit.left, new_constraints.hit.right);
+        std::swap(new_constraints.hit.top, new_constraints.hit.bottom);
+        static_object->collision(object, new_constraints.hit);
+        std::swap(new_constraints.hit.left, new_constraints.hit.right);
+        std::swap(new_constraints.hit.top, new_constraints.hit.bottom);
+      }
+
       if (new_constraints.hit.bottom)
         static_object->collision_moving_object_bottom(object);
       else if (new_constraints.hit.top)


### PR DESCRIPTION
Tux can now jump on trampolines stacked over other objects.

Cause of the bug : no proper collision was detected between the player and the trampoline in some circumstances.