### PR TITLE
Make unstable tiles destroyable from bottom

### DIFF
--- a/src/object/unstable_tile.cpp
+++ b/src/object/unstable_tile.cpp
@@ -50,7 +50,8 @@ UnstableTile::collision(GameObject& other, const CollisionHit& )
   {
     Player* player = dynamic_cast<Player*>(&other);
     if (player != nullptr &&
-       player->get_bbox().get_bottom() < m_col.m_bbox.get_top() + SHIFT_DELTA)
+       (player->get_bbox().get_bottom() < m_col.m_bbox.get_top() + SHIFT_DELTA ||
+       player->get_bbox().get_top() < m_col.m_bbox.get_bottom() + SHIFT_DELTA))
     {
       shake();
     }

--- a/src/object/unstable_tile.cpp
+++ b/src/object/unstable_tile.cpp
@@ -51,7 +51,7 @@ UnstableTile::collision(GameObject& other, const CollisionHit& )
     Player* player = dynamic_cast<Player*>(&other);
     if (player != nullptr &&
        (player->get_bbox().get_bottom() < m_col.m_bbox.get_top() + SHIFT_DELTA ||
-       player->get_bbox().get_top() < m_col.m_bbox.get_bottom() + SHIFT_DELTA))
+       player->get_bbox().get_top() < m_col.m_bbox.get_bottom() - SHIFT_DELTA))
     {
       shake();
     }


### PR DESCRIPTION
This pull request doesn't allow for case when player is trapped under unstable tile after it respawns