### PR TITLE
Rocks now apply friction when on the ground

### DIFF
--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -28,6 +28,8 @@ namespace {
 const std::string ROCK_SOUND = "sounds/brick.wav"; //TODO use own sound.
 }
 
+static const float GROUND_FRICTION = 0.1f; // Amount of friction to apply while on ground.
+
 Rock::Rock(const Vector& pos, const std::string& spritename) :
   MovingSprite(pos, spritename),
   ExposedObject<Rock, scripting::Rock>(this),
@@ -98,6 +100,11 @@ Rock::collision_solid(const CollisionHit& hit)
     SoundManager::current()->play(ROCK_SOUND, get_pos());
     physic.set_velocity_x(0);
     on_ground = true;
+  }
+
+  if (on_ground) {
+    // Full friction!
+    physic.set_velocity_x(physic.get_velocity_x() * (1.f - GROUND_FRICTION));
   }
 }
 


### PR DESCRIPTION
Prior to this PR, a rock falling on the ground while in a wind area that affects objects would instantly loose all its velocity upon hitting the ground, then it would slowly accelerate in the direction of the wind and would keep its velocity as long as it stayed in contact with the ground. With this PR, while on the ground, rocks will loose a certain amount of their velocity each frame.

Fixes #1899