### PR TITLE
Fixed single-width topping grass autotile config for forest

### DIFF
--- a/data/images/autotiles.satc
+++ b/data/images/autotiles.satc
@@ -1247,7 +1247,7 @@
     (autotile
       (id 1038)
       (solid #f)
-      (mask "***00010")
+      (mask "*****010")
     )
     (autotile
       (id 1044)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/66701383/147197035-a8de6209-d107-4b4e-b27d-9383fc0542dc.png)

After:
![image](https://user-images.githubusercontent.com/66701383/147196964-d34ebada-d854-4bf7-b2db-230a6c720d8b.png)

(Notice the grass on top of the 1x1 on the left)