### PR TITLE
Improvements to flipping

### DIFF
--- a/data/images/objects/door/door.sprite
+++ b/data/images/objects/door/door.sprite
@@ -1,14 +1,14 @@
 (supertux-sprite
   (action
     (name "closed")
-    (hitbox 8 4 44 80)
+    (hitbox 8 4 44 92)
     (images 
       "door-0.png"
     )
   )
   (action
     (name "opening")
-    (hitbox 8 4 44 80)
+    (hitbox 8 4 44 92)
     (images 
       "door-0.png"
       "door-1.png"
@@ -22,14 +22,14 @@
   )
   (action
     (name "open")
-    (hitbox 8 4 44 80)
+    (hitbox 8 4 44 92)
     (images 
       "door-7.png"
     )
   )
   (action
     (name "closing")
-    (hitbox 8 4 44 80)
+    (hitbox 8 4 44 92)
     (images 
       "door-7.png"
       "door-6.png"
@@ -43,7 +43,7 @@
   )
   (action
     (name "locked")
-    (hitbox 8 4 44 80)
+    (hitbox 8 4 44 92)
     (images 
       "door-locked.png"
     )

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -352,4 +352,11 @@ WillOWisp::move_to(const Vector& pos)
   set_pos(pos);
 }
 
+void
+WillOWisp::on_flip(float height)
+{
+  BadGuy::on_flip(height);
+  PathObject::on_flip(height);
+}
+
 /* EOF */

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -356,7 +356,7 @@ void
 WillOWisp::on_flip(float height)
 {
   BadGuy::on_flip(height);
-  PathObject::on_flip(height);
+  PathObject::on_flip();
 }
 
 /* EOF */

--- a/src/badguy/willowisp.hpp
+++ b/src/badguy/willowisp.hpp
@@ -58,6 +58,8 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void move_to(const Vector& pos) override;
 
+  virtual void on_flip(float height) override;
+
   virtual void expose(HSQUIRRELVM vm, SQInteger table_idx) override
   {
     ExposedObject<WillOWisp, scripting::WillOWisp>::expose(vm, table_idx);

--- a/src/object/background.cpp
+++ b/src/object/background.cpp
@@ -17,9 +17,11 @@
 #include "object/background.hpp"
 
 #include <physfs.h>
+#include <utility>
 
 #include "editor/editor.hpp"
 #include "supertux/d_scope.hpp"
+#include "supertux/flip_level_transformer.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "util/reader.hpp"
@@ -48,7 +50,8 @@ Background::Background() :
   m_target(DrawingTarget::COLORMAP),
   m_timer_color(),
   m_src_color(),
-  m_dst_color()
+  m_dst_color(),
+  m_flip(NO_FLIP)
 {
 }
 
@@ -73,7 +76,8 @@ Background::Background(const ReaderMapping& reader) :
   m_target(DrawingTarget::COLORMAP),
   m_timer_color(),
   m_src_color(),
-  m_dst_color()
+  m_dst_color(),
+  m_flip(NO_FLIP)
 {
   reader.get("fill", m_fill);
 
@@ -293,6 +297,7 @@ Background::draw_image(DrawingContext& context, const Vector& pos_)
   const int end_y   = static_cast<int>(ceilf((cliprect.get_bottom() - (pos_.y + img_h/2.0f)) / img_h)) + 1;
 
   Canvas& canvas = context.get_canvas(m_target);
+  context.set_flip(context.get_flip() ^ m_flip);
 
   if (m_fill)
   {
@@ -365,6 +370,7 @@ Background::draw_image(DrawingContext& context, const Vector& pos_)
         break;
     }
   }
+  context.set_flip(context.get_flip() ^ m_flip);
 }
 
 void
@@ -478,6 +484,16 @@ Background::load_background(const std::string& image_path)
 
   new_path = default_dir + it->second;
   return Surface::from_file(new_path);
+}
+
+void
+Background::on_flip(float height)
+{
+  GameObject::on_flip(height);
+  std::swap(m_image_bottom, m_image_top);
+  m_pos.y = height - m_pos.y - m_image->get_height();
+  m_scroll_offset.y = -m_scroll_offset.y;
+  FlipLevelTransformer::transform_flip(m_flip);
 }
 
 

--- a/src/object/background.hpp
+++ b/src/object/background.hpp
@@ -24,6 +24,7 @@
 #include "supertux/timer.hpp"
 #include "video/blend.hpp"
 #include "video/drawing_context.hpp"
+#include "video/flip.hpp"
 #include "video/surface_ptr.hpp"
 
 class ReaderMapping;
@@ -48,6 +49,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
+
+  virtual void on_flip(float height) override;
 
   void set_image(const std::string& name);
   void set_images(const std::string& name_top, const std::string& name_middle, const std::string& name_bottom);
@@ -104,6 +107,8 @@ private:
 
   Timer m_timer_color;
   Color m_src_color, m_dst_color;
+
+  Flip m_flip;
 
 private:
   Background(const Background&) = delete;

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -317,6 +317,13 @@ Coin::after_editor_set()
   }
 }
 
