### PR TITLE
Added option to offset the path handle on objects

### DIFF
--- a/src/badguy/ghoul.cpp
+++ b/src/badguy/ghoul.cpp
@@ -99,7 +99,7 @@ Ghoul::active_update(float dt_sec)
 {
   if (Editor::is_active() && get_path() && get_path()->is_valid()) {
     get_walker()->update(dt_sec);
-    set_pos(get_walker()->get_pos());
+    set_pos(get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle));
     return;
   }
 
@@ -145,7 +145,7 @@ Ghoul::active_update(float dt_sec)
       if (get_walker() == nullptr)
         return;
       get_walker()->update(dt_sec);
-      m_col.set_movement(get_walker()->get_pos() - get_pos());
+      m_col.set_movement(get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle) - get_pos());
       if (m_mystate == STATE_PATHMOVING_TRACK && glm::length(dist) <= m_track_range) {
         m_mystate = STATE_TRACKING;
       }

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -110,7 +110,7 @@ WillOWisp::active_update(float dt_sec)
 {
   if (Editor::is_active() && get_path() && get_path()->is_valid()) {
     get_walker()->update(dt_sec);
-    set_pos(get_walker()->get_pos());
+    set_pos(get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle));
     return;
   }
 
@@ -163,7 +163,7 @@ WillOWisp::active_update(float dt_sec)
       if (get_walker() == nullptr)
         return;
       get_walker()->update(dt_sec);
-      m_col.set_movement(get_walker()->get_pos() - get_pos());
+      m_col.set_movement(get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle) - get_pos());
       if (m_mystate == STATE_PATHMOVING_TRACK && glm::length(dist) <= m_track_range) {
         m_mystate = STATE_TRACKING;
       }
@@ -318,6 +318,7 @@ WillOWisp::get_settings()
   if (get_path())
   {
     result.add_bool(_("Adapt Speed"), &get_path()->m_adapt_speed, {}, {});
+    result.add_path_handle(_("Handle"), m_path_handle, "handle");
   }
 
   result.reorder({"sector", "spawnpoint", "flyspeed", "track-range", "hit-script", "vanish-range", "name", "path-ref", "region", "x", "y"});

--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -576,6 +576,43 @@ SExpObjectOption::add_to_menu(Menu& menu) const
 {
 }
 
