### PR TITLE
Use g_dictionary_manager for locale

### DIFF
--- a/src/supertux/resources.cpp
+++ b/src/supertux/resources.cpp
@@ -66,7 +66,7 @@ Resources::load()
   {
     console_font.reset(new TTFFont("fonts/SuperTux-Medium.ttf", 12, 1.25f, 0, 1));
 
-    auto font = get_font_for_locale(g_config->locale);
+    auto font = get_font_for_locale(g_dictionary_manager->get_language());
     if(font != current_font)
     {
       current_font = font;
@@ -88,16 +88,19 @@ Resources::load()
 }
 
 std::string
-Resources::get_font_for_locale(const std::string& locale)
+Resources::get_font_for_locale(const tinygettext::Language& locale)
 {
-  if(locale == "ne")
+  auto lang = locale.get_language();
+
+  if(lang == "ne")
     return "fonts/Dekko-Regular.ttf";
-  if(locale == "cmn" || locale == "ja" || locale == "zh_CN" || locale == "zh_TW")
+  if(lang == "cmn" || lang == "ja" || lang == "zh_CN" || lang == "zh_TW")
     return "fonts/NotoSansCJKjp-Medium.otf";
-  if(locale == "he")
+  if(lang == "he")
     return "fonts/VarelaRound-Regular.ttf";
-  if(locale == "ko")
+  if(lang == "ko")
     return "fonts/NanumBarunGothic.ttf";
+
   return "fonts/SuperTux-Medium.ttf";
 }
 

--- a/src/supertux/resources.hpp
+++ b/src/supertux/resources.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 
+#include "util/gettext.hpp"
 #include "video/font_ptr.hpp"
 #include "video/surface_ptr.hpp"
 
@@ -63,7 +64,7 @@ public:
 
 private:
   static std::string current_font;
-  static std::string get_font_for_locale(const std::string& locale);
+  static std::string get_font_for_locale(const tinygettext::Language& locale);
 
 public:
   Resources();


### PR DESCRIPTION
g_config->locale is set only if the user manually expressed a preference; automatic detection wouldn't pick the right font in that case.

Closes #1990
Fixes #1965 