### PR TITLE
Replace boost::format with fmt::format

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       # Revision of https://github.com/pelya/commandergenius.git - SDL2 repo is a submodule
       # We check out a specific stable revision, so the build won't break if I modify my SDL repo
-      SDL_ANDROID_REV: 532acc9192
+      SDL_ANDROID_REV: d3d938c27d66fe568637a7fe0dc0112cf6e76217
       # It takes 35 minutes per one architecture to build SuperTux, of which 20 minutes are for building Boost and ICU libraries
       # Enable additional architectures when we have these libraries inside the cache, or create a separate Android script for each architecture
       ARCH_LIST: armeabi-v7a arm64-v8a x86 x86_64

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           sed -i "s/MultiABI=.*/MultiABI='${ARCH_LIST}'/g" project/jni/application/supertux/AndroidAppSettings.cfg
 
+          # FIXME: Tweaks to get fmt compiled, should probably be upstreamed
+          sed -i "s#\(AppSubdirsBuild='[^']*\)'#\1 supertux/external/fmt/src supertux/external/fmt/include'#" project/jni/application/supertux/AndroidAppSettings.cfg
+          mv -v ../external/fmt/src/format.cc ../external/fmt/src/format.cpp
+
       - name: Copy precompiled libraries from cache
         uses: actions/cache@v2
         id: cache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,10 +67,6 @@ jobs:
         run: |
           sed -i "s/MultiABI=.*/MultiABI='${ARCH_LIST}'/g" project/jni/application/supertux/AndroidAppSettings.cfg
 
-          # FIXME: Tweaks to get fmt compiled, should probably be upstreamed
-          sed -i "s#\(AppSubdirsBuild='[^']*\)'#\1 supertux/external/fmt/src supertux/external/fmt/include'#" project/jni/application/supertux/AndroidAppSettings.cfg
-          mv -v ../external/fmt/src/format.cc ../external/fmt/src/format.cpp
-
       - name: Copy precompiled libraries from cache
         uses: actions/cache@v2
         id: cache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       # Revision of https://github.com/pelya/commandergenius.git - SDL2 repo is a submodule
       # We check out a specific stable revision, so the build won't break if I modify my SDL repo
-      SDL_ANDROID_REV: d3d938c27d66fe568637a7fe0dc0112cf6e76217
+      SDL_ANDROID_REV: 798fd0f5e167aa6ecce33623dbf88ebc6cd647ea
       # It takes 35 minutes per one architecture to build SuperTux, of which 20 minutes are for building Boost and ICU libraries
       # Enable additional architectures when we have these libraries inside the cache, or create a separate Android script for each architecture
       ARCH_LIST: armeabi-v7a arm64-v8a x86 x86_64
@@ -66,9 +66,6 @@ jobs:
         working-directory: build.android
         run: |
           sed -i "s/MultiABI=.*/MultiABI='${ARCH_LIST}'/g" project/jni/application/supertux/AndroidAppSettings.cfg
-
-          # FIXME: Tweaks to get fmt compiled, should probably be upstreamed
-          rm -v ../external/fmt/src/fmt.cc ../external/fmt/src/os.cc
 
       - name: Copy precompiled libraries from cache
         uses: actions/cache@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,6 +67,9 @@ jobs:
         run: |
           sed -i "s/MultiABI=.*/MultiABI='${ARCH_LIST}'/g" project/jni/application/supertux/AndroidAppSettings.cfg
 
+          # FIXME: Tweaks to get fmt compiled, should probably be upstreamed
+          rm -v ../external/fmt/src/fmt.cc ../external/fmt/src/os.cc
+
       - name: Copy precompiled libraries from cache
         uses: actions/cache@v2
         id: cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "discord-sdk"]
 	path = external/discord-sdk
 	url = https://github.com/discord/discord-rpc
+[submodule "external/fmt"]
+	path = external/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,13 @@ endif()
 
 find_package(PNG REQUIRED)
 
+option(USE_SYSTEM_FMT "Use preinstalled fmt, must be 8.0.0 or newer" OFF)
+if(USE_SYSTEM_FMT)
+  find_package(fmt 8.0.0 REQUIRED)
+else()
+  add_subdirectory(external/fmt EXCLUDE_FROM_ALL)
+endif()
+
 if(WIN32)
   if(VCPKG_BUILD)
     find_package(SDL2 CONFIG REQUIRED)
@@ -1007,6 +1014,12 @@ else()
 endif()
 target_link_libraries(supertux2_lib PUBLIC ${OGGVORBIS_LIBRARIES})
 target_link_libraries(supertux2_lib PUBLIC ${Boost_LIBRARIES})
