### PR TITLE
Update worldmap_cheat_menu.cpp bonuses.

### DIFF
--- a/src/supertux/menu/worldmap_cheat_menu.cpp
+++ b/src/supertux/menu/worldmap_cheat_menu.cpp
@@ -34,10 +34,10 @@ WorldmapCheatMenu::WorldmapCheatMenu()
   add_label(_("Cheats"));
   add_hl();
   add_entry(MNID_GROW, _("Bonus: Grow"));
-  add_entry(MNID_FIRE, _("Bonus: Fire"));
-  add_entry(MNID_ICE, _("Bonus: Ice"));
-  add_entry(MNID_AIR, _("Bonus: Air"));
-  add_entry(MNID_EARTH, _("Bonus: Earth"));
+  add_entry(MNID_FIRE, _("Bonus: Fire x 64"));
+  add_entry(MNID_ICE, _("Bonus: Ice x 64"));
+  add_entry(MNID_AIR, _("Bonus: Air x 64"));
+  add_entry(MNID_EARTH, _("Bonus: Earth x 64"));
   add_entry(MNID_SHRINK, _("Bonus: None"));
   add_hl();
   add_entry(MNID_GHOST, (tux.get_ghost_mode() ?


### PR DESCRIPTION
This updates the worldmap's cheat menu bonuses to be the same as in-level cheat menu.