### PR TITLE
Fix for hat sprite desync

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1683,8 +1683,20 @@ Player::draw(DrawingContext& context)
   if (m_player_status.has_hat_sprite())
   {
     m_powersprite->set_action(m_sprite->get_action());
+    if (m_powersprite->get_frames() == m_sprite->get_frames())
+    {
+      m_powersprite->set_frame(m_sprite->get_current_frame());
+      m_powersprite->set_frame_progress(m_sprite->get_current_frame_progress());
+    }
     if (m_player_status.bonus == EARTH_BONUS)
+    {
       m_lightsprite->set_action(m_sprite->get_action());
+      if (m_lightsprite->get_frames() == m_sprite->get_frames())
+      {
+        m_lightsprite->set_frame(m_sprite->get_current_frame());
+        m_lightsprite->set_frame_progress(m_sprite->get_current_frame_progress());
+      }
+    }
   }
 
   /*

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -43,6 +43,10 @@ public:
   /** Set number of animation cycles until animation stops */
   void set_animation_loops(int loops = -1) { m_animation_loops = loops; }
 
+  void set_frame_progress(int frame_progress) { m_frame = frame_progress; }
+
+  void set_frame(int frame) { m_frameidx = frame; }
+
   /* Stop animation */
   void stop_animation() { m_animation_loops = 0; }
 
@@ -54,6 +58,9 @@ public:
 
   /** Get currently drawn frame */
   int get_current_frame() const { return m_frameidx; }
+
+  /** Get current frame progress */
+  int get_current_frame_progress() const { return m_frame; }
 
   /** Get sprite's name */
   const std::string& get_name() const { return m_data.name; }


### PR DESCRIPTION
This pull request fixes the bug when swimming where the powerup hats would desync from the body when collected, producing an odd jittering animation.  I made it to where the hat sprite is forced into the same frame and frame progress as the body, but only when they share the same amount of frames in order to avoid bugs with other actions.  Also, this has been applied only to the player.  It would close #1719.