### PR TITLE
Added code coverage analysis with lcov/gcov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,11 @@ jobs:
           - os: macos-latest
             build_type: Release
             release: 'ON'
+          - os: ubuntu-latest
+            build_type: Debug
+            compiler: gcc
+            arch: 64
+            coverage: 'ON'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -93,7 +98,8 @@ jobs:
             libglew-dev \
             libcurl4-openssl-dev \
             libglm-dev \
-            zlib1g-dev
+            zlib1g-dev \
+            lcov
       - name: Install 32-bit linux dependencies
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 32 }}
         run: |
@@ -184,6 +190,14 @@ jobs:
       - name: Run tests
         working-directory: build
         run: ./test_supertux2
+      - name: Make coverage
+        if: ${{ matrix.coverage }}
+        working-directory: build
+        run: |
+          lcov --capture --directory . --exclude '/usr/*' --exclude '*/tests/*' --exclude '*/external/*' --output-file coverage.info
+          mkdir coverage
+          cd coverage
+          genhtml ../coverage.info
       - name: Package
         if: ${{ matrix.os != 'ubuntu-latest' || matrix.arch != '32' }}
         env:
@@ -228,6 +242,10 @@ jobs:
           name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-dmg"
           path: build/upload/*.dmg
           if-no-files-found: ignore
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "coverage"
+          path: build/coverage/*
       - uses: anshulrgoyal/upload-s3-action@master
         # These all have repository_owner conditions because the secret isn't available to other owners
         if: matrix.release == 'ON' && env.CI_KEY != null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1035,7 +1035,7 @@ if(BUILD_TESTS)
   find_package(GTest REQUIRED)
 
   # build SuperTux tests
-  file(GLOB TEST_SUPERTUX_SOURCES tests/*.cpp)
+  file(GLOB_RECURSE TEST_SUPERTUX_SOURCES tests/*.cpp)
   add_executable(test_supertux2 ${TEST_SUPERTUX_SOURCES})
   target_compile_options(test_supertux2 PRIVATE ${WARNINGS_CXX_FLAGS})
   target_link_libraries(test_supertux2
@@ -1054,6 +1054,18 @@ if(BUILD_TESTS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       target_compile_options(supertux2_lib PUBLIC -fprofile-arcs -ftest-coverage)
       target_link_options(supertux2_lib PUBLIC -lgcov --coverage)
+
+      add_custom_target(coverage_clear_unix
+        COMMAND find . -name "*.gcda" | xargs rm || true # FIXME: Make this platform-neutral
+        COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/coverage)
+
+      add_custom_target(coverage_unix
+        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target coverage_clear_unix
+        COMMAND ${CMAKE_CTEST_COMMAND}
+        COMMAND lcov --capture --directory ${CMAKE_CURRENT_BINARY_DIR} --exclude '/usr/*' --exclude '*/tests/*' --exclude '*/external/*' --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/coverage
+        COMMAND genhtml ${CMAKE_CURRENT_BINARY_DIR}/coverage.info -o ${CMAKE_CURRENT_BINARY_DIR}/coverage -t "${SUPERTUX_VERSION_STRING}")
     else(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       message(WARNING "Coverage for non-GNU compilers has yet to be implemented")
     endif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1048,6 +1048,18 @@ if(BUILD_TESTS)
   add_test(NAME test_supertux2
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND test_supertux2)
+
+  # Prepare coverage with gcov/lcov
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      target_compile_options(supertux2_lib PUBLIC -fprofile-arcs -ftest-coverage)
+      target_link_options(supertux2_lib PUBLIC -lgcov --coverage)
+    else(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      message(WARNING "Coverage for non-GNU compilers has yet to be implemented")
+    endif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  else(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Building tests in a non-Debug build will NOT make files for coverage! Change CMAKE_BUILD_TYPE to Debug to prepare for coverage analysis.")
+  endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 ## Install stuff

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Tests
+
+This folder groups all files needed to run the test suite.
+
+## Hierarchy
+
+- **[`data/`](data/)**: Data files needed to perform tests.
+- **[`unit/`](unit/)**: Unit test files designed to fully test a single specific file in the [src](../src/) folder at the root of the repository. The folder structure and file naming should be identical in both folders.
+
+Files that aren't in any folder are part of the legacy test suite.
+
+Test suites which perform coverage differently (e. g. integration tests, running the game from the point of view of the user, etc) should be located in their own folder within `test/`.

--- a/tests/unit/util/colorspace_oklab.cpp
+++ b/tests/unit/util/colorspace_oklab.cpp
@@ -1,0 +1,105 @@
+//  SuperTux
+//  Copyright (C) 2015 Ingo Ruhnke <grumbel@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "util/colorspace_oklab.hpp"
+
+#include <gtest/gtest.h>
+
+#include "video/color.hpp"
+
+TEST(ColorOKLCh, ctor)
+{
+  ColorOKLCh color(.3f, .4f, .5f);
+  EXPECT_FLOAT_EQ(color.L, .3f);
+  EXPECT_FLOAT_EQ(color.C, .4f);
+  EXPECT_FLOAT_EQ(color.h, .5f);
+}
+
+TEST(ColorOKLCh, ctor_Color)
+{
+  Color col(.3f, .4f, .5f);
+  ColorOKLCh color(col);
+  EXPECT_FLOAT_EQ(color.L, .50023675f);
+  EXPECT_FLOAT_EQ(color.C, .050982524f);
+  EXPECT_FLOAT_EQ(color.h, -1.9393998f);
+}
+
+TEST(ColorOKLCh, to_srgb)
+{
+  Color col(.1f, 1.f, 0.f);
+  ColorOKLCh color(col);
+
+  col = color.to_srgb();
+
+  // Can't use strict equality because of imprecision
+  // 1 / 256 = 0.00390625, so 0.001 should make no difference.
+  EXPECT_NEAR(col.red, .1f, 0.001f);
+  EXPECT_NEAR(col.green, 1.f, 0.001f);
+  EXPECT_NEAR(col.blue, 0.f, 0.001f);
+}
+
+TEST(ColorOKLCh, get_maximum_chroma)
+{
+  ColorOKLCh color(.6f, 1.f, .3f);
+
+  float chroma = color.get_maximum_chroma();
+
+  EXPECT_FLOAT_EQ(chroma, .24032472f);
+}
+
+TEST(ColorOKLCh, get_maximum_chroma_any_l)
+{
+  ColorOKLCh color(0.f, .1f, .05f);
+
+  float chroma = color.get_maximum_chroma_any_l();
+
+  EXPECT_FLOAT_EQ(chroma, .26009744f);
+}
+
+TEST(ColorOKLCh, clip_chroma)
+{
+  ColorOKLCh color(.45f, .67f, .12f);
+
+  color.clip_chroma();
+
+  EXPECT_FLOAT_EQ(color.L, .45f);
+  EXPECT_FLOAT_EQ(color.C, .1804768f);
+  EXPECT_FLOAT_EQ(color.h, .12f);
+}
+
+TEST(ColorOKLCh, clip_lightness)
+{
+  ColorOKLCh color(.45f, .67f, .12f);
+
+  color.clip_lightness();
+
+  EXPECT_FLOAT_EQ(color.L, .64147455f);
+  EXPECT_FLOAT_EQ(color.C, .2572695f);
+  EXPECT_FLOAT_EQ(color.h, .12f);
+}
+
+TEST(ColorOKLCh, clip_adaptive_L0_L_cusp)
+{
+  ColorOKLCh color(1.f, 1.f, 1.f);
+
+  color.clip_adaptive_L0_L_cusp(0.25f);
+
+  EXPECT_FLOAT_EQ(color.L, .83574224f);
+  EXPECT_FLOAT_EQ(color.C, .10836758f);
+  EXPECT_FLOAT_EQ(color.h, 1.f);
+}
+
+/* EOF */

