### PR TITLE
Cutscene audio fix

### DIFF
--- a/data/levels/world1/intro.nut
+++ b/data/levels/world1/intro.nut
@@ -198,6 +198,8 @@ Tux.do_duck();
   Effect.fade_out(2);
   wait(2.1);
   end_cutscene();
+  // If cutscene has been skipped, Tux won't have shrinked
+  Tux.set_bonus("none");
   Level.finish(true);
 }
 
@@ -241,6 +243,8 @@ function end_level()
   Effect.fade_out(2);
   wait(2.1);
   end_cutscene();
+  // If cutscene has been skipped, Tux won't have shrinked
+  Tux.set_bonus("none");
   Level.finish(true);
 }
 

--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -47,6 +47,8 @@ OpenALSoundSource::stop()
   //        https://github.com/emscripten-core/emscripten/issues/13797
   // The sounds stop anyways, but the code is probably unclean as a result.
   alSourceRewindv(1, &m_source); // Stops the source
+#else
+  set_volume(0.f);
 #endif
   alSourcei(m_source, AL_BUFFER, AL_NONE);
   try

--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -92,6 +92,10 @@ void start_cutscene()
   if (session->get_current_level().m_is_in_cutscene)
   {
     log_warning << "start_cutscene(): starting a new cutscene above another one, ending preceeding cutscene (use end_cutscene() in scripts!)" << std::endl;
+
+    // Remove all sounds that started playing while skipping
+    if (session->get_current_level().m_skip_cutscene)
+      SoundManager::current()->stop_sounds();
   }
 
   session->get_current_level().m_is_in_cutscene = true;
@@ -111,6 +115,10 @@ void end_cutscene()
   {
     log_warning << "end_cutscene(): no cutscene to end, resetting status anyways" << std::endl;
   }
+
+  // Remove all sounds that started playing while skipping
+  if (session->get_current_level().m_skip_cutscene)
+    SoundManager::current()->stop_sounds();
 
   session->get_current_level().m_is_in_cutscene = false;
   session->get_current_level().m_skip_cutscene = false;


### PR DESCRIPTION
Skipping a cutscene no longer plays all the sounds of the cutscene simultaneously.