### PR TITLE
Fixed name problem for generated AppImages

### DIFF
--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -16,6 +16,12 @@ if [ "$OS_NAME" = "ubuntu-latest" ] && [ "$PACKAGE" = "ON" ]; then
     ../.ci_scripts/build_appimage.sh
     # extract built appimages for uploading
     mv ~/out/* .
+
+    # CI expects all artifacts to start with "SuperTux-", AppImage generates "SuperTux_v2-...."
+    for filename in SuperTux_2-*.AppImage; do 
+        [ -f "$filename" ] || continue
+        mv "$filename" "${filename//_2/}"
+    done
 fi
 
 mkdir upload


### PR DESCRIPTION
This PR ensures AppImage files are named properly and will get picked up for releases.