+PathHandleOption::PathHandleOption(const std::string& text, PathWalker::Handle& handle,
+                                         const std::string& key, unsigned int flags) :
+  ObjectOption(text, key, flags),
+  m_target(handle)
+{
+}
+
+void
+PathHandleOption::save(Writer& writer) const
+{
+  writer.start_list(get_key());
+  writer.write("scale_x", m_target.m_scalar_pos.x);
+  writer.write("scale_y", m_target.m_scalar_pos.y);
+  writer.write("offset_x", m_target.m_pixel_offset.x);
+  writer.write("offset_y", m_target.m_pixel_offset.y);
+  writer.end_list(get_key());
+}
+
+std::string
+PathHandleOption::to_string() const
+{
+  return "("
+        + std::to_string(m_target.m_scalar_pos.x) + ", " 
+        + std::to_string(m_target.m_scalar_pos.y) + "), ("
+        + std::to_string(m_target.m_pixel_offset.x) + ", "
+        + std::to_string(m_target.m_pixel_offset.y) + ")";
+}
+
+void
+PathHandleOption::add_to_menu(Menu& menu) const
+{
+  menu.add_floatfield(get_text() + " (" + _("Scale X") + ")", &m_target.m_scalar_pos.x);
+  menu.add_floatfield(get_text() + " (" + _("Scale Y") + ")", &m_target.m_scalar_pos.y);
+  menu.add_floatfield(get_text() + " (" + _("Offset X") + ")", &m_target.m_pixel_offset.x);
+  menu.add_floatfield(get_text() + " (" + _("Offset Y") + ")", &m_target.m_pixel_offset.y);
+}
+
 RemoveObjectOption::RemoveObjectOption() :
   ObjectOption(_("Remove"), "", 0)
 {

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -23,8 +23,9 @@
 
 #include <sexp/value.hpp>
 
-#include "video/color.hpp"
 #include "gui/menu_action.hpp"
+#include "object/path_walker.hpp"
+#include "video/color.hpp"
 
 enum ObjectOptionFlag {
   /** Set if the value is a hidden implementation detail that
@@ -382,6 +383,24 @@ private:
 private:
   SExpObjectOption(const SExpObjectOption&) = delete;
   SExpObjectOption& operator=(const SExpObjectOption&) = delete;
+};
+
+class PathHandleOption : public ObjectOption
+{
+public:
+  PathHandleOption(const std::string& text, PathWalker::Handle& handle,
+                   const std::string& key, unsigned int flags);
+
+  virtual void save(Writer& write) const override;
+  virtual std::string to_string() const override;
+  virtual void add_to_menu(Menu& menu) const override;
+
+private:
+  PathWalker::Handle& m_target;
+
+private:
+  PathHandleOption(const PathHandleOption&) = delete;
+  PathHandleOption& operator=(const PathHandleOption&) = delete;
 };
 
 class RemoveObjectOption : public ObjectOption

--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -304,6 +304,16 @@ ObjectSettings::add_particle_editor()
   add_option(std::make_unique<ParticleEditorOption>());
 }
 
+
+void
+ObjectSettings::add_path_handle(const std::string& text,
+                                PathWalker::Handle& handle,
+                                const std::string& key,
+                                unsigned int flags)
+{
+  add_option(std::make_unique<PathHandleOption>(text, handle, key, flags));
+}
+
 void
 ObjectSettings::add_button(const std::string& text, const std::function<void()>& callback)
 {

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "editor/object_option.hpp"
+#include "object/path_walker.hpp"
 
 #include <algorithm>
 
@@ -139,6 +140,8 @@ public:
                 sexp::Value& value, unsigned int flags = 0);
   void add_test_from_here();
   void add_particle_editor();
+  void add_path_handle(const std::string& text, PathWalker::Handle& handle,
+                       const std::string& key = {}, unsigned int flags = 0);
 
   // VERY UNSTABLE - use with care   ~ Semphris (author of that option)
   void add_button(const std::string& text, const std::function<void()>& callback);

--- a/src/object/bicycle_platform.cpp
+++ b/src/object/bicycle_platform.cpp
@@ -154,7 +154,7 @@ BicyclePlatform::update(float dt_sec)
   if (m_walker)
   {
     m_walker->update(std::max(0.0f, dt_sec * m_angular_speed * 0.1f));
-    m_center = m_walker->get_pos();
+    m_center = m_walker->get_pos(Sizef(), {});
   }
   else
   {

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -226,6 +226,7 @@ Camera::get_settings()
   if (get_walker() && get_path()->is_valid()) {
     result.add_walk_mode(_("Path Mode"), &get_path()->m_mode, {}, {});
     result.add_bool(_("Adapt Speed"), &get_path()->m_adapt_speed, {}, {});
+    result.add_path_handle(_("Handle"), m_path_handle, "handle");
   }
 
   return result;
@@ -685,7 +686,8 @@ Camera::update_scroll_autoscroll(float dt_sec)
     return;
 
   get_walker()->update(dt_sec);
-  m_translation = get_walker()->get_pos();
+  // TODO: Get the camera size?
+  m_translation = get_walker()->get_pos(Sizef(), m_path_handle);
 
   keep_in_bounds(m_translation);
 }

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -67,7 +67,7 @@ Coin::finish_construction()
     if (m_starting_node >= static_cast<int>(get_path()->get_nodes().size()))
       m_starting_node = static_cast<int>(get_path()->get_nodes().size()) - 1;
 
-    set_pos(get_path()->get_nodes()[m_starting_node].position);
+    set_pos(m_path_handle.get_pos(m_col.m_bbox.get_size(), get_path()->get_nodes()[m_starting_node].position));
     get_walker()->jump_to_node(m_starting_node);
   }
 
@@ -82,12 +82,12 @@ Coin::update(float dt_sec)
     Vector v(0.0f, 0.0f);
     if (m_from_tilemap)
     {
-      v = m_offset + get_walker()->get_pos();
+      v = m_offset + get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle);
     }
     else
     {
       get_walker()->update(dt_sec);
-      v = get_walker()->get_pos();
+      v = get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle);
     }
 
     if (get_path()->is_valid()) {
@@ -101,9 +101,9 @@ Coin::editor_update()
 {
   if (get_walker()) {
     if (m_from_tilemap) {
-      set_pos(m_offset + get_walker()->get_pos());
+      set_pos(m_offset + get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle));
     } else {
-      set_pos(get_walker()->get_pos());
+      set_pos(get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle));
 
       if (!get_path()) return;
       if (!get_path()->is_valid()) return;
@@ -111,7 +111,7 @@ Coin::editor_update()
       if (m_starting_node >= static_cast<int>(get_path()->get_nodes().size()))
         m_starting_node = static_cast<int>(get_path()->get_nodes().size()) - 1;
 
-      set_pos(get_path()->get_nodes()[m_starting_node].position);
+      set_pos(m_path_handle.get_pos(m_col.m_bbox.get_size(), get_path()->get_nodes()[m_starting_node].position));
     }
   }
 }
@@ -291,6 +291,7 @@ Coin::get_settings()
     result.add_walk_mode(_("Path Mode"), &get_path()->m_mode, {}, {});
     result.add_bool(_("Adapt Speed"), &get_path()->m_adapt_speed, {}, {});
     result.add_int(_("Starting Node"), &m_starting_node, "starting-node", 0, 0U);
+    result.add_path_handle(_("Handle"), m_path_handle, "handle");
   }
 
   result.add_script(_("Collect script"), &m_collect_script, "collect-script");

--- a/src/object/path_object.cpp
+++ b/src/object/path_object.cpp
@@ -27,6 +27,7 @@
 #include "util/writer.hpp"
 
 PathObject::PathObject() :
+  m_path_handle(),
   m_path_uid(),
   m_walker()
 {
@@ -41,6 +42,15 @@ PathObject::init_path(const ReaderMapping& mapping, bool running_default)
 {
   bool running = running_default;
   mapping.get("running", running);
+
+  boost::optional<ReaderMapping> handle_map;
+  if (mapping.get("handle", handle_map))
+  {
+    handle_map->get("scale_x", m_path_handle.m_scalar_pos.x);
+    handle_map->get("scale_y", m_path_handle.m_scalar_pos.y);
+    handle_map->get("offset_x", m_path_handle.m_pixel_offset.x);
+    handle_map->get("offset_y", m_path_handle.m_pixel_offset.y);
+  }
 
   std::string path_ref;
   boost::optional<ReaderMapping> path_mapping;

--- a/src/object/path_object.hpp
+++ b/src/object/path_object.hpp
@@ -44,6 +44,9 @@ public:
   std::string get_path_ref() const;
   void editor_set_path_by_ref(const std::string& new_ref);
 
+protected:
+  PathWalker::Handle m_path_handle;
+
 private:
   UID m_path_uid;
   std::unique_ptr<PathWalker> m_walker;

--- a/src/object/path_walker.cpp
+++ b/src/object/path_walker.cpp
@@ -29,6 +29,12 @@
 #include "util/gettext.hpp"
 #include "math/easing.hpp"
 
+Vector
+PathWalker::Handle::get_pos(const Sizef& size, const Vector& pos) const
+{
+  return pos - Vector(size.width * m_scalar_pos.x, size.height * m_scalar_pos.y) - m_pixel_offset;
+}
+
 PathWalker::PathWalker(UID path_uid, bool running_) :
   m_path_uid(path_uid),
   m_running(running_),
@@ -100,7 +106,7 @@ PathWalker::update(float dt_sec)
 }
 
 Vector
-PathWalker::get_pos() const
+PathWalker::get_pos(const Sizef& object_size, const Handle& handle) const
 {
   Path* path = get_path();
   if (!path) return Vector(0, 0);
@@ -121,9 +127,11 @@ PathWalker::get_pos() const
          p3 = m_walking_speed > 0 ? next_node->bezier_before : next_node->bezier_after,
          p4 = next_node->position;
 
-  return path->m_adapt_speed ?
+  Vector position = path->m_adapt_speed ?
                           Bezier::get_point(p1, p2, p3, p4, progress) :
                           Bezier::get_point_by_length(p1, p2, p3, p4, progress);
+
+  return handle.get_pos(object_size, position);
 }
 
 void

--- a/src/object/path_walker.hpp
+++ b/src/object/path_walker.hpp
@@ -34,7 +34,7 @@ public:
   class Handle
   {
   public:
-    Handle() = default;
+    Handle() : m_scalar_pos(), m_pixel_offset() {}
     Vector get_pos(const Sizef& size, const Vector& pos) const;
 
   public:

--- a/src/object/path_walker.hpp
+++ b/src/object/path_walker.hpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <memory>
 
+#include "math/sizef.hpp"
 #include "object/path.hpp"
 #include "util/uid.hpp"
 
@@ -29,6 +30,19 @@ class ObjectOption;
 class PathWalker final
 {
 public:
+  /** Helper class that allows to displace a handle on an object */
+  class Handle
+  {
+  public:
+    Handle() = default;
+    Vector get_pos(const Sizef& size, const Vector& pos) const;
+
+  public:
+    Vector m_scalar_pos; /**< The scale of the object the handle should be displaced to ((0,0) = top left, (1,1) = bottom right) */
+    Vector m_pixel_offset; /**< The secondary displacement, in absolute size (pixels) */
+  };
+
+public:
   PathWalker(UID path_uid, bool running = true);
   ~PathWalker();
 
@@ -36,7 +50,7 @@ public:
   void update(float dt_sec);
 
   /** current position of path walker */
-  Vector get_pos() const;
+  Vector get_pos(const Sizef& object_size, const Handle& handle) const;
 
   /** advance until at given node, then stop */
   void goto_node(int node_no);

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -63,7 +63,7 @@ Platform::finish_construction()
 
   get_walker()->jump_to_node(m_starting_node);
 
-  m_col.m_bbox.set_pos(get_path()->get_nodes()[m_starting_node].position);
+  m_col.m_bbox.set_pos(m_path_handle.get_pos(m_col.m_bbox.get_size(), get_path()->get_nodes()[m_starting_node].position));
 }
 
 ObjectSettings
@@ -76,6 +76,7 @@ Platform::get_settings()
   result.add_bool(_("Adapt Speed"), &get_path()->m_adapt_speed, {}, {});
   result.add_bool(_("Running"), &get_walker()->m_running, "running", true, 0);
   result.add_int(_("Starting Node"), &m_starting_node, "starting-node", 0, 0U);
+  result.add_path_handle(_("Handle"), m_path_handle, "handle");
 
   result.reorder({"running", "name", "path-ref", "starting-node", "sprite", "x", "y"});
 
@@ -128,7 +129,7 @@ Platform::update(float dt_sec)
   }
 
   get_walker()->update(dt_sec);
