### PR TITLE
Add generic list selection menu and use it in an editor menu

### DIFF
--- a/src/gui/menu_badguy_select.cpp
+++ b/src/gui/menu_badguy_select.cpp
@@ -19,6 +19,7 @@
 #include "gui/dialog.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
+#include "gui/menu_list.hpp"
 
 std::vector<std::string> BadguySelectMenu::all_badguys;
 
@@ -92,7 +93,7 @@ BadguySelectMenu::refresh_menu()
 
   add_label(_("List of enemies"));
   add_hl();
-  add_string_select(-2, _("Enemy"), &selected, all_badguys);
+  add_entry(-2, _("Select enemy"));
   add_entry(-3, _("Add"));
   add_hl();
 
@@ -138,6 +139,8 @@ BadguySelectMenu::menu_action(MenuItem& item)
     });
     dialog->add_cancel_button(_("No"));
     MenuManager::instance().set_dialog(std::move(dialog));
+  } else if (item.get_id() == -2) {
+    MenuManager::instance().push_menu(std::make_unique<ListMenu>(&all_badguys, &selected));
   } else if (item.get_id() == -3) {
     add_badguy();
   }

--- a/src/gui/menu_badguy_select.cpp
+++ b/src/gui/menu_badguy_select.cpp
@@ -140,7 +140,7 @@ BadguySelectMenu::menu_action(MenuItem& item)
     dialog->add_cancel_button(_("No"));
     MenuManager::instance().set_dialog(std::move(dialog));
   } else if (item.get_id() == -2) {
-    MenuManager::instance().push_menu(std::make_unique<ListMenu>(&all_badguys, &selected));
+    MenuManager::instance().push_menu(std::make_unique<ListMenu>(all_badguys, &selected));
   } else if (item.get_id() == -3) {
     add_badguy();
   }

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -2,14 +2,11 @@
 #include "gui/menu_list.hpp"
 #include "gui/menu_manager.hpp"
 
-ListMenu::ListMenu(std::vector<std::string>* items_, int* selected_) : 
-  items(items_), 
-  selected(selected_)
+ListMenu::ListMenu(const std::vector<std::string>& items, int* selected) : 
+  m_selected(selected)
 {
-  int i = 0;
-  for(auto& item : *items) {
-    add_entry(i, item);
-    i++;
+  for(uint i = 0; i < items.size(); i++) {
+    add_entry(i, items[i]);
   }
   add_hl();
   add_back("OK");
@@ -17,7 +14,9 @@ ListMenu::ListMenu(std::vector<std::string>* items_, int* selected_) :
 
 void
 ListMenu::menu_action(MenuItem& item) {
-  *selected = item.get_id();
+  if(m_selected) {
+    *m_selected = item.get_id();
+  }
   MenuManager::instance().pop_menu();
 }
 

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -1,0 +1,24 @@
+#include "gui/menu_item.hpp"
+#include "gui/menu_list.hpp"
+#include "gui/menu_manager.hpp"
+
+ListMenu::ListMenu(std::vector<std::string>* items_, int* selected_) : 
+  items(items_), 
+  selected(selected_)
+{
+  int i = 0;
+  for(auto& item : *items) {
+    add_entry(i, item);
+    i++;
+  }
+  add_hl();
+  add_back("OK");
+}
+
+void
+ListMenu::menu_action(MenuItem& item) {
+  *selected = item.get_id();
+  MenuManager::instance().pop_menu();
+}
+
+/* EOF */

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -21,8 +21,8 @@
 ListMenu::ListMenu(const std::vector<std::string>& items, int* selected) : 
   m_selected(selected)
 {
-  for(uint i = 0; i < items.size(); i++) {
-    add_entry(i, items[i]);
+  for(size_t i = 0; i < items.size(); i++) {
+    add_entry(static_cast<int>(i), items[i]);
   }
   add_hl();
   add_back("OK");

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -1,3 +1,19 @@
+//  SuperTux -- List menu
+//  Copyright (C) 2021 Rami <rami.slicer@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #include "gui/menu_item.hpp"
 #include "gui/menu_list.hpp"
 #include "gui/menu_manager.hpp"

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -24,7 +24,7 @@ class ListMenu final : public Menu
 public:
   ListMenu(const std::vector<std::string>& items, int* selected);
 
-  void menu_action(MenuItem& item);
+  void menu_action(MenuItem& item) override;
 
 private:
   int* m_selected;

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -6,13 +6,12 @@
 class ListMenu final : public Menu 
 {
 public:
-    ListMenu(std::vector<std::string>* items_, int* selected_);
+  ListMenu(const std::vector<std::string>& items, int* selected_);
 
-    void menu_action(MenuItem& item);
+  void menu_action(MenuItem& item);
 
 private:
-    std::vector<std::string>* items;
-    int* selected;
+  int* m_selected;
 
 private:
   // non-copyable footer

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -1,3 +1,19 @@
+//  SuperTux -- List menu
+//  Copyright (C) 2021 Rami <rami.slicer@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #ifndef HEADER_SUPERTUX_GUI_MENU_LIST_HPP
 #define HEADER_SUPERTUX_GUI_MENU_LIST_HPP
 
@@ -6,7 +22,7 @@
 class ListMenu final : public Menu 
 {
 public:
-  ListMenu(const std::vector<std::string>& items, int* selected_);
+  ListMenu(const std::vector<std::string>& items, int* selected);
 
   void menu_action(MenuItem& item);
 

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -1,0 +1,25 @@
+#ifndef HEADER_SUPERTUX_GUI_MENU_LIST_HPP
+#define HEADER_SUPERTUX_GUI_MENU_LIST_HPP
+
+#include "gui/menu.hpp"
+
+class ListMenu final : public Menu 
+{
+public:
+    ListMenu(std::vector<std::string>* items_, int* selected_);
+
+    void menu_action(MenuItem& item);
+
+private:
+    std::vector<std::string>* items;
+    int* selected;
+
+private:
+  // non-copyable footer
+  ListMenu(const ListMenu&) = delete;
+  ListMenu& operator=(const ListMenu&) = delete;
+};
+
+#endif
+
+/* EOF */


### PR DESCRIPTION
Add a generic list selection menu and use it.

* Add menu_list.cpp and its header
* Replace a somewhat annoying string selector used to configure the badguys emitted by a dispenser who's options were _every single_ badguy.

Closes #1894 