+
+# Mark fmt includes as SYSTEM to avoid warnings
+get_target_property(FMT_INCLUDE_DIRS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(supertux2_lib SYSTEM PUBLIC ${FMT_INCLUDE_DIRS})
+target_link_libraries(supertux2_lib PUBLIC fmt::fmt)
+
 if(USE_SYSTEM_PHYSFS)
   target_link_libraries(supertux2_lib PUBLIC ${PHYSFS_LIBRARY})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,10 +206,15 @@ endif()
 
 find_package(PNG REQUIRED)
 
-option(USE_SYSTEM_FMT "Use preinstalled fmt, must be 8.0.0 or newer" OFF)
+option(USE_SYSTEM_FMT "Use preinstalled fmt if available, must be 8.0.0 or newer" ON)
 if(USE_SYSTEM_FMT)
-  find_package(fmt 8.0.0 REQUIRED)
+  find_package(fmt 8.0.0)
+endif()
+
+if(TARGET fmt::fmt)
+  message(STATUS "Found fmt")
 else()
+  message(STATUS "Could NOT find fmt, using external/fmt fallback")
   add_subdirectory(external/fmt EXCLUDE_FROM_ALL)
 endif()
 

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@ EOF
 
               pkgs.boost
               pkgs.curl
+              pkgs.fmt
               pkgs.fribidi
               pkgs.harfbuzz
               pkgs.freetype

--- a/src/gui/menu_badguy_select.cpp
+++ b/src/gui/menu_badguy_select.cpp
@@ -16,12 +16,12 @@
 
 #include "gui/menu_badguy_select.hpp"
 
+#include <fmt/format.h>
+
 #include "gui/dialog.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
 #include "gui/menu_list.hpp"
-
-#include "boost/format.hpp"
 
 std::vector<std::string> BadguySelectMenu::all_badguys;
 
@@ -95,7 +95,7 @@ BadguySelectMenu::refresh()
 
   add_label(_("List of enemies"));
   add_hl();
-  add_entry(-2, str(boost::format(_("Select enemy (%s)")) % all_badguys[selected]));
+  add_entry(-2, fmt::format(_("Select enemy ({})"), all_badguys[selected]));
   add_entry(-3, _("Add"));
   add_hl();
 

--- a/src/supertux/command_line_arguments.cpp
+++ b/src/supertux/command_line_arguments.cpp
@@ -16,7 +16,7 @@
 
 #include "supertux/command_line_arguments.hpp"
 
-#include <boost/format.hpp>
+#include <fmt/format.h>
 #include <config.h>
 #include <physfs.h>
 
@@ -91,7 +91,7 @@ void
 CommandLineArguments::print_help(const char* arg0) const
 {
   std::cerr
-    << boost::format(_("Usage: %s [OPTIONS] [LEVELFILE]")) % arg0 << "\n" << "\n"
+    << fmt::format(fmt::runtime(_("Usage: {} [OPTIONS] [LEVELFILE]")), arg0) << "\n" << "\n"
     << _("General Options:") << "\n"
     << _("  -h, --help                   Show this help message and quit") << "\n"
     << _("  -v, --version                Show SuperTux version and quit") << "\n"
@@ -406,7 +406,7 @@ CommandLineArguments::parse_args(int argc, char** argv)
     }
     else
     {
-      throw std::runtime_error((boost::format("Unknown option '%1%''. Use --help to see a list of options") % arg).str());
+      throw std::runtime_error(fmt::format("Unknown option '{}''. Use --help to see a list of options", arg));
     }
   }
 

--- a/src/supertux/levelintro.cpp
+++ b/src/supertux/levelintro.cpp
@@ -30,7 +30,7 @@
 #include "util/gettext.hpp"
 #include "video/compositor.hpp"
 
-#include <boost/format.hpp>
+#include <fmt/format.h>
 
 LevelIntro::LevelIntro(const Level& level, const Statistics* best_level_statistics, const PlayerStatus& player_status) :
   m_level(level),
