### PR TITLE
Testing a level by pressing Ctrl+T no longer messes up the autotile config

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -315,6 +315,7 @@ Editor::get_level_directory() const
 void
 Editor::test_level(const boost::optional<std::pair<std::string, Vector>>& test_pos)
 {
+  m_overlay_widget->reset_action_press();
 
   Tile::draw_editor_images = false;
   Compositor::s_render_lighting = true;

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -488,6 +488,16 @@ EditorOverlayWidget::edit_path(Path* path, GameObject* new_marked_object)
 }
 
 void
+EditorOverlayWidget::reset_action_press()
+{
+  if (action_pressed)
+  {
+    g_config->editor_autotile_mode = !g_config->editor_autotile_mode;
+    action_pressed = false;
+  }
+}
+
+void
 EditorOverlayWidget::select_object()
 {
   delete_markers();
@@ -974,8 +984,11 @@ EditorOverlayWidget::on_key_up(const SDL_KeyboardEvent& key)
     g_config->editor_snap_to_grid = !g_config->editor_snap_to_grid;
   }
   if (sym == SDLK_LCTRL || sym == SDLK_RCTRL) {
-    g_config->editor_autotile_mode = !g_config->editor_autotile_mode;
-    action_pressed = false;
+    if (action_pressed)
+    {
+      g_config->editor_autotile_mode = !g_config->editor_autotile_mode;
+      action_pressed = false;
+    }
     // Hovered objects depend on which keys are pressed
     hover_object();
   }

--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -63,6 +63,7 @@ public:
   void on_level_change();
 
   void edit_path(Path* path, GameObject* new_marked_object = nullptr);
+  void reset_action_press();
 
 private:
   static bool action_pressed;


### PR DESCRIPTION
Fixes #1923