### PR TITLE
Added reference counter for PathObjects

### DIFF
--- a/src/badguy/ghoul.cpp
+++ b/src/badguy/ghoul.cpp
@@ -76,17 +76,6 @@ Ghoul::finish_construction()
 }
 
 void
-Ghoul::editor_delete()
-{
-  auto path_obj = get_path_gameobject();
-  if(path_obj != nullptr)
-  {
-    path_obj->editor_delete();
-  }
-  GameObject::editor_delete();
-}
-
-void
 Ghoul::activate()
 {
   if (Editor::is_active())

--- a/src/badguy/ghoul.hpp
+++ b/src/badguy/ghoul.hpp
@@ -32,7 +32,6 @@ public:
   bool is_flammable() const override;
 
   void finish_construction() override;
-  void editor_delete() override; 
 
   void activate() override;
   void deactivate() override;

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -106,17 +106,6 @@ WillOWisp::after_editor_set()
 }
 
 void
-WillOWisp::editor_delete()
-{
-  auto path_obj = get_path_gameobject();
-  if(path_obj != nullptr)
-  {
-    path_obj->editor_delete();
-  }
-  GameObject::editor_delete();
-}
-
-void
 WillOWisp::active_update(float dt_sec)
 {
   if (Editor::is_active() && get_path() && get_path()->is_valid()) {

--- a/src/badguy/willowisp.hpp
+++ b/src/badguy/willowisp.hpp
@@ -34,7 +34,6 @@ public:
 
   virtual void finish_construction() override;
   virtual void after_editor_set() override;
-  virtual void editor_delete() override;
 
   virtual void activate() override;
   virtual void deactivate() override;

--- a/src/gui/menu_paths.cpp
+++ b/src/gui/menu_paths.cpp
@@ -32,6 +32,7 @@ auto on_select = [](std::string path, PathObject& target, std::string path_ref) 
       auto* into = Editor::current()->get_sector()->get_object_by_name<PathGameObject>(path_ref);
       if (from && into) {
         from->copy_into(*into);
+        MenuManager::instance().pop_menu();
       } else {
         log_warning << "Could not copy path, misses " << (from ? "" : "'from'")
                     << (into ? "" : "'into'") << std::endl;
@@ -40,6 +41,7 @@ auto on_select = [](std::string path, PathObject& target, std::string path_ref) 
     });
     dialog->add_button(_("Bind"), [path, &target] {
       target.editor_set_path_by_ref(path);
+        MenuManager::instance().pop_menu();
     });
     dialog->add_cancel_button(_("Cancel"));
     dialog->set_text("Do you wish to clone the path to edit it separately,\nor do you want to bind both paths together\nso that any edit on one edits the other?");

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -117,21 +117,6 @@ Coin::editor_update()
 }
 
 void
-Coin::editor_delete()
-{
-  // Removed since paths can be shared by multiple objects
-  // TODO: Handle reference counting for paths
-#if 0
-  auto path_obj = get_path_gameobject();
-  if(path_obj != nullptr)
-  {
-    path_obj->editor_delete();
-  }
-#endif
-  GameObject::editor_delete();
-}
-
-void
 Coin::collect()
 {
   static Timer sound_timer;

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -45,7 +45,6 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
   virtual void editor_update() override;
-  virtual void editor_delete() override;
 
   virtual void move_to(const Vector& pos) override;
 

--- a/src/object/path_gameobject.cpp
+++ b/src/object/path_gameobject.cpp
@@ -18,10 +18,14 @@
 
 #include <boost/optional.hpp>
 
+#include "editor/node_marker.hpp"
+#include "gui/menu_manager.hpp"
 #include "object/path.hpp"
+#include "object/path_object.hpp"
 #include "sprite/sprite.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "supertux/debug.hpp"
+#include "supertux/sector.hpp"
 #include "util/log.hpp"
 #include "util/reader_mapping.hpp"
 #include "util/unique_name.hpp"
@@ -102,7 +106,7 @@ PathGameObject::~PathGameObject()
 void
 PathGameObject::update(float dt_sec)
 {
-  // nothing to do
+  check_references();
 }
 
 void
@@ -176,6 +180,12 @@ PathGameObject::get_settings()
 }
 
 void
