### PR TITLE
Wind objects now affect Rocks

### DIFF
--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -200,5 +200,18 @@ Rock::get_settings()
   return result;
 }
 
+void
+Rock::add_wind_velocity(const Vector& velocity, const Vector& end_speed)
+{
+  // only add velocity in the same direction as the wind
+  if (end_speed.x > 0 && physic.get_velocity_x() < end_speed.x)
+    physic.set_velocity_x(std::min(physic.get_velocity_x() + velocity.x, end_speed.x));
+  if (end_speed.x < 0 && physic.get_velocity_x() > end_speed.x)
+    physic.set_velocity_x(std::max(physic.get_velocity_x() + velocity.x, end_speed.x));
+  if (end_speed.y > 0 && physic.get_velocity_y() < end_speed.y)
+    physic.set_velocity_y(std::min(physic.get_velocity_y() + velocity.y, end_speed.y));
+  if (end_speed.y < 0 && physic.get_velocity_y() > end_speed.y)
+    physic.set_velocity_y(std::max(physic.get_velocity_y() + velocity.y, end_speed.y));
+}
 
 /* EOF */

--- a/src/object/rock.hpp
+++ b/src/object/rock.hpp
@@ -42,6 +42,9 @@ public:
   virtual std::string get_display_name() const override { return _("Rock"); }
   virtual ObjectSettings get_settings() override;
 
+  /** Adds velocity from wind */
+  virtual void add_wind_velocity(const Vector& velocity, const Vector& end_speed);
+
 protected:
   Physic physic;
   bool on_ground;

--- a/src/object/wind.cpp
+++ b/src/object/wind.cpp
@@ -158,7 +158,7 @@ Wind::collision(GameObject& other, const CollisionHit& )
   }
 
   auto rock = dynamic_cast<Rock*>(&other);
-  if (rock && affects_badguys)
+  if (rock && affects_objects)
   {
     rock->add_wind_velocity(speed * acceleration * dt_sec, speed);
   }

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -61,6 +61,7 @@ private:
   float dt_sec; /**< stores last dt_sec gotten at update() */
 
   bool affects_badguys; /**< whether the wind can affect badguys */
+  bool affects_objects; /**< whether the wind can affect objects */
   bool affects_player; /**< whether the wind can affect the player: useful for cinematic wind */
   bool fancy_wind;
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/66701383/138780238-fc4bff51-6ed8-4996-960a-c2101e3ea5a3.mp4

There is an option to control which wind zones affect objects, independently from badguys and players.

Fixes #1826 