### PR TITLE
Add GLM dependency to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,7 @@ distributions.
 * [cURL](http://curl.haxx.se/libcurl/): for Add-on downloads
 * [libogg and libvorbis](https://www.xiph.org/)
 * [FreeType](https://www.freetype.org/)
+* [GLM](https://github.com/g-truc/glm)
 * [libraqm](https://github.com/HOST-Oman/libraqm): optional, but needed
   to display Arabic
 
@@ -71,7 +72,7 @@ For ease of use, here are some installation lines for some Linux distributions:
 
 - Ubuntu 18.04/20.04:
   ```
-  sudo apt-get update && sudo apt-get install -y cmake build-essential libogg-dev libvorbis-dev libopenal-dev libboost-all-dev libsdl2-dev libsdl2-image-dev libfreetype6-dev libraqm-dev libcurl4-openssl-dev libglew-dev libharfbuzz-dev libfribidi-dev
+  sudo apt-get update && sudo apt-get install -y cmake build-essential libogg-dev libvorbis-dev libopenal-dev libboost-all-dev libsdl2-dev libsdl2-image-dev libfreetype6-dev libraqm-dev libcurl4-openssl-dev libglew-dev libharfbuzz-dev libfribidi-dev libglm-dev
   ```
 
 Installing under Linux/UNIX using CMake


### PR DESCRIPTION
Since 7187e3f6d7ce2ccc25bcc96e9bee25c24416d545 SuperTux depends on [GLM](https://github.com/g-truc/glm). I didn’t had this installed so I ran into an error when generating the Makefiles.