@@ -133,7 +133,7 @@ LevelIntro::draw(Compositor& compositor)
 
   std::string author = m_level.get_author();
   if ((!author.empty()) && (author != "SuperTux Team")) {
-    std::string author_text = str(boost::format(_("contributed by %s")) % author);
+    std::string author_text = fmt::format(fmt::runtime(_("contributed by {}")), author);
     context.color().draw_center_text(Resources::small_font, author_text, Vector(0, static_cast<float>(py)), LAYER_FOREGROUND1, s_author_color);
     py += static_cast<int>(Resources::small_font->get_height());
   }

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -195,7 +195,7 @@ AddonMenu::rebuild_menu()
           if ((m_langpacks_only && addon.get_type() == Addon::LANGUAGEPACK) || !m_langpacks_only)
           {
             std::string text = generate_menu_item_text(addon);
-            add_entry(MAKE_REPOSITORY_MENU_ID(idx), fmt::format(fmt::runtime( _("Install {})), text));
+            add_entry(MAKE_REPOSITORY_MENU_ID(idx), fmt::format(fmt::runtime( _("Install {}")), text));
             have_new_stuff = true;
           }
         }

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -16,7 +16,7 @@
 
 #include "supertux/menu/addon_menu.hpp"
 
-#include <boost/format.hpp>
+#include <fmt/format.h>
 
 #include "addon/addon.hpp"
 #include "addon/addon_manager.hpp"
@@ -68,14 +68,13 @@ std::string generate_menu_item_text(const Addon& addon)
 
   if (!addon.get_author().empty())
   {
-    text = str(boost::format(_("%s \"%s\" by \"%s\""))
-               % type % addon.get_title() % addon.get_author());
+    text = fmt::format(fmt::runtime(_("{} \"{}\" by \"{}\"")),
+                       type, addon.get_title(), addon.get_author());
   }
   else
   {
     // Only addon type and name, no need for translation.
-    text = str(boost::format("%s \"%s\"")
-               % type % addon.get_title());
+    text = fmt::format("{} \"{}\"", type, addon.get_title());
   }
 
   return text;
@@ -182,7 +181,7 @@ AddonMenu::rebuild_menu()
             if ((m_langpacks_only && addon.get_type() == Addon::LANGUAGEPACK) || !m_langpacks_only)
             {
               std::string text = generate_menu_item_text(addon);
-              add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s *NEW*") ) % text));
+              add_entry(MAKE_REPOSITORY_MENU_ID(idx), fmt::format(fmt::runtime(_("Install {} *NEW*")), text));
               have_new_stuff = true;
             }
           }
@@ -196,7 +195,7 @@ AddonMenu::rebuild_menu()
           if ((m_langpacks_only && addon.get_type() == Addon::LANGUAGEPACK) || !m_langpacks_only)
           {
             std::string text = generate_menu_item_text(addon);
-            add_entry(MAKE_REPOSITORY_MENU_ID(idx), str(boost::format( _("Install %s") ) % text));
+            add_entry(MAKE_REPOSITORY_MENU_ID(idx), fmt::format(fmt::runtime( _("Install {})), text));
             have_new_stuff = true;
           }
         }
@@ -308,7 +307,7 @@ AddonMenu::install_addon(const Addon& addon)
   auto addon_id = addon.get_id();
   TransferStatusPtr status = m_addon_manager.request_install_addon(addon_id);
   auto dialog = std::make_unique<DownloadDialog>(status, false, m_auto_install_langpack);
-  dialog->set_title(str(boost::format( _("Downloading %s") ) % generate_menu_item_text(addon)));
+  dialog->set_title(fmt::format(fmt::runtime(_("Downloading {}")), generate_menu_item_text(addon)));
   status->then([this, addon_id](bool success)
   {
     if (success)

--- a/src/supertux/menu/editor_delete_level_menu.cpp
+++ b/src/supertux/menu/editor_delete_level_menu.cpp
@@ -15,8 +15,10 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "supertux/menu/editor_delete_level_menu.hpp"
+
 #include <physfs.h>
-#include <boost/format.hpp>
+#include <fmt/format.h>
+
 #include "supertux/levelset.hpp"
 #include "supertux/level_parser.hpp"
 #include "supertux/level.hpp"
@@ -57,7 +59,7 @@ EditorDeleteLevelMenu::menu_action(MenuItem& item)
       Dialog::show_message(_("You cannot delete level that you are editing!"));
     else
     {
-      Dialog::show_confirmation(str(boost::format(_("You are about to delete level \"%s\". Are you sure?")) % m_level_names[id]), [this, id]()
+      Dialog::show_confirmation(fmt::format(_("You are about to delete level \"{}\". Are you sure?"), m_level_names[id]), [this, id]()
       {
         PHYSFS_delete(m_level_full_paths[id].c_str());
         delete_item(id + 2);

--- a/src/supertux/menu/editor_delete_levelset_menu.cpp
+++ b/src/supertux/menu/editor_delete_levelset_menu.cpp
@@ -15,7 +15,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "supertux/menu/editor_delete_levelset_menu.hpp"
-#include <boost/format.hpp>
+
+#include <fmt/format.h>
+
 #include "editor/editor.hpp"
 #include "gui/dialog.hpp"
 #include "physfs/util.hpp"
@@ -78,7 +80,7 @@ EditorDeleteLevelsetMenu::menu_action(MenuItem& item)
       Dialog::show_message(_("You cannot delete the world that you are editing"));
     else
     {
-      Dialog::show_confirmation(str(boost::format(_("You are about to delete world \"%s\". Are you sure?")) % m_world_names[id]), [this, id, &contrib_worlds]()
+      Dialog::show_confirmation(fmt::format(_("You are about to delete world \"{}\". Are you sure?"), m_world_names[id]), [this, id, &contrib_worlds]()
       {
         physfsutil::remove_with_content(contrib_worlds[id]);
         m_editor_levelset_select_menu->reload_menu();

--- a/src/supertux/menu/editor_levelset_select_menu.cpp
+++ b/src/supertux/menu/editor_levelset_select_menu.cpp
@@ -18,7 +18,7 @@
 
 #include <physfs.h>
 #include <sstream>
-#include <boost/format.hpp>
+#include <fmt/format.h>
 
 #include "editor/editor.hpp"
 #include "gui/menu_item.hpp"
@@ -98,9 +98,9 @@ EditorLevelsetSelectMenu::initialize()
                           new Levelset(level_world, /* recursively = */ true));
       int level_count = levelset->get_num_levels();
       std::ostringstream level_title;
-      level_title << title << " (" <<
-        boost::format(__("%d level", "%d levels", level_count)) % level_count <<
-        ")";
+      level_title << title << " ("
+                  << fmt::format(fmt::runtime(__("{} level", "{} levels", level_count)), level_count)
+                  << ")";
       add_entry(i++, level_title.str());
       m_contrib_worlds.push_back(level_world);
     }

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -16,7 +16,7 @@
 
 #include "supertux/menu/profile_menu.hpp"
 
-#include <boost/format.hpp>
+#include <fmt/format.h>
 #include <sstream>
 
 #include "gui/dialog.hpp"
@@ -38,11 +38,11 @@ ProfileMenu::ProfileMenu()
     std::ostringstream out;
     if (i == g_config->profile)
     {
-      out << str(boost::format(_("[Profile %s]")) %i);
+      out << fmt::format(fmt::runtime(_("[Profile {}]")), i);
     }
     else
     {
-      out << str(boost::format(_("Profile %s")) %i);
+      out << fmt::format(fmt::runtime(_("Profile {}")), i);
     }
     add_entry(i, out.str());
   }

--- a/src/util/gettext.hpp
+++ b/src/util/gettext.hpp
@@ -24,23 +24,24 @@ extern std::unique_ptr<tinygettext::DictionaryManager> g_dictionary_manager;
 
 /*
  * If you need to do a nontrivial substitution of values into a pattern, use
- * boost::format rather than an ad-hoc concatenation.  That way, translators can
+ * fmt::format rather than an ad-hoc concatenation.  That way, translators can
  * translate the format string as a whole (and even rearrange the values if
  * necessary with "%1$s"-style codes) instead of multiple pieces.  Patterns like
- * "Label: %s" with only one string piece are a borderline case where
- * boost::format is not really necessary.
+ * "Label: {}" with only one string piece are a borderline case where
+ * fmt::format is not really necessary.
  *
  * http://www.mihai-nita.net/article.php?artID=20060430a
+ * https://fmt.dev/latest/syntax.html
  *
  * Bad:
  *     std::string greeting = _("Hello ") + name + _("!");
  *     std::cout << _("Hello ") << name << _("!");
  * Good:
- *     #include <boost/format.hpp>
- *     std::string greeting = str(boost::format(_("Hello %s!")) % name);
- *     std::cout << boost::format(_("Hello %s!")) % name;
+ *     #include <fmt/format.h>
+ *     std::string greeting = fmt::format(fmt::runtime(_("Hello {}!")), name);
+ *     std::cout << fmt::format(fmt::runtime(_("Hello {}!")), name);
  *
- * If you need singular and plural forms use __ instead of _ and boost::format
+ * If you need singular and plural forms use __ instead of _ and fmt::format
  * if necessary.
  *
  * https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
@@ -48,9 +49,10 @@ extern std::unique_ptr<tinygettext::DictionaryManager> g_dictionary_manager;
  * Bad:
  *     std::cout << _("You collected ") << num << _(" coins");
  * Good:
- *     #include <boost/format.hpp>
- *     std::cout << boost::format(__("You collected %d coin",
- *                                   "You collected %d coins", num)) % num;
+ *     #include <fmt/format.h>
+ *     std::cout << fmt::format(fmt::runtime(__("You collected {} coin",
+ *                                              "You collected {} coins", num)),
+ *                              num));
  */
 
 static inline std::string _(const std::string& message)


### PR DESCRIPTION
This is in preparation for C++20. fmt shares mostly the same API as std::format(), which isn't in a usable state yet.

Using the system provided fmt ended up being too brittle, as 6, 7 and 8 all have incompatibilities with each other when it comes to having runtime generated format strings (e.g. as returned from gettext()), thus external/fmt/ submodule was added.

Since the syntax of format strings changes, merging this has to wait until after 0.6.3.

fmt should be usable with C++14.