### PR TITLE
fixing music not playing after death sometimes (#1833)

### DIFF
--- a/src/audio/sound_manager.cpp
+++ b/src/audio/sound_manager.cpp
@@ -399,8 +399,10 @@ SoundManager::resume_music(float fadetime)
 
   if (fadetime > 0) {
     if (m_music_source
-       && m_music_source->get_fade_state() != StreamSoundSource::FadingResume)
+       && m_music_source->get_fade_state() != StreamSoundSource::FadingResume) {
       m_music_source->set_fading(StreamSoundSource::FadingResume, fadetime);
+      m_music_source->resume();
+    }
   } else {
     m_music_source->resume();
   }


### PR DESCRIPTION
Resuming m_music_source on top of calling set_fading will play
the music if it has been paused, and will do nothing if the music
is not paused yet.