### PR TITLE
Fixed audio stop function

### DIFF
--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -42,13 +42,11 @@ OpenALSoundSource::~OpenALSoundSource()
 void
 OpenALSoundSource::stop()
 {
-#ifndef __EMSCRIPTEN__
-  // FIXME: Emscripten's OpenAL port crashes when calling this, see:
-  //        https://github.com/emscripten-core/emscripten/issues/13797
-  // The sounds stop anyways, but the code is probably unclean as a result.
+#ifdef WIN32
+  // See commit 417a8e7a8c599bfc2dceaec7b6f64ac865318ef1
   alSourceRewindv(1, &m_source); // Stops the source
 #else
-  set_volume(0.f);
+  alSourceStop(m_source);
 #endif
   alSourcei(m_source, AL_BUFFER, AL_NONE);
   try


### PR DESCRIPTION
The OpenAL function used to stop audio was not `alSourceStop` but `alSourceRewindv`, used in 417a8e7 in response to #391 and #334. The problem is that the fix was applied for all platforms, and some new platforms (including but not limited to WASM) don't handle it very well.

This function restores the standard, expected function `alSourceStop`, except for Windows where it keeps using the other function.

I tested WASM and Linux, both work well; it should be tested on other platforms if possible.