### PR TITLE
Show world description at bottom of screen

### DIFF
--- a/data/levels/bonus1/info
+++ b/data/levels/bonus1/info
@@ -1,6 +1,6 @@
-;SuperTux-Level-Subset
 (supertux-level-subset
   (title (_ "Bonus Island I"))
-  (description "Levels from the Bonus World 1")
+  (description (_ "Compilation of early fan-submitted levels. Added in 0.1.2"))
   (levelset #f)
+  (hide-from-contribs #f)
 )

--- a/data/levels/bonus2/info
+++ b/data/levels/bonus2/info
@@ -1,6 +1,6 @@
-;SuperTux-Level-Subset
 (supertux-level-subset
   (title (_ "Bonus Island II"))
-  (description "Levels from the Bonus World 2")
+  (description (_ "Compilation of more early fan-submitted levels. Added in 0.1.3"))
   (levelset #f)
+  (hide-from-contribs #f)
 )

--- a/data/levels/bonus3/info
+++ b/data/levels/bonus3/info
@@ -1,5 +1,6 @@
 (supertux-level-subset
   (title (_ "Bonus Island III"))
-  (description "Collection of the multitudes of levels submitted to the bugtracker prior to development moving over to Git.")
+  (description (_ "Collection of the multitudes of levels submitted to the old bugtracker. Added in 0.3.5"))
   (levelset #f)
+  (hide-from-contribs #f)
 )

--- a/data/levels/bonus4/info
+++ b/data/levels/bonus4/info
@@ -1,6 +1,6 @@
 (supertux-level-subset
   (title (_ "Bonus Island IV"))
-  (description (_ ""))
+  (description (_ "Collection of levels with many varying themes. Added in 0.6.1"))
   (levelset #f)
   (hide-from-contribs #f)
 )

--- a/data/levels/community2016/info
+++ b/data/levels/community2016/info
@@ -1,6 +1,6 @@
 (supertux-level-subset
-  (title (_ "Community Island 2020"))
-  (description (_ ""))
+  (title (_ "Community Island"))
+  (description (_ "Level pack consisting of level contest winners"))
   (levelset #f)
   (hide-from-contribs #f)
 )

--- a/data/levels/revenge_in_redmond/info
+++ b/data/levels/revenge_in_redmond/info
@@ -1,6 +1,6 @@
 (supertux-level-subset
   (title (_ "Revenge in Redmond"))
-  (description (_ "A small and simple level pack celebrating the good old days of early SuperTux, Revenge in Redmond."))
+  (description (_ "Level pack celebrating the good ol' days of SuperTux for its 20th anniversary"))
   (levelset #f)
   (hide-from-contribs #f)
 )

--- a/src/supertux/menu/contrib_menu.cpp
+++ b/src/supertux/menu/contrib_menu.cpp
@@ -19,6 +19,7 @@
 #include <physfs.h>
 #include <sstream>
 
+#include "gui/item_action.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
 #include "physfs/util.hpp"
@@ -114,7 +115,9 @@ ContribMenu::ContribMenu() :
 
           std::ostringstream title;
           title << "[" << world->get_title() << "]";
-          add_entry(i++, title.str());
+          std::ostringstream desc;
+          desc << world->get_description();
+          add_entry(i++, title.str()).set_help(desc.str());
           m_contrib_worlds.push_back(std::move(world));
         }
         else if (world->is_worldmap())
@@ -137,7 +140,9 @@ ContribMenu::ContribMenu() :
 
           std::ostringstream title;
           title << world->get_title();
-          add_entry(i++, title.str());
+          std::ostringstream desc;
+          desc << world->get_description();
+          add_entry(i++, title.str()).set_help(desc.str());
           m_contrib_worlds.push_back(std::move(world));
         }
         else

--- a/src/supertux/world.hpp
+++ b/src/supertux/world.hpp
@@ -34,6 +34,7 @@ private:
 public:
   std::string get_basedir() const { return m_basedir; }
   std::string get_title() const { return m_title; }
+  std::string get_description() const { return m_description; }
 
   bool hide_from_contribs() const { return m_hide_from_contribs; }
 


### PR DESCRIPTION
This PR allows for the world description to show at the bottom of the screen when hovering over that worldmap.