### PR TITLE
Editor::m_hovered_object now has a priority algorithm

### DIFF
--- a/src/editor/marker_object.cpp
+++ b/src/editor/marker_object.cpp
@@ -16,7 +16,6 @@
 
 #include "editor/marker_object.hpp"
 
-#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/color.hpp"
 #include "video/drawing_context.hpp"

--- a/src/editor/marker_object.hpp
+++ b/src/editor/marker_object.hpp
@@ -19,6 +19,8 @@
 
 #include "supertux/moving_object.hpp"
 
+#include "video/layer.hpp"
+
 class DrawingContext;
 
 class MarkerObject : public MovingObject
@@ -37,6 +39,8 @@ public:
   virtual bool hide_if_no_offset() const { return false; }
 
   virtual bool is_saveable() const override { return false; }
+
+  virtual int get_layer() const override { return LAYER_GUI - 20; }
 
 private:
   MarkerObject(const MarkerObject&) = delete;

--- a/src/object/ambient_sound.hpp
+++ b/src/object/ambient_sound.hpp
@@ -43,6 +43,7 @@
 #include "supertux/moving_object.hpp"
 #include "scripting/ambient_sound.hpp"
 #include "squirrel/exposed_object.hpp"
+#include "video/layer.hpp"
 
 class GameObject;
 class ReaderMapping;
@@ -76,6 +77,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
+
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
 
 protected:
   virtual void update(float dt_sec) override;

--- a/src/object/block.hpp
+++ b/src/object/block.hpp
@@ -43,6 +43,8 @@ public:
 
   virtual void on_flip(float height) override;
 
+  virtual int get_layer() const override { return LAYER_OBJECTS + 1; }
+
 protected:
   virtual void hit(Player& player) = 0;
 

--- a/src/object/bullet.hpp
+++ b/src/object/bullet.hpp
@@ -22,6 +22,7 @@
 #include "supertux/moving_object.hpp"
 #include "supertux/physic.hpp"
 #include "supertux/player_status.hpp"
+#include "video/layer.hpp"
 
 class Bullet final : public MovingObject
 {
@@ -33,6 +34,8 @@ public:
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual bool is_saveable() const override { return false; }
+
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
 
   /** Makes bullet bounce off an object (that got hit). To be called
       by the collision handler of that object. Note that the @c hit

--- a/src/object/flower.hpp
+++ b/src/object/flower.hpp
@@ -36,6 +36,8 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void on_flip(float height) override;
 
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
+
 private:
   BonusType type;
   SpritePtr sprite;

--- a/src/object/invisible_wall.hpp
+++ b/src/object/invisible_wall.hpp
@@ -19,6 +19,8 @@
 
 #include "supertux/moving_object.hpp"
 
+#include "video/layer.hpp"
+
 class ReaderMapping;
 
 /** A tile that starts falling down if tux stands to long on it */
@@ -37,6 +39,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
+
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
 
 private:
   virtual void update(float dt_sec) override;

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -53,6 +53,8 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
 
+  virtual int get_layer() const override { return m_layer; }
+
   std::string get_sprite_name() const;
   void change_sprite(const std::string& new_sprite_name);
   void spawn_explosion_sprites(int count, const std::string& sprite_path);

--- a/src/object/particle_zone.cpp
+++ b/src/object/particle_zone.cpp
@@ -125,7 +125,7 @@ ParticleZone::draw(DrawingContext& context)
                           m_particle_name, 
                           m_col.m_bbox.p1(),
                           FontAlignment::ALIGN_LEFT,
-                          LAYER_GUI + 2,
+                          LAYER_OBJECTS,
                           Color::WHITE);
   }
 }

--- a/src/object/particle_zone.hpp
+++ b/src/object/particle_zone.hpp
@@ -20,6 +20,7 @@
 #include "squirrel/exposed_object.hpp"
 // TODO: #include "scripting/wind.hpp"
 #include "supertux/moving_object.hpp"
+#include "video/layer.hpp"
 
 class ReaderMapping;
 