-  Vector movement = get_walker()->get_pos() - get_pos();
+  Vector movement = get_walker()->get_pos(m_col.m_bbox.get_size(), m_path_handle) - get_pos();
   m_col.set_movement(movement);
   m_col.propagate_movement(movement);
   m_speed = movement / dt_sec;
@@ -143,7 +144,7 @@ Platform::editor_update()
   if (m_starting_node >= static_cast<int>(get_path()->get_nodes().size()))
     m_starting_node = static_cast<int>(get_path()->get_nodes().size()) - 1;
 
-  set_pos(get_path()->get_nodes()[m_starting_node].position);
+  set_pos(m_path_handle.get_pos(m_col.m_bbox.get_size(), get_path()->get_nodes()[m_starting_node].position));
 }
 
 void

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -197,7 +197,7 @@ TileMap::finish_construction()
     if (m_starting_node >= static_cast<int>(get_path()->get_nodes().size()))
       m_starting_node = static_cast<int>(get_path()->get_nodes().size()) - 1;
 
-    set_offset(get_path()->get_nodes()[m_starting_node].position);
+    set_offset(m_path_handle.get_pos(get_size() * 32, get_path()->get_nodes()[m_starting_node].position));
     get_walker()->jump_to_node(m_starting_node);
   }
 
