### PR TITLE
When pressing ESC after dying at a level start, ignore the play time if left or right is hold

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -167,9 +167,11 @@ GameSession::restart_level(bool after_death)
 }
 
 void
-GameSession::on_escape_press()
+GameSession::on_escape_press(const Controller& controller)
 {
-  if ((m_currentsector->get_player().is_dying() && m_play_time > 2.0f) || m_end_sequence)
+  if ((m_currentsector->get_player().is_dying() && (m_play_time > 2.0f
+      || controller.hold(Control::LEFT) || controller.hold(Control::RIGHT)))
+    || m_end_sequence)
   {
     // Let the timers run out, we fast-forward them to force past a sequence
     if (m_end_sequence)
@@ -331,7 +333,7 @@ GameSession::update(float dt_sec, const Controller& controller)
   if (controller.pressed(Control::ESCAPE) ||
       controller.pressed(Control::START))
   {
-    on_escape_press();
+    on_escape_press(controller);
   }
 
   if (controller.pressed(Control::CHEAT_MENU) &&

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -167,10 +167,10 @@ GameSession::restart_level(bool after_death)
 }
 
 void
-GameSession::on_escape_press(const Controller& controller)
+GameSession::on_escape_press(bool force_quick_respawn)
 {
   if ((m_currentsector->get_player().is_dying() && (m_play_time > 2.0f
-      || controller.hold(Control::LEFT) || controller.hold(Control::RIGHT)))
+      || force_quick_respawn))
     || m_end_sequence)
   {
     // Let the timers run out, we fast-forward them to force past a sequence
@@ -333,7 +333,8 @@ GameSession::update(float dt_sec, const Controller& controller)
   if (controller.pressed(Control::ESCAPE) ||
       controller.pressed(Control::START))
   {
-    on_escape_press(controller);
+    on_escape_press(controller.hold(Control::LEFT)
+      || controller.hold(Control::RIGHT));
   }
 
   if (controller.pressed(Control::CHEAT_MENU) &&

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -100,7 +100,7 @@ private:
   void drawstatus(DrawingContext& context);
   void draw_pause(DrawingContext& context);
 
-  void on_escape_press(const Controller& controller);
+  void on_escape_press(bool force_quick_respawn);
 
 private:
   std::unique_ptr<Level> m_level;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -91,7 +91,7 @@ public:
   void force_ghost_mode();
 
   Savegame& get_savegame() const { return m_savegame; }
-  
+
   void set_scheduler(SquirrelScheduler& new_scheduler);
 
 private:
@@ -100,7 +100,7 @@ private:
   void drawstatus(DrawingContext& context);
   void draw_pause(DrawingContext& context);
 
-  void on_escape_press();
+  void on_escape_press(const Controller& controller);
 
 private:
   std::unique_ptr<Level> m_level;
@@ -154,7 +154,7 @@ private:
   bool m_active; /** Game active? **/
 
   bool m_end_seq_started;
-  
+
   std::unique_ptr<GameObject> m_current_cutscene_text;
 
 private:


### PR DESCRIPTION
The play time condition is required so that it is possible to leave a level where Tux immediately dies in the beginning.
If Tux nonetheless dies near the beginning, pressing ESC while holding left or right now enables the player to quickly respawn.