### PR TITLE
Tiles from other tilesets can now be imported from the strf files

### DIFF
--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -39,7 +39,7 @@ TileSetParser::TileSetParser(TileSet& tileset, const std::string& filename) :
 }
 
 void
-TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
+TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset, bool imported)
 {
   if (offset && static_cast<int32_t>(start) + offset < 1) {
     start = -offset + 1;
@@ -70,8 +70,8 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     else if (iter.get_key() == "tilegroup")
     {
       /* tilegroups are only interesting for the editor */
-      /* ignore tilegroups for imported tilesets unless there's no limit and no offset*/
-      if (start || end || offset) continue;
+      /* ignore tilegroups for imported tilesets */
+      if (imported) continue;
       ReaderMapping reader = iter.as_mapping();
       Tilegroup tilegroup;
       reader.get("name", tilegroup.name);
@@ -85,8 +85,8 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     }
     else if (iter.get_key() == "autotileset")
     {
-      /* ignore autotiles for imported tilesets unless there's no limit and no offset */
-      if (start || end || offset) continue;
+      /* ignore autotiles for imported tilesets */
+      if (imported) continue;
       ReaderMapping reader = iter.as_mapping();
       std::string autotile_filename;
       if (!reader.get("source", autotile_filename))
@@ -111,7 +111,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
       reader.get("end", import_end);
       reader.get("offset", import_offset);
       TileSetParser import_parser(m_tileset, import_filename);
-      import_parser.parse(import_start, import_end, import_offset);
+      import_parser.parse(import_start, import_end, import_offset, true);
     }
     else
     {
@@ -119,7 +119,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     }
   }
   /* only create the unassigned tilegroup from the parent strf */
-  if (g_config->developer_mode && !end)
+  if (g_config->developer_mode && !imported)
   {
     m_tileset.add_unassigned_tilegroup();
   }

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -43,7 +43,11 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
 {
   if (offset && (int)start + offset < 1) {
     start = -offset + 1;
-    log_warning << "The defined offset would assign non-positive ids to tiles, tiles below " << -offset + 1 << " will be ignored" << std::endl;
+    log_warning << "The defined offset would assign non-positive ids to tiles, tiles below " << -offset + 1 << " will be ignored." << std::endl;
+  }
+  if (end < start) {
+    log_warning << "The defined range has a negative size, no tiles will be imported." << std::endl;
+    return;
   }
 
   m_tiles_path = FileSystem::dirname(m_filename);

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -291,7 +291,7 @@ TileSetParser::parse_tiles(const ReaderMapping& reader, uint32_t min, uint32_t m
 
       for (size_t i = 0; i < ids.size(); ++i)
       {
-        if(!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
+        if (!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
         ids[i] += offset;
 
         const int x = static_cast<int>(32 * (i % width));
@@ -324,7 +324,7 @@ TileSetParser::parse_tiles(const ReaderMapping& reader, uint32_t min, uint32_t m
     {
       for (size_t i = 0; i < ids.size(); ++i)
       {
-        if(!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
+        if (!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
         ids[i] += offset;
 
         int x = static_cast<int>(32 * (i % width));

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -95,14 +95,14 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     {
       ReaderMapping reader = iter.as_mapping();
       std::string import_filename;
-      uint32_t start = 0, end = 0;
-      int32_t offset = 0;
+      uint32_t import_start = 0, import_end = 0;
+      int32_t import_offset = 0;
       reader.get("file", import_filename);
-      reader.get("start", start);
-      reader.get("end", end);
-      reader.get("offset", offset);
+      reader.get("start", import_start);
+      reader.get("end", import_end);
+      reader.get("offset", import_offset);
       TileSetParser import_parser(m_tileset, import_filename);
-      import_parser.parse(start, end, offset);
+      import_parser.parse(import_start, import_end, import_offset);
     }
     else
     {

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -41,7 +41,7 @@ TileSetParser::TileSetParser(TileSet& tileset, const std::string& filename) :
 void
 TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
 {
-  if (offset && (int)start + offset < 1) {
+  if (offset && static_cast<int32_t>(start) + offset < 1) {
     start = -offset + 1;
     log_warning << "The defined offset would assign non-positive ids to tiles, tiles below " << -offset + 1 << " will be ignored." << std::endl;
   }

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -61,7 +61,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     else if (iter.get_key() == "tilegroup")
     {
       /* tilegroups are only interesting for the editor */
-      /* ignore tilegroups for imported tilesets */
+      /* ignore tilegroups for imported tilesets unless there's no limit and no offset*/
       if (end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       Tilegroup tilegroup;
@@ -76,7 +76,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     }
     else if (iter.get_key() == "autotileset")
     {
-       /* ignore autotiles for imported tilesets */
+      /* ignore autotiles for imported tilesets unless there's no limit and no offset */
       if (end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       std::string autotile_filename;

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -41,6 +41,11 @@ TileSetParser::TileSetParser(TileSet& tileset, const std::string& filename) :
 void
 TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
 {
+  if (offset && (int)start + offset < 1) {
+    start = -offset + 1;
+    log_warning << "The defined offset would assign non-positive ids to tiles, tiles below " << -offset + 1 << " will be ignored" << std::endl;
+  }
+
   m_tiles_path = FileSystem::dirname(m_filename);
 
   auto doc = ReaderDocument::from_file(m_filename);

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -62,7 +62,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     {
       /* tilegroups are only interesting for the editor */
       /* ignore tilegroups for imported tilesets */
-      if (end) continue;
+      if (end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       Tilegroup tilegroup;
       reader.get("name", tilegroup.name);
@@ -77,7 +77,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     else if (iter.get_key() == "autotileset")
     {
        /* ignore autotiles for imported tilesets */
-      if (end) continue;
+      if (end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       std::string autotile_filename;
       if (!reader.get("source", autotile_filename))
@@ -324,7 +324,7 @@ TileSetParser::parse_tiles(const ReaderMapping& reader, uint32_t min, uint32_t m
     {
       for (size_t i = 0; i < ids.size(); ++i)
       {
-        if (!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
+        if(!ids[i] || (max && (ids[i] < min || ids[i] > max))) continue;
         ids[i] += offset;
 
         int x = static_cast<int>(32 * (i % width));

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -62,7 +62,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     {
       /* tilegroups are only interesting for the editor */
       /* ignore tilegroups for imported tilesets unless there's no limit and no offset*/
-      if (end || offset) continue;
+      if (start || end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       Tilegroup tilegroup;
       reader.get("name", tilegroup.name);
@@ -77,7 +77,7 @@ TileSetParser::parse(uint32_t start, uint32_t end, int32_t offset)
     else if (iter.get_key() == "autotileset")
     {
       /* ignore autotiles for imported tilesets unless there's no limit and no offset */
-      if (end || offset) continue;
+      if (start || end || offset) continue;
       ReaderMapping reader = iter.as_mapping();
       std::string autotile_filename;
       if (!reader.get("source", autotile_filename))

--- a/src/supertux/tile_set_parser.hpp
+++ b/src/supertux/tile_set_parser.hpp
@@ -38,7 +38,7 @@ private:
 public:
   TileSetParser(TileSet& tileset, const std::string& filename);
 
-  void parse(uint32_t start = 0, uint32_t end = 0, int32_t offset = 0);
+  void parse(uint32_t start = 0, uint32_t end = 0, int32_t offset = 0, bool imported = false);
 
 private:
   void parse_tile(const ReaderMapping& reader, uint32_t min, uint32_t max, int32_t offset);

--- a/src/supertux/tile_set_parser.hpp
+++ b/src/supertux/tile_set_parser.hpp
@@ -38,11 +38,11 @@ private:
 public:
   TileSetParser(TileSet& tileset, const std::string& filename);
 
-  void parse();
+  void parse(uint32_t start = 0, uint32_t end = 0, int32_t offset = 0);
 
 private:
-  void parse_tile(const ReaderMapping& reader);
-  void parse_tiles(const ReaderMapping& reader);
+  void parse_tile(const ReaderMapping& reader, uint32_t min, uint32_t max, int32_t offset);
+  void parse_tiles(const ReaderMapping& reader, uint32_t min, uint32_t max, int32_t offset);
   std::vector<SurfacePtr> parse_imagespecs(const ReaderMapping& cur,
                                            const boost::optional<Rect>& region = boost::none) const;
 

--- a/src/supertux/tile_set_parser.hpp
+++ b/src/supertux/tile_set_parser.hpp
@@ -38,11 +38,11 @@ private:
 public:
   TileSetParser(TileSet& tileset, const std::string& filename);
 
-  void parse(uint32_t start = 0, uint32_t end = 0, int32_t offset = 0, bool imported = false);
+  void parse(int32_t start = 0, int32_t end = 0, int32_t offset = 0, bool imported = false);
 
 private:
-  void parse_tile(const ReaderMapping& reader, uint32_t min, uint32_t max, int32_t offset);
-  void parse_tiles(const ReaderMapping& reader, uint32_t min, uint32_t max, int32_t offset);
+  void parse_tile(const ReaderMapping& reader, int32_t min, int32_t max, int32_t offset);
+  void parse_tiles(const ReaderMapping& reader, int32_t min, int32_t max, int32_t offset);
   std::vector<SurfacePtr> parse_imagespecs(const ReaderMapping& cur,
                                            const boost::optional<Rect>& region = boost::none) const;
 


### PR DESCRIPTION
Fixes #325

Implements tile importing in the way Grumbel suggested in the issue. This only imports tiles, since tilegroups would be full of non-imported tiles (therefore holes) and the user may want to define their own tilegroups anyway. Similarly, autotiles may depend on non-imported tiles and are therefore not imported.

The most obvious use case for this feature is that if a player wants to add custom tiles into their add-on while keeping the vanilla tiles.strf tiles, they previously had to either redefine tiles.strf (which broke a lot of stuff when the add-on was used), or to create a new strf file and copy all the contents of tiles.strf manually, which could break if tiles.strf got updated (for example, an image was changed and the existing ids were remapped to the new image). Now the player could just create a new strf, import tiles they need, add their own and mix & match them all into their own tilegroups.

Note: a full tileset (with no limit and no offset) can be imported using (start 0)(end 0)(offset 0) - this will also import autotiles and tilegroups, however, if new tiles are then added into the imported tileset, the user may redefine their ids by having used them before

Please test! I haven't had time to throw every possible problem at it (like offsets making the tiles go below 1, and other edge cases). I will test this myself later today, but the more people test it, the better!\
_edit:_ I have now tested (and fixed) a few things (see the commits)

example: if I want to make an add-on, and I need to add two tiles, I can now just make a strf that looks like this:

```
(supertux-tiles
  (import-tileset
    (file "images/tiles.strf")
    (start 0)   ;; I want the tiles from the beginning
    (end 4326)  ;; This is the last tile in the file at this time. I will use the higher ids myself
    (offset 0)  ;; I want the tiles to retain their original ids without an offset
  )
  (tiles
    (image "images/tiles/my_tiles.png")
    (ids 4327 4328)
    (attributes ...)
    (data ...)
  )
  (import-tileset
    (file "images/tiles.strf")
    (start 4327) ;; New tiles were added since made this tileset, I want to import them (the new ones only)
    (end 4400)   ;; This is the current last id
    (offset 2)   ;; Since I have already used two ids for my tiles, I need to offset these tiles by 2
  )
)
```

I would need to define tilegroups and autotiles manually, but it's still less tedious than defining everything manually and I would be able to mix my new tiles into them.
If you have any better ideas for tilegroup and/or autotile importing, please tell me. Thank you.