--- a/tests/unit/util/colorspace_oklab.cpp
+++ b/tests/unit/util/colorspace_oklab.cpp
@@ -23,18 +23,21 @@
 TEST(ColorOKLCh, ctor)
 {
   ColorOKLCh color(.3f, .4f, .5f);
-  EXPECT_FLOAT_EQ(color.L, .3f);
-  EXPECT_FLOAT_EQ(color.C, .4f);
-  EXPECT_FLOAT_EQ(color.h, .5f);
+
+  // Can't use strict equality because of imprecision
+  // 1 / 256 = 0.00390625, so 0.001 should make no difference.
+  EXPECT_NEAR(color.L, .3f, 0.001f);
+  EXPECT_NEAR(color.C, .4f, 0.001f);
+  EXPECT_NEAR(color.h, .5f, 0.001f);
 }
 
 TEST(ColorOKLCh, ctor_Color)
 {
   Color col(.3f, .4f, .5f);
   ColorOKLCh color(col);
-  EXPECT_FLOAT_EQ(color.L, .50023675f);
-  EXPECT_FLOAT_EQ(color.C, .050982524f);
-  EXPECT_FLOAT_EQ(color.h, -1.9393998f);
+  EXPECT_NEAR(color.L, .50023675f, 0.001f);
+  EXPECT_NEAR(color.C, .050982524f, 0.001f);
+  EXPECT_NEAR(color.h, -1.9393998f, 0.001f);
 }
 
 TEST(ColorOKLCh, to_srgb)
