### PR TITLE
Save editor configuration to file

### DIFF
--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -40,14 +40,6 @@ class Tip;
 class EditorOverlayWidget final : public Widget
 {
 public:
-  static bool render_background;
-  static bool render_grid;
-  static bool snap_to_grid;
-  static bool autotile_mode;
-  static bool autotile_help;
-  static bool alt_pressed;
-  static int selected_snap_grid_size;
-
   static Color text_autotile_available_color;
   static Color text_autotile_active_color;
   static Color text_autotile_error_color;
@@ -74,6 +66,7 @@ public:
 
 private:
   static bool action_pressed;
+  static bool alt_pressed;
 
 private:
   void input_tile(const Vector& pos, uint32_t tile);

--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -20,6 +20,7 @@
 
 #include "editor/editor.hpp"
 #include "supertux/d_scope.hpp"
+#include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "util/reader.hpp"
 #include "util/reader_mapping.hpp"
@@ -372,7 +373,7 @@ Background::draw_image(DrawingContext& context, const Vector& pos_)
 void
 Background::draw(DrawingContext& context)
 {
-  if (Editor::is_active() && !EditorOverlayWidget::render_background)
+  if (Editor::is_active() && !g_config->editor_render_background)
     return;
 
   if (m_image.get() == nullptr)

--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -18,6 +18,7 @@
 
 #include "editor/editor.hpp"
 #include "object/camera.hpp"
+#include "supertux/gameconfig.hpp"
 #include "supertux/level.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader.hpp"
@@ -236,7 +237,7 @@ Gradient::set_direction(const GradientDirection& direction)
 void
 Gradient::draw(DrawingContext& context)
 {
-  if (Editor::is_active() && !EditorOverlayWidget::render_background)
+  if (Editor::is_active() && !g_config->editor_render_background)
     return;
 
   Rectf gradient_region;

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -307,7 +307,6 @@ CommandLineArguments::parse_args(int argc, char** argv)
     else if (arg == "--developer")
     {
       developer_mode = true;
-      EditorOverlayWidget::autotile_help = !developer_mode;
     }
     else if (arg == "--christmas")
     {

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -73,6 +73,13 @@ Config::Config() :
   enable_discord(false),
 #endif
   hide_editor_levelnames(false),
+  editor_selected_snap_grid_size(3),
+  editor_render_grid(true),
+  editor_snap_to_grid(true),
+  editor_render_background(true),
+  editor_render_lighting(false),
+  editor_autotile_mode(false),
+  editor_autotile_help(true),
   editor_autosave_frequency(5),
   repository_url()
 {
@@ -113,9 +120,23 @@ Config::load()
 #endif
   }
 
+  // Compatibility; will be overwritten by the "editor" category
   config_mapping.get("editor_autosave_frequency", editor_autosave_frequency);
 
-  EditorOverlayWidget::autotile_help = !developer_mode;
+  editor_autotile_help = !developer_mode;
+
+  boost::optional<ReaderMapping> editor_mapping;
+  if (config_mapping.get("editor", editor_mapping))
+  {
+    editor_mapping->get("autosave_frequency", editor_autosave_frequency);
+    editor_mapping->get("autotile_help", editor_autotile_help);
+    editor_mapping->get("autotile_mode", editor_autotile_mode);
+    editor_mapping->get("render_background", editor_render_background);
+    editor_mapping->get("render_grid", editor_render_grid);
+    editor_mapping->get("render_lighting", editor_render_lighting);
+    editor_mapping->get("selected_snap_grid_size", editor_selected_snap_grid_size);
+    editor_mapping->get("snap_to_grid", editor_snap_to_grid);
+  } else { log_warning << "!!!!" << std::endl; }
 
   if (is_christmas()) {
     if (!config_mapping.get("christmas", christmas_mode))
@@ -245,8 +266,6 @@ Config::save()
   }
   writer.end_list("integrations");
 
-  writer.write("editor_autosave_frequency", editor_autosave_frequency);
-
   if (is_christmas()) {
     writer.write("christmas", christmas_mode);
   }
@@ -318,6 +337,19 @@ Config::save()
     writer.end_list("addon");
   }
   writer.end_list("addons");
+
+  writer.start_list("editor");
+  {
+    writer.write("autosave_frequency", editor_autosave_frequency);
+    writer.write("autotile_help", editor_autotile_help);
+    writer.write("autotile_mode", editor_autotile_mode);
+    writer.write("render_background", editor_render_background);
+    writer.write("render_grid", editor_render_grid);
+    writer.write("render_lighting", editor_render_lighting);
+    writer.write("selected_snap_grid_size", editor_selected_snap_grid_size);
+    writer.write("snap_to_grid", editor_snap_to_grid);
+  }
+  writer.end_list("editor");
 
   writer.end_list("supertux-config");
 }

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -113,6 +113,13 @@ public:
 #endif
   bool hide_editor_levelnames;
 
+  int editor_selected_snap_grid_size;
+  bool editor_render_grid;
+  bool editor_snap_to_grid;
+  bool editor_render_background;
+  bool editor_render_lighting;
+  bool editor_autotile_mode;
+  bool editor_autotile_help;
   int editor_autosave_frequency;
 
   std::string repository_url;

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -62,13 +62,13 @@ EditorMenu::EditorMenu()
   
   add_hl();
 
-  add_string_select(-1, _("Grid Size"), &EditorOverlayWidget::selected_snap_grid_size, snap_grid_sizes);
-  add_toggle(-1, _("Show Grid"), &EditorOverlayWidget::render_grid);
-  add_toggle(-1, _("Grid Snapping"), &EditorOverlayWidget::snap_to_grid);
-  add_toggle(-1, _("Render Background"), &EditorOverlayWidget::render_background);
-  add_toggle(-1, _("Render Light"), &Compositor::s_render_lighting);
-  add_toggle(-1, _("Autotile Mode"), &EditorOverlayWidget::autotile_mode);
-  add_toggle(-1, _("Enable Autotile Help"), &EditorOverlayWidget::autotile_help);
+  add_string_select(-1, _("Grid Size"), &(g_config->editor_selected_snap_grid_size), snap_grid_sizes);
+  add_toggle(-1, _("Show Grid"), &(g_config->editor_render_grid));
+  add_toggle(-1, _("Grid Snapping"), &(g_config->editor_snap_to_grid));
+  add_toggle(-1, _("Render Background"), &(g_config->editor_render_background));
+  add_toggle(-1, _("Render Light"), &(Compositor::s_render_lighting));
+  add_toggle(-1, _("Autotile Mode"), &(g_config->editor_autotile_mode));
+  add_toggle(-1, _("Enable Autotile Help"), &(g_config->editor_autotile_help));
   add_intfield(_("Autosave Frequency"), &(g_config->editor_autosave_frequency));
 
   add_submenu(worldmap ? _("Worldmap Settings") : _("Level Settings"),


### PR DESCRIPTION
This will make the editor configuration persist when closing the game.

Note that due to implementation details, the lighting option is not saved. There should be discussion around this one, as the game automatically toggles it on when leaving the editor, making it difficult to persist.