### PR TITLE
Editor load filesystem

### DIFF
--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -71,6 +71,11 @@ Level::save(const std::string& filepath, bool retry)
   try {
     { // make sure the level directory exists
       std::string dirname = FileSystem::dirname(filepath);
+      if (dirname == "./")
+      {
+        dirname = "";
+      }
+
       if (!PHYSFS_exists(dirname.c_str()))
       {
         if (!PHYSFS_mkdir(dirname.c_str()))
@@ -104,6 +109,11 @@ Level::save(const std::string& filepath, bool retry)
       log_warning << "Failed to save the level, retrying..." << std::endl;
       { // create the level directory again
         std::string dirname = FileSystem::dirname(filepath);
+        if (dirname == "./")
+        {
+          dirname = "";
+        }
+        
         if (!PHYSFS_mkdir(dirname.c_str()))
         {
           std::ostringstream msg;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -494,9 +494,11 @@ Main::launch_game(const CommandLineArguments& args)
           fileExists = FileSystem::exists(level_file);
           if(fileExists)
           {
-            auto dirname = FileSystem::dirname(level_file);
-            PHYSFS_mount(dirname.c_str(), nullptr, 0);
-            level_file = filename;
+            auto dirname = FileSystem::dirname(level_file) + "/";
+            auto filename = FileSystem::basename(level_file);
+            auto mountpoint = "level-editor-temp/";
+            PHYSFS_mount(dirname.c_str(), mountpoint, 0);
+            level_file = FileSystem::join(mountpoint, filename);
           }
         }
         if (fileExists) {

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -487,9 +487,21 @@ Main::launch_game(const CommandLineArguments& args)
       }
       else if (args.editor)
       {
-        if (PHYSFS_exists(start_level.c_str())) {
+        auto level_file = start_level;
+        auto fileExists = PHYSFS_exists(level_file.c_str());
+        if(!fileExists)
+        {
+          fileExists = FileSystem::exists(level_file);
+          if(fileExists)
+          {
+            auto dirname = FileSystem::dirname(level_file);
+            PHYSFS_mount(dirname.c_str(), nullptr, 0);
+            level_file = filename;
+          }
+        }
+        if (fileExists) {
           auto editor = std::make_unique<Editor>();
-          editor->set_level(start_level);
+          editor->set_level(level_file);
           editor->setup();
           editor->update(0, Controller());
           m_screen_manager->push_screen(std::move(editor));

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -496,9 +496,9 @@ Main::launch_game(const CommandLineArguments& args)
           {
             auto dirname = FileSystem::dirname(level_file) + "/";
             auto filename = FileSystem::basename(level_file);
-            auto mountpoint = "level-editor-temp/";
-            PHYSFS_mount(dirname.c_str(), mountpoint, 0);
-            level_file = FileSystem::join(mountpoint, filename);
+            PHYSFS_mount(dirname.c_str(), "/", 0);
+            PHYSFS_setWriteDir(dirname.c_str());
+            level_file = filename;
           }
         }
         if (fileExists) {

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -116,6 +116,11 @@ World::save(bool retry)
   {
     { // make sure the levelset directory exists
       std::string dirname = FileSystem::dirname(filepath);
+      if (dirname == "./")
+      {
+        dirname = "";
+      }
+
       if (!PHYSFS_exists(dirname.c_str()))
       {
         if (!PHYSFS_mkdir(dirname.c_str()))
@@ -156,6 +161,10 @@ World::save(bool retry)
       log_warning << "Failed to save the levelset info, retrying..." << std::endl;
       { // create the levelset directory again
         std::string dirname = FileSystem::dirname(filepath);
+        if (dirname == "./")
+        {
+          dirname = "";
+        }
         if (!PHYSFS_mkdir(dirname.c_str()))
         {
           std::ostringstream msg;


### PR DESCRIPTION
Load levels and worldmaps from the filesystem instead of using a PHYSFS local reference.

Fixes #1819

Please test this!