### PR TITLE
Attempt to fix changing sprites of certain objects in editor

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -865,6 +865,8 @@ BadGuy::get_settings()
 void
 BadGuy::after_editor_set()
 {
+  MovingSprite::after_editor_set();
+
   if (m_dir == Direction::AUTO)
   {
     if (m_sprite->has_action("editor-left")) {

--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -464,6 +464,8 @@ Dispenser::get_settings()
 void
 Dispenser::after_editor_set()
 {
+  BadGuy::after_editor_set();
+
   set_correct_action();
 }
 

--- a/src/badguy/flame.cpp
+++ b/src/badguy/flame.cpp
@@ -17,18 +17,18 @@
 #include "badguy/flame.hpp"
 
 #include "audio/sound_manager.hpp"
-#include "audio/sound_source.hpp"
 #include "editor/editor.hpp"
 #include "math/util.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
+#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
 
 static const std::string FLAME_SOUND = "sounds/flame.wav";
 
-Flame::Flame(const ReaderMapping& reader) :
-  BadGuy(reader, "images/creatures/flame/flame.sprite", LAYER_FLOATINGOBJECTS,
+Flame::Flame(const ReaderMapping& reader, const std::string& sprite) :
+  BadGuy(reader, sprite, LAYER_FLOATINGOBJECTS,
          "images/objects/lightmap_light/lightmap_light-small.sprite"),
   angle(0),
   radius(),
@@ -43,6 +43,9 @@ Flame::Flame(const ReaderMapping& reader) :
   }
   m_countMe = false;
   SoundManager::current()->preload(FLAME_SOUND);
+
+  reader.get("sprite", m_sprite_name, m_sprite_name.c_str());
+  m_sprite = SpriteManager::current()->create(m_sprite_name);
 
   set_colgroup_active(COLGROUP_TOUCHABLE);
 

--- a/src/badguy/flame.hpp
+++ b/src/badguy/flame.hpp
@@ -19,12 +19,13 @@
 
 #include "badguy/badguy.hpp"
 
-class SoundSource;
+#include "audio/sound_source.hpp"
 
 class Flame : public BadGuy
 {
 public:
-  Flame(const ReaderMapping& reader);
+  Flame(const ReaderMapping& reader,
+        const std::string& sprite = "images/creatures/flame/flame.sprite");
 
   virtual void activate() override;
   virtual void deactivate() override;

--- a/src/badguy/ghostflame.cpp
+++ b/src/badguy/ghostflame.cpp
@@ -43,6 +43,11 @@ ObjectSettings
 Ghostflame::get_settings()
 {
   ObjectSettings result = Flame::get_settings();
+
+  // FIXME: What is the interest of having a badguy that is only a retexture of another badguy?
+  // This at least removes the option from the editor to avoid confusing behavior.
+  result.remove("sprite");
+
   return result;
 }
 

--- a/src/badguy/ghostflame.cpp
+++ b/src/badguy/ghostflame.cpp
@@ -16,15 +16,10 @@
 
 #include "badguy/ghostflame.hpp"
 
-#include "audio/sound_source.hpp"
-#include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
-
 Ghostflame::Ghostflame(const ReaderMapping& reader) :
-  Flame(reader)
+  Flame(reader, "images/creatures/flame/ghostflame.sprite")
 {
   m_lightsprite->set_color(Color(0.21f, 0.00f, 0.21f));
-  m_sprite = SpriteManager::current()->create("images/creatures/flame/ghostflame.sprite");
 }
 
 bool
@@ -37,24 +32,6 @@ bool
 Ghostflame::is_freezable() const
 {
   return false;
-}
-
-ObjectSettings
-Ghostflame::get_settings()
-{
-  ObjectSettings result = Flame::get_settings();
-
-  // FIXME: What is the interest of having a badguy that is only a retexture of another badguy?
-  // This at least removes the option from the editor to avoid confusing behavior.
-  result.remove("sprite");
-
-  return result;
-}
-
-void
-Ghostflame::after_editor_set()
-{
-  m_sprite_name = "images/creatures/flame/ghostflame.sprite";
 }
 
 /* EOF */

--- a/src/badguy/ghostflame.hpp
+++ b/src/badguy/ghostflame.hpp
@@ -28,8 +28,6 @@ public:
   virtual bool is_freezable() const override;
   virtual std::string get_class() const override { return "ghostflame"; }
   virtual std::string get_display_name() const override { return _("Ghost Flame"); }
-  virtual ObjectSettings get_settings() override;
-  virtual void after_editor_set() override;
 
 private:
   Ghostflame(const Ghostflame&) = delete;

--- a/src/badguy/iceflame.cpp
+++ b/src/badguy/iceflame.cpp
@@ -23,14 +23,12 @@
 #include "math/util.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
 Iceflame::Iceflame(const ReaderMapping& reader) :
-  Flame(reader)
+  Flame(reader, "images/creatures/flame/iceflame.sprite")
 {
   m_lightsprite->set_color(Color(0.00f, 0.13f, 0.18f));
-  m_sprite = SpriteManager::current()->create("images/creatures/flame/iceflame.sprite");
 }
 
 void

--- a/src/badguy/kamikazesnowball.cpp
+++ b/src/badguy/kamikazesnowball.cpp
@@ -88,7 +88,8 @@ KamikazeSnowball::collision_player(Player& player, const CollisionHit& hit)
 LeafShot::LeafShot(const ReaderMapping& reader) :
   KamikazeSnowball(reader)
 {
-  m_sprite = SpriteManager::current()->create("images/creatures/leafshot/leafshot.sprite");
+  m_sprite_name = "images/creatures/leafshot/leafshot.sprite";
+  m_sprite = SpriteManager::current()->create(m_sprite_name);
 }
 
 void

--- a/src/badguy/walking_candle.cpp
+++ b/src/badguy/walking_candle.cpp
@@ -89,6 +89,8 @@ WalkingCandle::get_settings()
 void
 WalkingCandle::after_editor_set()
 {
+  WalkingBadguy::after_editor_set();
+
   m_sprite->set_color(lightcolor);
   m_lightsprite->set_color(lightcolor);
 }

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -99,6 +99,8 @@ WillOWisp::finish_construction()
 void
 WillOWisp::after_editor_set()
 {
+  BadGuy::after_editor_set();
+
   m_lightsprite->set_color(Color(m_color.red * 0.2f,
                                  m_color.green * 0.2f,
                                  m_color.blue * 0.2f));

--- a/src/editor/worldmap_objects.cpp
+++ b/src/editor/worldmap_objects.cpp
@@ -200,6 +200,7 @@ WorldmapSpawnPoint::get_settings()
   ObjectSettings result = WorldmapObject::get_settings();
 
   result.add_worldmap_direction(_("Direction"), &m_dir, worldmap::Direction::NONE, "auto-dir");
+  result.remove("sprite");
 
   result.reorder({"auto-dir", "name", "x", "y"});
 

--- a/src/editor/worldmap_objects.cpp
+++ b/src/editor/worldmap_objects.cpp
@@ -135,11 +135,6 @@ LevelDot::get_settings()
   return result;
 }
 
-void
-LevelDot::after_editor_set()
-{
-}
-
 Teleporter::Teleporter (const ReaderMapping& mapping) :
   WorldmapObject(mapping, "images/worldmap/common/teleporterdot.sprite"),
   m_worldmap(),

--- a/src/editor/worldmap_objects.hpp
+++ b/src/editor/worldmap_objects.hpp
@@ -55,7 +55,6 @@ public:
   virtual std::string get_class() const override { return "level"; }
   virtual std::string get_display_name() const override { return _("Level"); }
   virtual ObjectSettings get_settings() override;
-  virtual void after_editor_set() override;
 
 private:
   std::string m_level_filename;

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -61,6 +61,8 @@ Candle::Candle(const ReaderMapping& mapping) :
 void
 Candle::after_editor_set()
 {
+  MovingSprite::after_editor_set();
+
   candle_light_1->set_color(lightcolor);
   candle_light_2->set_color(lightcolor);
 

--- a/src/object/decal.cpp
+++ b/src/object/decal.cpp
@@ -55,13 +55,6 @@ Decal::get_settings()
   return result;
 }
 
-void
-Decal::after_editor_set()
-{
-  m_sprite = SpriteManager::current()->create(m_sprite_name);
-  m_sprite->set_action(m_default_action);
-}
-
 Decal::~Decal()
 {
 }

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -40,7 +40,6 @@ public:
   virtual std::string get_display_name() const override { return _("Decal"); }
 
   virtual ObjectSettings get_settings() override;
-  virtual void after_editor_set() override;
 
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -69,6 +69,8 @@ Lantern::get_settings()
 void
 Lantern::after_editor_set()
 {
+  Rock::after_editor_set();
+
   updateColor();
 }
 

--- a/src/object/magicblock.cpp
+++ b/src/object/magicblock.cpp
@@ -101,6 +101,8 @@ MagicBlock::get_settings()
 void
 MagicBlock::after_editor_set()
 {
+  MovingSprite::after_editor_set();
+
   if (m_color.red == 0 && m_color.green == 0 && m_color.blue == 0) { //is it black?
     m_black = true;
     m_trigger_red = MIN_INTENSITY;

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -166,6 +166,8 @@ MovingSprite::after_editor_set()
   std::string current_action = m_sprite->get_action();
   m_sprite = SpriteManager::current()->create(m_sprite_name);
   m_sprite->set_action(current_action);
+
+  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
 }
 
 void

--- a/src/object/rublight.cpp
+++ b/src/object/rublight.cpp
@@ -48,7 +48,7 @@ RubLight::RubLight(const ReaderMapping& mapping) :
 ObjectSettings
 RubLight::get_settings()
 {
-  ObjectSettings result = MovingObject::get_settings();
+  ObjectSettings result = MovingSprite::get_settings();
 
   // The object settings and their default values shown in the Editor
   result.add_color(_("Color"), &color, "color", Color(1.0f, 0.5f, 0.3f));

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -33,7 +33,8 @@ Door::Door(const ReaderMapping& mapping) :
   target_sector(),
   target_spawnpoint(),
   script(),
-  sprite(SpriteManager::current()->create("images/objects/door/door.sprite")),
+  sprite_name("images/objects/door/door.sprite"),
+  sprite(SpriteManager::current()->create(sprite_name)),
   stay_open_timer(),
   m_flip(NO_FLIP)
 {
@@ -41,6 +42,7 @@ Door::Door(const ReaderMapping& mapping) :
   mapping.get("y", m_col.m_bbox.get_top());
   mapping.get("sector", target_sector);
   mapping.get("spawnpoint", target_spawnpoint);
+  mapping.get("sprite", sprite_name);
 
   mapping.get("script", script);
 
@@ -56,7 +58,8 @@ Door::Door(int x, int y, const std::string& sector, const std::string& spawnpoin
   target_sector(sector),
   target_spawnpoint(spawnpoint),
   script(),
-  sprite(SpriteManager::current()->create("images/objects/door/door.sprite")),
+  sprite_name("images/objects/door/door.sprite"),
+  sprite(SpriteManager::current()->create(sprite_name)),
   stay_open_timer(),
   m_flip(NO_FLIP)
 {
@@ -73,6 +76,7 @@ Door::get_settings()
 {
   ObjectSettings result = TriggerBase::get_settings();
 
+  result.add_sprite(_("Sprite"), &sprite_name, "sprite", std::string("images/objects/door/door.sprite"));
   result.add_script(_("Script"), &script, "script");
   result.add_text(_("Sector"), &target_sector, "sector");
   result.add_text(_("Spawn point"), &target_spawnpoint, "spawnpoint");
@@ -80,6 +84,12 @@ Door::get_settings()
   result.reorder({"sector", "spawnpoint", "name", "x", "y"});
 
   return result;
+}
+
+void
+Door::after_editor_set() {
+  sprite = SpriteManager::current()->create(sprite_name);
+  m_col.m_bbox.set_size(sprite->get_current_hitbox_width(), sprite->get_current_hitbox_height());
 }
 
 Door::~Door()

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -35,6 +35,7 @@ public:
   virtual std::string get_display_name() const override { return _("Door"); }
 
   virtual ObjectSettings get_settings() override;
+  virtual void after_editor_set() override;
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
@@ -55,6 +56,7 @@ private:
   std::string target_sector; /**< target sector to teleport to */
   std::string target_spawnpoint; /**< target spawnpoint to teleport to */
   std::string script;
+  std::string sprite_name;
   SpritePtr sprite; /**< "door" sprite to render */
   Timer stay_open_timer; /**< time until door will close again */
   Flip m_flip;

--- a/src/trigger/switch.cpp
+++ b/src/trigger/switch.cpp
@@ -70,6 +70,7 @@ Switch::get_settings()
 void
 Switch::after_editor_set() {
   sprite = SpriteManager::current()->create(sprite_name);
+  m_col.m_bbox.set_size(sprite->get_current_hitbox_width(), sprite->get_current_hitbox_height());
 }
 
 void


### PR DESCRIPTION
Fixes #1961

Or rather, should.

Please test this PR to ensure that all objects are indeed fixed.

@HybridDog The rublight's settings builder pulls from grandparent MovingObject instead of parent MovingSprite; was it intended to be that way? It seems like an accident, but I don't want to risk introducing unintended side effects.
![image](https://user-images.githubusercontent.com/66701383/146496053-79115b4d-4a63-40a5-bcc5-1cfcd23ec205.png)


### Important notes
- **Spotlight** currently cannot have its sprite changed because it is composed of several layers of different sprites; it would need to be refactored before supporting sprite changing. I did not do it in this PR because I wanted to stick to simple bugfixes strictly, to have it merged in time for 0.6.3 if possible (and to avoid introducing new bugs, as much as possible).