### PR TITLE
Fixed inconsistent jump height when jumping from a climbable

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2137,6 +2137,7 @@ Player::stop_climbing(Climbable& /*climbable*/)
 
   if (m_controller->hold(Control::JUMP)) {
     m_on_ground_flag = true;
+    m_jump_early_apex = false;
     do_jump(m_player_status.bonus == BonusType::AIR_BONUS ? -540.0f : -480.0f);
   }
   else if (m_controller->hold(Control::UP)) {


### PR DESCRIPTION
Prior to this fix, it was possible that jumping while climbing would refuse to do a large jump, no matter how long the jump button was pressed. This is because the code that handles jumping while climbing is not the same as the usual one, and it forgot to handle the early apex.
Steps to reproduce the bug:
- In a level, navigate to a location with a tall climbable zone with walkable land below it
- Go right below the climbable zone
- Start jumping and hold, as to do a high jump
- Before reaching the apex, interrupt your jump (as if you changed your mind and wanted to do a small jump), and immediately after (not before, after), press and hold up to start climbing
- From there, attempt to do a high jump. Prior to this commit, it would fail and force the early apex on you; after, it will do a high jump, as expected.

Fixes #1905