### PR TITLE
Fixed GL shader compatibility (enables WebGL)

### DIFF
--- a/data/shader/shader100.frag
+++ b/data/shader/shader100.frag
@@ -24,7 +24,7 @@ void main(void)
   else
   {
     vec4 pixel = texture2D(displacement_texture, texcoord_var.st + (displacement_animate * game_time));
-    vec2 displacement = (pixel.rg - vec2(0.5f, 0.5f)) * 255.0f;
+    vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * 255.0;
     float alpha = pixel.a;
 
     vec2 uv = (fragcoord2uv * (gl_FragCoord.xyw + vec3(displacement.xy * alpha, 0))).xy;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66701383/146128246-08f99417-e934-4175-a7ee-49cdcb8b7275.png)

This enables the OpenGL renderer, which replaces the SDL renderer where possible.

New effects are now enabled, such as relfexion:
![image](https://user-images.githubusercontent.com/66701383/146133208-01886660-3ab9-4e38-86dc-af02db40f7e0.png)
... and refraction:
![image](https://user-images.githubusercontent.com/66701383/146133420-066e66d5-0f15-4c19-b5b0-386d057a8273.png)
