### PR TITLE
Walljump Fixes and Improvements

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -942,7 +942,7 @@ Player::do_backflip() {
 
 void
 Player::do_jump(float yspeed) {
-  if (!on_ground() && !m_coyote_timer.started())
+  if (!m_can_walljump && !m_in_walljump_tile && !on_ground() && !m_coyote_timer.started())
     return;
 
   m_physic.set_velocity_y(yspeed);
@@ -1058,7 +1058,9 @@ Player::handle_vertical_input()
   if (m_controller->pressed(Control::JUMP) && m_can_walljump && !m_backflipping)
   {
     SoundManager::current()->play((is_big()) ? "sounds/bigjump.wav" : "sounds/jump.wav");
-    m_physic.set_velocity(m_on_left_wall ? 450.f : -450.f, -520.f);
+    m_physic.set_velocity_x(m_player_status.bonus == AIR_BONUS ?
+      m_on_left_wall ? 480.f : -480.f : m_on_left_wall ? 380.f : -380.f);
+    do_jump(-520.f);
   }
 
  m_physic.set_acceleration_y(0);
@@ -1618,7 +1620,7 @@ Player::draw(DrawingContext& context)
   }
   else if ((m_controller->hold(Control::LEFT) || m_controller->hold(Control::RIGHT)) && m_can_walljump)
   {
-    m_sprite->set_action(sa_prefix+"-walljump"+sa_postfix, 1);
+    m_sprite->set_action(sa_prefix+"-walljump"+(m_on_left_wall ? "-left" : "-right"), 1);
   }
   else if (!on_ground() || m_fall_mode != ON_GROUND)
   {


### PR DESCRIPTION
This quick PR makes horizontal and vertical movement while wall jumping more configurable, as well as fixing a bug where Tux would appear to cling to the air sometimes.