@@ -40,6 +41,8 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual ObjectSettings get_settings() override;
+
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
 
   Rectf get_rect() {return m_col.m_bbox;}
 

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -27,6 +27,7 @@
 #include "supertux/player_status.hpp"
 #include "supertux/sequence.hpp"
 #include "supertux/timer.hpp"
+#include "video/layer.hpp"
 #include "video/surface_ptr.hpp"
 
 class BadGuy;
@@ -74,6 +75,8 @@ public:
   virtual void on_flip(float height) override;
   virtual bool is_saveable() const override { return false; }
   virtual bool is_singleton() const override { return true; }
+
+  virtual int get_layer() const override { return LAYER_OBJECTS + 1; }
 
   void set_controller(const Controller* controller);
   /** Level solved. Don't kill Tux any more. */

--- a/src/object/spawnpoint.hpp
+++ b/src/object/spawnpoint.hpp
@@ -20,6 +20,7 @@
 #include "supertux/moving_object.hpp"
 
 #include "video/surface_ptr.hpp"
+#include "video/layer.hpp"
 
 class ReaderMapping;
 class DrawingContext;
@@ -45,6 +46,8 @@ public:
   virtual std::string get_class() const override { return "spawnpoint"; }
   virtual std::string get_display_name() const override { return _("Spawnpoint"); }
   virtual ObjectSettings get_settings() override;
+
+  virtual int get_layer() const override { return LAYER_FOREGROUND1; }
 
 private:
   SurfacePtr m_surface;

--- a/src/object/specialriser.hpp
+++ b/src/object/specialriser.hpp
@@ -38,6 +38,8 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 
+  virtual int get_layer() const override { return m_child ? m_child->get_layer() : -2147483648; }
+
 private:
   Vector m_start_pos; 
   float m_offset;

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -52,6 +52,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
+  virtual int get_layer() const override { return m_layer; }
+
   void set_angle(float angle_) { angle = angle_; }
   void set_speed(float speed_) { speed = speed_; }
   void set_color(Color color_) { color = color_; }

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -43,6 +43,8 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
 
+  virtual int get_layer() const override { return m_layer; }
+
   /** @name Scriptable Methods
       @{ */
   bool get_burning() const; /**< returns true if torch is lighted */

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -21,6 +21,8 @@
 #include "scripting/wind.hpp"
 #include "supertux/moving_object.hpp"
 
+#include "video/layer.hpp"
+
 class ReaderMapping;
 
 /** Defines an area that will gently push Players in one direction */
@@ -40,6 +42,8 @@ public:
   virtual std::string get_display_name() const override { return _("Wind");}
 
   virtual ObjectSettings get_settings() override;
+
+  virtual int get_layer() const override { return LAYER_OBJECTS; }
 
   /** @name Scriptable Methods
       @{ */

--- a/src/supertux/moving_object.hpp
+++ b/src/supertux/moving_object.hpp
@@ -99,6 +99,8 @@ public:
 
   virtual void on_flip(float height) override;
 
+  virtual int get_layer() const = 0;
+
 protected:
   void set_group(CollisionGroup group)
   {

--- a/src/trigger/trigger_base.hpp
+++ b/src/trigger/trigger_base.hpp
@@ -19,9 +19,11 @@
 
 #include <list>
 
-#include "sprite/sprite_ptr.hpp"
 #include "supertux/moving_object.hpp"
 #include "supertux/object_remove_listener.hpp"
+
+#include "sprite/sprite_ptr.hpp"
+#include "video/layer.hpp"
 
 class Player;
 
@@ -52,6 +54,8 @@ public:
 
   /** Called by GameObject destructor of an object in losetouch_listeners */
   virtual void object_removed(GameObject* object) override;
+
+  virtual int get_layer() const override { return LAYER_TILES + 1; }
 
 private:
   SpritePtr m_sprite;


### PR DESCRIPTION
Fixes #1973

With this PR, when clicking on a stack of objects in the editor, priority will be given to objects according to the following criteria:
1. Markers will be given priority (Path nodes)
2. Objects with higher layer
3. Objects most recently loaded in the editor (at same layer, most recently loaded will be rendered on top)