+PathGameObject::editor_update()
+{
+  check_references();
+}
+
+void
 PathGameObject::editor_select()
 {
   log_fatal << "PathGameObject::selected" << std::endl;
@@ -187,10 +197,43 @@ PathGameObject::editor_deselect()
   log_fatal << "PathGameObject::deselected" << std::endl;
 }
 
+void
+PathGameObject::remove_me()
+{
+  if (Sector::current())
+  {
+    auto handles = Sector::get().get_objects_by_type<NodeMarker>();
+
+    for (auto& handle : handles)
+      handle.remove_me(); // Removing a node handle also removes its bezier handles
+  }
+
+  GameObject::remove_me();
+}
+
 void 
 PathGameObject::copy_into(PathGameObject& other)
 {
   other.get_path().m_nodes = get_path().m_nodes;
+}
+
+void
+PathGameObject::check_references()
+{
+  if (!Sector::current())
+    return;
+
+  // Object settings menu might hold references to paths
+  if (MenuManager::instance().is_active())
+    return;
+
+  const auto& path_objects = Sector::get().get_objects_by_type<PathObject>();
+
+  for (const auto& path_obj : path_objects)
+    if (path_obj.get_path_gameobject() == this)
+      return;
+
+  remove_me();
 }
 
 /* EOF */

--- a/src/object/path_gameobject.hpp
+++ b/src/object/path_gameobject.hpp
@@ -47,14 +47,21 @@ public:
     return "images/engine/editor/path.png";
   }
 
+  virtual void editor_update() override;
   virtual void editor_select() override;
   virtual void editor_deselect() override;
+
+  virtual void remove_me() override;
 
   virtual ObjectSettings get_settings() override;
 
   Path& get_path() { return *m_path; }
 
   void copy_into(PathGameObject& other);
+
+private:
+  /** Removes the object if the path is not referenced anywhere */
+  void check_references();
 
 private:
   std::unique_ptr<Path> m_path;

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -146,17 +146,6 @@ Platform::editor_update()
 }
 
 void
-Platform::editor_delete()
-{
-  auto path_obj = get_path_gameobject();
-  if(path_obj != nullptr)
-  {
-    path_obj->editor_delete();
-  }
-  GameObject::editor_delete();
-}
-
-void
 Platform::goto_node(int node_no)
 {
   get_walker()->goto_node(node_no);

--- a/src/object/platform.hpp
+++ b/src/object/platform.hpp
@@ -45,7 +45,6 @@ public:
   virtual std::string get_display_name() const override { return _("Platform"); }
 
   virtual void editor_update() override;
-  virtual void editor_delete() override;
 
   const Vector& get_speed() const { return m_speed; }
 

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -362,20 +362,6 @@ TileMap::editor_update()
 }
 
 void
-TileMap::editor_delete()
-{
-  // Paths may be used by multiple objects
-#if 0
-  auto path_obj = get_path_gameobject();
-  if(path_obj != nullptr)
-  {
-    path_obj->editor_delete();
-  }
-#endif
-  GameObject::editor_delete();
-}
-
-void
 TileMap::draw(DrawingContext& context)
 {
   // skip draw if current opacity is 0.0

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -58,7 +58,6 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
-  virtual void editor_delete() override;
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;


### PR DESCRIPTION
Automatically manages a path's lifetime based on whether or not it is referenced by other objects.

Also fixes a bug where node handles in the editor would persist after a path is deleted, resulting in undefined behavior. It does not, however, remove nodes upon deselection; it only removes nodes when the path itself is deleted.