### PR TITLE
Fix warnings appearing during normal play

### DIFF
--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -349,11 +349,11 @@ Background::draw_image(DrawingContext& context, const Vector& pos_)
             Vector p(pos_.x + static_cast<float>(x) * img_w - img_w_2,
                      pos_.y + static_cast<float>(y) * img_h - img_h_2);
 
-            if (m_image_top.get() != nullptr && (y < 0))
+            if (m_image_top && (y < 0))
             {
               canvas.draw_surface(m_image_top, p, 0.f, m_color, m_blend, m_layer);
             }
-            else if (m_image_bottom.get() != nullptr && (y > 0))
+            else if (m_image_bottom && (y > 0))
             {
               canvas.draw_surface(m_image_bottom, p, 0.f, m_color, m_blend, m_layer);
             }
@@ -373,7 +373,7 @@ Background::draw(DrawingContext& context)
   if (Editor::is_active() && !g_config->editor_render_background)
     return;
 
-  if (m_image.get() == nullptr)
+  if (!m_image)
     return;
 
   Sizef level_size(d_gameobject_manager->get_width(),
@@ -456,6 +456,9 @@ std::unordered_map<std::string, std::string> fallback_paths = {
 SurfacePtr
 Background::load_background(const std::string& image_path)
 {
+  if (image_path.empty())
+    return nullptr;
+
   if (PHYSFS_exists(image_path.c_str()))
     // No need to search fallback paths
     return Surface::from_file(image_path);

--- a/src/supertux/autotile.cpp
+++ b/src/supertux/autotile.cpp
@@ -300,7 +300,9 @@ AutotileSet::get_mask_from_tile(uint32_t tile) const
 void
 AutotileSet::validate() const
 {
-  for (int mask = 0; mask <= (m_corner ? 15 : 255); mask++)
+  // Corner autotiles are always empty if all 4 corners are, but regular
+  // autotiles should have a valid tile ID that can be surrounded by emptiness
+  for (int mask = (m_corner ? 1 : 0); mask <= (m_corner ? 15 : 255); mask++)
   {
     uint8_t num_mask = static_cast<uint8_t>(mask);
     bool tile_exists = false;

--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -92,9 +92,9 @@ Level::save(const std::string& filepath, bool retry)
 
     Writer writer(filepath);
     save(writer);
-    log_warning << "Level saved as " << filepath << "." 
-                << (boost::algorithm::ends_with(filepath, "~") ? " [Autosave]" : "")
-                << std::endl;
+    log_info << "Level saved as " << filepath << "." 
+             << (boost::algorithm::ends_with(filepath, "~") ? " [Autosave]" : "")
+             << std::endl;
   } catch(std::exception& e) {
     if (retry) {
       std::stringstream msg;

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -55,7 +55,7 @@ TitleScreen::TitleScreen(Savegame& savegame) :
 void
 TitleScreen::make_tux_jump()
 {
-  static bool jumpWasReleased = true;
+  static bool jumpWasReleased = false;
   Sector& sector  = m_titlesession->get_current_sector();
   Player& tux = sector.get_player();
 
@@ -92,7 +92,9 @@ TitleScreen::setup()
   if (Sector::current() != &sector) {
     auto& music = sector.get_singleton_by_type<MusicObject>();
     music.play_music(LEVEL_MUSIC);
-    sector.activate(sector.get_player().get_pos());
+    // sector.activate(Vector) expects position calculated for big tux, but tux
+    // might be small on the title screen
+    sector.activate(sector.get_player().get_pos() - Vector(0.f, sector.get_player().is_big() ? 0.f : 32.f));
   }
 
   MenuManager::instance().set_menu(MenuStorage::MAIN_MENU);


### PR DESCRIPTION
Warnings are messages that developers should pay attention to and fix as soon as possible; I've fixed those we have so far.
- Backgrounds with empty images now refuse to load images when the corresponding filename is empty.
- Corner autotile configurations no longer warn for missing tile ID for mask "0000", because such tiles should always be empty.
- Tux spawning in solid matter was due to how the code that was handling Tux was expecting him to be big, but wasn't always big; the code has been adapted for this.
- Warnings appearing when a level is saved got replaced by an info message, as saving a level successfully isn't an error.

**If any other warning appear on your screens under normal circumstances, please tell me so I can fix them.**