### PR TITLE
Newly created worldmaps use the new tileset

### DIFF
--- a/src/supertux/level_parser.cpp
+++ b/src/supertux/level_parser.cpp
@@ -206,7 +206,7 @@ LevelParser::create(const std::string& filepath, const std::string& levelname)
   m_level.m_filename = filepath;
   m_level.m_name = levelname;
   m_level.m_license = "CC-BY-SA 4.0 International";
-  m_level.m_tileset = m_worldmap ? "images/worldmap.strf" : "images/tiles.strf";
+  m_level.m_tileset = m_worldmap ? "images/ice_world.strf" : "images/tiles.strf";
 
   auto sector = SectorParser::from_nothing(m_level);
   sector->set_name("main");

--- a/src/supertux/sector_parser.cpp
+++ b/src/supertux/sector_parser.cpp
@@ -331,7 +331,7 @@ SectorParser::create_sector()
 
   auto& intact = m_sector.add<TileMap>(tileset);
   if (worldmap) {
-    intact.resize(100, 100, 9);
+    intact.resize(100, 100, 1);
   } else {
     intact.resize(100, 35, 0);
   }

--- a/src/supertux/sector_parser.cpp
+++ b/src/supertux/sector_parser.cpp
@@ -328,10 +328,17 @@ SectorParser::create_sector()
     frgrd.set_layer(100);
     frgrd.set_solid(false);
   }
+  else
+  {
+    auto& water = m_sector.add<TileMap>(tileset);
+    water.resize(100, 35, 1);
+    water.set_layer(-100);
+    water.set_solid(false);
+  }
 
   auto& intact = m_sector.add<TileMap>(tileset);
   if (worldmap) {
-    intact.resize(100, 100, 1);
+    intact.resize(100, 100, 0);
   } else {
     intact.resize(100, 35, 0);
   }

--- a/src/worldmap/worldmap_parser.cpp
+++ b/src/worldmap/worldmap_parser.cpp
@@ -78,7 +78,7 @@ WorldMapParser::load_worldmap(const std::string& filename)
     }
     /* load default tileset */
     if (m_worldmap.m_tileset == nullptr) {
-      m_worldmap.m_tileset = TileManager::current()->get_tileset("images/worldmap.strf");
+      m_worldmap.m_tileset = TileManager::current()->get_tileset("images/ice_world.strf");
     }
 
     boost::optional<ReaderMapping> sector;


### PR DESCRIPTION
Worldmaps are created using `ice_world.strf` by default, instead of the old `worldmap.strf`.