### PR TITLE
Make ping-pong the default path mode if the path mode is invalid

### DIFF
--- a/src/object/path.cpp
+++ b/src/object/path.cpp
@@ -36,8 +36,8 @@ string_to_walk_mode(const std::string& mode_string)
   else if (mode_string == "circular")
     return WalkMode::CIRCULAR;
   else {
-    log_warning << "Unknown path mode '" << mode_string << "'found. Using oneshot instead." << std::endl;
-    return WalkMode::ONE_SHOT;
+    log_warning << "Unknown path mode '" << mode_string << "'found. Using pingpong instead." << std::endl;
+    return WalkMode::PING_PONG;
   }
 }
 
@@ -51,8 +51,8 @@ walk_mode_to_string(WalkMode walk_mode)
   else if (walk_mode == WalkMode::CIRCULAR)
     return "circular";
   else {
-    log_warning << "Unknown path mode found. Using oneshot instead." << std::endl;
-    return "oneshot";
+    log_warning << "Unknown path mode found. Using pingpong instead." << std::endl;
+    return "pingpong";
   }
 }
 


### PR DESCRIPTION
As discussed on Discord, oneshot is not the best option for the default path mode, especially for levels where unordered was used before it was removed (because it makes the platform stop after a single "cycle"). This PR changes the default path mode to pingpong (which was decided to be the best option in the same Discord discussion), so the affected platforms don't stop moving after reaching the last node.