### PR TITLE
Fixed some translation issues in the code

### DIFF
--- a/src/supertux/menu/game_menu.cpp
+++ b/src/supertux/menu/game_menu.cpp
@@ -28,8 +28,6 @@
 #include "object/player.hpp"
 #include "util/gettext.hpp"
 
-static const std::string CONFIRMATION_PROMPT = _("Are you sure?");
-
 GameMenu::GameMenu() :
   reset_callback ( [] {
     MenuManager::instance().clear_menu_stack();
@@ -76,7 +74,7 @@ GameMenu::menu_action(MenuItem& item)
     case MNID_RESETLEVEL:
       if (g_config->confirmation_dialog)
       {
-        Dialog::show_confirmation(CONFIRMATION_PROMPT, reset_callback);
+        Dialog::show_confirmation(_("Are you sure?"), reset_callback);
       }
       else
       {
@@ -87,7 +85,7 @@ GameMenu::menu_action(MenuItem& item)
     case MNID_RESETLEVELCHECKPOINT:
       if (g_config->confirmation_dialog)
       {
-        Dialog::show_confirmation(CONFIRMATION_PROMPT,
+        Dialog::show_confirmation(_("Are you sure?"),
                                   reset_checkpoint_callback);
       }
       else
@@ -99,7 +97,7 @@ GameMenu::menu_action(MenuItem& item)
     case MNID_ABORTLEVEL:
       if (g_config->confirmation_dialog)
       {
-        Dialog::show_confirmation(CONFIRMATION_PROMPT, abort_callback);
+        Dialog::show_confirmation(_("Are you sure?"), abort_callback);
       }
       else
       {

--- a/src/supertux/menu/integrations_menu.cpp
+++ b/src/supertux/menu/integrations_menu.cpp
@@ -49,12 +49,12 @@ IntegrationsMenu::IntegrationsMenu()
   add_label(_("Integrations"));
   add_hl();
   add_toggle(MNID_LEVELNAMES_EDITOR, _("Do not share level names when editing"), &g_config->hide_editor_levelnames)
-    .set_help("Enable this if you want to work on secret levels and don't want the names to be spoiled");
+    .set_help(_("Enable this if you want to work on secret levels and don't want the names to be spoiled"));
 #ifdef ENABLE_DISCORD
   add_toggle(MNID_ENABLE_DISCORD, _("Enable Discord integration"), &g_config->enable_discord)
-    .set_help("Sends information to your Discord application about what you're doing in the game.");
+    .set_help(_("Sends information to your Discord application about what you're doing in the game."));
 #else
-  add_inactive( _("Discord (disabled; not compiled)"));
+  add_inactive(_("Discord (disabled; not compiled)"));
 #endif
   add_hl();
   add_back(_("Back"));


### PR DESCRIPTION
This fixes two translation issues:
- A translation was initialized in a static variable, which was evaluated before main() got a chance to run and load in the translation configuration.
- Two strings weren't set to be translated. **Note: having those translated would require breaking the string freeze.** Given that the strings were already there and it was just a mistake on my end, we may choose to make it an exception; or not, if it would be too much hassle. I wish not to pressure anybody at any option; I have no preference regarding this issue.

Fixes #1982 