@@ -253,6 +253,7 @@ TileMap::get_settings()
     result.add_walk_mode(_("Path Mode"), &get_path()->m_mode, {}, {});
     result.add_bool(_("Adapt Speed"), &get_path()->m_adapt_speed, {}, {});
     result.add_bool(_("Running"), &get_walker()->m_running, "running", false);
+    result.add_path_handle(_("Handle"), m_path_handle, "handle");
   }
 
   result.add_tiles(_("Tiles"), this, "tiles");
@@ -322,7 +323,7 @@ TileMap::update(float dt_sec)
   // if we have a path to follow, follow it
   if (get_walker()) {
     get_walker()->update(dt_sec);
-    Vector v = get_walker()->get_pos();
+    Vector v = get_walker()->get_pos(get_size() * 32, m_path_handle);
     if (get_path() && get_path()->is_valid()) {
       m_movement = v - get_offset();
       set_offset(v);
@@ -333,7 +334,7 @@ TileMap::update(float dt_sec)
         }
       }
     } else {
-      set_offset(Vector(0, 0));
+      set_offset(m_path_handle.get_pos(get_size() * 32, Vector(0, 0)));
     }
   }
 
@@ -345,8 +346,8 @@ TileMap::editor_update()
 {
   if (get_walker()) {
     if (get_path() && get_path()->is_valid()) {
-      m_movement = get_walker()->get_pos() - get_offset();
-      set_offset(get_walker()->get_pos());
+      m_movement = get_walker()->get_pos(get_size() * 32, m_path_handle) - get_offset();
+      set_offset(get_walker()->get_pos(get_size() * 32, m_path_handle));
 
       if (!get_path()) return;
       if (!get_path()->is_valid()) return;
@@ -355,9 +356,9 @@ TileMap::editor_update()
         m_starting_node = static_cast<int>(get_path()->get_nodes().size()) - 1;
 
       m_movement += get_path()->get_nodes()[m_starting_node].position - get_offset();
-      set_offset(get_path()->get_nodes()[m_starting_node].position);
+      set_offset(m_path_handle.get_pos(get_size() * 32, get_path()->get_nodes()[m_starting_node].position));
     } else {
-      set_offset(Vector(0, 0));
+      set_offset(m_path_handle.get_pos(get_size() * 32, Vector(0, 0)));
     }
   }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/66701383/146655597-886a4208-b601-457d-8228-03b116a0cca7.mp4

Allows displacing objects relatively to the path nodes, either proportionally to the object's size (Scale), in pixels (Offset), or both.