### PR TITLE
Update CMakeLists.txt to enable GLM Experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,10 @@ endif(NOT EMSCRIPTEN)
 ## Add definitions
 if(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
   add_definitions(-DRELEASE)
+  add_definitions(-D GLM_ENABLE_EXPERIMENTAL)
 elseif(CMAKE_BUILD_TYPE MATCHES Debug)
   add_definitions(-DDEBUG)
+  add_definitions(-D GLM_ENABLE_EXPERIMENTAL)
 endif()
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
Build fails on Debian Buster without these entries for either Release or Debug builds.