### PR TITLE
Include <cfloat> for FLT_EPSILON

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -16,6 +16,8 @@
 
 #include "supertux/game_session.hpp"
 
+#include <cfloat>
+
 #include "audio/sound_manager.hpp"
 #include "control/input_manager.hpp"
 #include "editor/editor.hpp"


### PR DESCRIPTION
This fixes a build failure in Fedora rawhide, using GCC 11 and Boost 1.76.0.