+void
+Coin::on_flip(float height)
+{
+  MovingSprite::on_flip(height);
+  PathObject::on_flip();
+}
+
 ObjectSettings
 HeavyCoin::get_settings()
 {

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -48,6 +48,8 @@ public:
 
   virtual void move_to(const Vector& pos) override;
 
+  virtual void on_flip(float height) override;
+
   void collect();
 
 private:

--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -14,6 +14,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <utility>
+
 #include "object/gradient.hpp"
 
 #include "editor/editor.hpp"
@@ -267,6 +269,14 @@ Gradient::is_saveable() const
 {
   return !(Level::current() &&
            Level::current()->is_worldmap());
+}
+
+void
+Gradient::on_flip(float height)
+{
+  GameObject::on_flip(height);
+  if (m_gradient_direction == VERTICAL || m_gradient_direction == VERTICAL_SECTOR)
+    std::swap(m_gradient_top, m_gradient_bottom);
 }
 
 /* EOF */

--- a/src/object/gradient.hpp
+++ b/src/object/gradient.hpp
@@ -47,6 +47,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
+  virtual void on_flip(float height) override;
+
   void set_gradient(Color top, Color bottom);
   void fade_gradient(Color top, Color bottom, float time);
   Color get_gradient_top() const { return m_gradient_top; }

--- a/src/object/path_object.cpp
+++ b/src/object/path_object.cpp
@@ -115,4 +115,11 @@ PathObject::editor_set_path_by_ref(const std::string& new_ref)
   m_path_uid = path_obj->get_uid();
 }
 
+void
+PathObject::on_flip()
+{
+  m_path_handle.m_scalar_pos.y = 1 - m_path_handle.m_scalar_pos.y;
+  m_path_handle.m_pixel_offset.y = -m_path_handle.m_pixel_offset.y;
+}
+
 /* EOF */

--- a/src/object/path_object.hpp
+++ b/src/object/path_object.hpp
@@ -45,6 +45,8 @@ public:
   void editor_set_path_by_ref(const std::string& new_ref);
 
 protected:
+  void on_flip();
+
   PathWalker::Handle m_path_handle;
 
 private:

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -181,4 +181,11 @@ Platform::move_to(const Vector& pos)
   set_pos(pos);
 }
 
+void
+Platform::on_flip(float height)
+{
+  MovingSprite::on_flip(height);
+  PathObject::on_flip();
+}
+
 /* EOF */

--- a/src/object/platform.hpp
+++ b/src/object/platform.hpp
@@ -46,6 +46,8 @@ public:
 
   virtual void editor_update() override;
 
+  virtual void on_flip(float height) override;
+
   const Vector& get_speed() const { return m_speed; }
 
   /** @name Scriptable Methods

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -414,6 +414,7 @@ TileMap::on_flip(float height)
   Vector offset = get_offset();
   offset.y = height - offset.y - get_bbox().get_height();
   set_offset(offset);
+  PathObject::on_flip();
 }
 
 void


### PR DESCRIPTION
Fixes #2002

This PR fixes the offsets `PathObject`s had on levelflip (which could in some cases extend a sector's height just by flipping, because a flipped path-following tilemap got offset beyond the sector's boundaries). It also changes the hitbox of `door.sprite` (just slightly) to prevent doors from having a gap underneath them on levelflip.

It also makes backgrounds and gradients flip.