@@ -44,8 +47,6 @@ TEST(ColorOKLCh, to_srgb)
 
   col = color.to_srgb();
 
-  // Can't use strict equality because of imprecision
-  // 1 / 256 = 0.00390625, so 0.001 should make no difference.
   EXPECT_NEAR(col.red, .1f, 0.001f);
   EXPECT_NEAR(col.green, 1.f, 0.001f);
   EXPECT_NEAR(col.blue, 0.f, 0.001f);
@@ -57,7 +58,7 @@ TEST(ColorOKLCh, get_maximum_chroma)
 
   float chroma = color.get_maximum_chroma();
 
-  EXPECT_FLOAT_EQ(chroma, .24032472f);
+  EXPECT_NEAR(chroma, .24032472f, 0.001f);
 }
 
 TEST(ColorOKLCh, get_maximum_chroma_any_l)
@@ -66,7 +67,7 @@ TEST(ColorOKLCh, get_maximum_chroma_any_l)
 
   float chroma = color.get_maximum_chroma_any_l();
 
-  EXPECT_FLOAT_EQ(chroma, .26009744f);
+  EXPECT_NEAR(chroma, .26009744f, 0.001f);
 }
 
 TEST(ColorOKLCh, clip_chroma)
@@ -75,9 +76,9 @@ TEST(ColorOKLCh, clip_chroma)
 
   color.clip_chroma();
 
-  EXPECT_FLOAT_EQ(color.L, .45f);
-  EXPECT_FLOAT_EQ(color.C, .1804768f);
-  EXPECT_FLOAT_EQ(color.h, .12f);
+  EXPECT_NEAR(color.L, .45f, 0.001f);
+  EXPECT_NEAR(color.C, .1804768f, 0.001f);
+  EXPECT_NEAR(color.h, .12f, 0.001f);
 }
 
 TEST(ColorOKLCh, clip_lightness)
@@ -86,9 +87,9 @@ TEST(ColorOKLCh, clip_lightness)
 
   color.clip_lightness();
 
-  EXPECT_FLOAT_EQ(color.L, .64147455f);
-  EXPECT_FLOAT_EQ(color.C, .2572695f);
-  EXPECT_FLOAT_EQ(color.h, .12f);
+  EXPECT_NEAR(color.L, .64147455f, 0.001f);
+  EXPECT_NEAR(color.C, .2572695f, 0.001f);
+  EXPECT_NEAR(color.h, .12f, 0.001f);
 }
 
 TEST(ColorOKLCh, clip_adaptive_L0_L_cusp)
@@ -97,9 +98,9 @@ TEST(ColorOKLCh, clip_adaptive_L0_L_cusp)
 
   color.clip_adaptive_L0_L_cusp(0.25f);
 
-  EXPECT_FLOAT_EQ(color.L, .83574224f);
-  EXPECT_FLOAT_EQ(color.C, .10836758f);
-  EXPECT_FLOAT_EQ(color.h, 1.f);
+  EXPECT_NEAR(color.L, .83574224f, 0.001f);
+  EXPECT_NEAR(color.C, .10836758f, 0.001f);
+  EXPECT_NEAR(color.h, 1.f, 0.001f);
 }
 
 /* EOF */


### PR DESCRIPTION
This will allow developers to view an analysis of the code coverage done by tests through either local generation or with CI artifacts.

![image](https://user-images.githubusercontent.com/66701383/144767919-b582ba4c-588d-4dd8-b851-f5a3709cc59d.png)