### PR TITLE
Fixed backtrack softlock on Icy Island

### DIFF
--- a/data/levels/world1/worldmap.nut
+++ b/data/levels/world1/worldmap.nut
@@ -39,11 +39,14 @@ if(! ("fitr_up" in state)){
   print("[DEBUG] 'Fork in the Road' road fork (up) initialized\n");
 }
 
-fitr_down.set_solid(state.fitr_down);
-fitr_up.set_solid(state.fitr_up);
-fitr_down_boulder.set_alpha(state.fitr_down ? 0 : 1);
-fitr_up_boulder.set_alpha(state.fitr_up ? 0 : 1);
+function reset_forks(fade_time = 0.35) {
+  fitr_down.set_solid(state.fitr_down);
+  fitr_up.set_solid(state.fitr_up);
+  fitr_down_boulder.fade(state.fitr_down ? 0 : 1, fade_time);
+  fitr_up_boulder.fade(state.fitr_up ? 0 : 1, fade_time);
+}
 
+reset_forks(0.0);
 
 
 // ============================================================================

--- a/data/levels/world1/worldmap.stwm
+++ b/data/levels/world1/worldmap.stwm
@@ -239,6 +239,18 @@ worldmap.settings.fade_to_ambient_light(1, 1, 1, 0.5);")
       (x 67)
       (y 83)
     )
+    (special-tile
+      (invisible-tile #t)
+      (script "state.fitr_up <- true; reset_forks();")
+      (x 56)
+      (y 66)
+    )
+    (special-tile
+      (invisible-tile #t)
+      (script "state.fitr_down <- true; reset_forks();")
+      (x 55)
+      (y 73)
+    )
     (sprite-change
       (stay-action "boat")
       (change-on-touch #t)


### PR DESCRIPTION
Backtracking Icy Island to A Fork in the Road now unlocks the boulders when passing from behind.

Fixes #1949