### PR TITLE
Use jump to enter menus

### DIFF
--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -169,6 +169,7 @@ Dialog::process_input(const Controller& controller)
   }
 
   if (controller.pressed(Control::ACTION) ||
+      controller.pressed(Control::JUMP) ||
       controller.pressed(Control::MENU_SELECT))
   {
     on_button_click(m_selected_button);

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -434,6 +434,7 @@ Menu::process_input(const Controller& controller)
   }
 
   if (controller.pressed(Control::ACTION) ||
+     controller.pressed(Control::JUMP) ||
      controller.pressed(Control::MENU_SELECT) ||
      (!is_sensitive() && controller.pressed(Control::MENU_SELECT_SPACE))) {
     menuaction = MenuAction::HIT;


### PR DESCRIPTION
This is a small PR that allows usage of the jump key to enter menus, making it more consistent with the rest of the game.