### PR TITLE
Show selected enemy in dispenser menu

### DIFF
--- a/src/gui/menu_badguy_select.cpp
+++ b/src/gui/menu_badguy_select.cpp
@@ -21,6 +21,8 @@
 #include "gui/menu_manager.hpp"
 #include "gui/menu_list.hpp"
 
+#include "boost/format.hpp"
+
 std::vector<std::string> BadguySelectMenu::all_badguys;
 
 BadguySelectMenu::BadguySelectMenu(std::vector<std::string>* badguys_) :
@@ -93,7 +95,7 @@ BadguySelectMenu::refresh()
 
   add_label(_("List of enemies"));
   add_hl();
-  add_entry(-2, _("Select enemy") + " (" + all_badguys[selected] + ")");
+  add_entry(-2, str(boost::format(_("Select enemy (%s)")) % all_badguys[selected]));
   add_entry(-3, _("Add"));
   add_hl();
 

--- a/src/gui/menu_badguy_select.cpp
+++ b/src/gui/menu_badguy_select.cpp
@@ -83,17 +83,17 @@ BadguySelectMenu::BadguySelectMenu(std::vector<std::string>* badguys_) :
     all_badguys.push_back("zeekling");
   }
 
-  refresh_menu();
+  refresh();
 }
 
 void
-BadguySelectMenu::refresh_menu()
+BadguySelectMenu::refresh()
 {
   m_items.clear();
 
   add_label(_("List of enemies"));
   add_hl();
-  add_entry(-2, _("Select enemy"));
+  add_entry(-2, _("Select enemy") + " (" + all_badguys[selected] + ")");
   add_entry(-3, _("Add"));
   add_hl();
 
@@ -111,7 +111,7 @@ void
 BadguySelectMenu::remove_badguy()
 {
   badguys->erase(badguys->begin() + remove_item);
-  refresh_menu();
+  refresh();
   if (m_items[m_active_item]->skippable()) {
     //We are on the bottom headline.
     m_active_item++;
@@ -122,7 +122,7 @@ void
 BadguySelectMenu::add_badguy()
 {
   badguys->push_back(all_badguys[selected]);
-  refresh_menu();
+  refresh();
 }
 
 void
@@ -140,7 +140,7 @@ BadguySelectMenu::menu_action(MenuItem& item)
     dialog->add_cancel_button(_("No"));
     MenuManager::instance().set_dialog(std::move(dialog));
   } else if (item.get_id() == -2) {
-    MenuManager::instance().push_menu(std::make_unique<ListMenu>(all_badguys, &selected));
+    MenuManager::instance().push_menu(std::make_unique<ListMenu>(all_badguys, &selected, this));
   } else if (item.get_id() == -3) {
     add_badguy();
   }

--- a/src/gui/menu_badguy_select.hpp
+++ b/src/gui/menu_badguy_select.hpp
@@ -30,12 +30,13 @@ public:
 
   void remove_badguy();
 
+  void refresh();
+
 private:
   std::vector<std::string>* badguys;
   int selected;
   int remove_item;
 
-  void refresh_menu();
   void add_badguy();
 
 private:

--- a/src/gui/menu_badguy_select.hpp
+++ b/src/gui/menu_badguy_select.hpp
@@ -30,7 +30,7 @@ public:
 
   void remove_badguy();
 
-  void refresh();
+  void refresh() override;
 
 private:
   std::vector<std::string>* badguys;

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -17,6 +17,7 @@
 #include "gui/menu_item.hpp"
 #include "gui/menu_list.hpp"
 #include "gui/menu_manager.hpp"
+#include "util/gettext.hpp"
 
 ListMenu::ListMenu(const std::vector<std::string>& items, int* selected, Menu* parent) : 
   m_selected(selected),
@@ -26,7 +27,7 @@ ListMenu::ListMenu(const std::vector<std::string>& items, int* selected, Menu* p
     add_entry(static_cast<int>(i), items[i]);
   }
   add_hl();
-  add_back("OK");
+  add_back(_("Cancel"));
 }
 
 void

--- a/src/gui/menu_list.cpp
+++ b/src/gui/menu_list.cpp
@@ -18,8 +18,9 @@
 #include "gui/menu_list.hpp"
 #include "gui/menu_manager.hpp"
 
-ListMenu::ListMenu(const std::vector<std::string>& items, int* selected) : 
-  m_selected(selected)
+ListMenu::ListMenu(const std::vector<std::string>& items, int* selected, Menu* parent) : 
+  m_selected(selected),
+  m_parent(parent)
 {
   for(size_t i = 0; i < items.size(); i++) {
     add_entry(static_cast<int>(i), items[i]);
@@ -33,6 +34,7 @@ ListMenu::menu_action(MenuItem& item) {
   if(m_selected) {
     *m_selected = item.get_id();
   }
+  m_parent->refresh();
   MenuManager::instance().pop_menu();
 }
 

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -22,12 +22,13 @@
 class ListMenu final : public Menu 
 {
 public:
-  ListMenu(const std::vector<std::string>& items, int* selected);
+  ListMenu(const std::vector<std::string>& items, int* selected, Menu *parent);
 
   void menu_action(MenuItem& item) override;
 
 private:
   int* m_selected;
+  Menu* m_parent;
 
 private:
   // non-copyable footer

--- a/src/gui/menu_list.hpp
+++ b/src/gui/menu_list.hpp
@@ -22,7 +22,7 @@
 class ListMenu final : public Menu 
 {
 public:
-  ListMenu(const std::vector<std::string>& items, int* selected, Menu *parent);
+  ListMenu(const std::vector<std::string>& items, int* selected, Menu* parent);
 
   void menu_action(MenuItem& item) override;
 


### PR DESCRIPTION
After the recent change to the enemy select menu, the game no longer showed what enemy is currently selected (the only way to know was to either select it again or add a new one and delete it if it wasn't the right one). This pull request makes the menu show "Select enemy (currently selected)" instead of just "Select enemy".

refresh_menu() is changed to refresh() because refresh() is defined in the generic Menu class, whereas refresh_menu() was only in menu_badguy_select, so using it would mean eiher restricting menu_list to badguy select menu only or having two functions with identical functionality defined in Menu.

It also changes OK to Cancel in the list menu as OK makes no sense if no changes are made (and it also makes it translatable).