### PR TITLE
Fix segfault when quitting a level while grabbing

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -234,6 +234,7 @@ Player::Player(PlayerStatus& player_status, const std::string& name_) :
 
 Player::~Player()
 {
+  ungrab_object();
   if (m_climbing) stop_climbing(*m_climbing);
 }
 


### PR DESCRIPTION
Fixes #1739

Reproduction steps:
Jump on Mr ice block, grab, and abort level while grabbing. Segfaults

As explained in the issue, the player is destroyed before the grab listener. I believe it segfaults here:
https://github.com/SuperTux/supertux/blob/1df160fa556f6f1875b869562bb579c3bab8163b/src/supertux/game_object.cpp#L54-L56
when the grab listener (associated with the now-destroyed player) does something.

By ungrabbing in the player destructor, we also remove this listener and avoid this issue. Let me know if this seems correct, thanks
