### PR TITLE
Remove unordered path mode from the editor

### DIFF
--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -141,7 +141,7 @@ ObjectSettings::add_walk_mode(const std::string& text, WalkMode* value_ptr,
 {
   add_option(std::make_unique<StringSelectObjectOption>(
                text, reinterpret_cast<int*>(value_ptr),
-               std::vector<std::string>{_("One shot"), _("Ping-pong"), _("Circular"), _("Unordered")},
+               std::vector<std::string>{_("One shot"), _("Ping-pong"), _("Circular")},
                boost::none, key, flags));
 }
 


### PR DESCRIPTION
Unordered paths were removed a long time ago, but for whatever reason, the "Unordered" entry still stayed in the editor (it doesn't actually do anything other than throw a warning, set the path mode to oneshot and confuse the user). This PR removes the entry from path settings.