### PR TITLE
Followup to custom menus

### DIFF
--- a/src/editor/button_widget.cpp
+++ b/src/editor/button_widget.cpp
@@ -43,12 +43,10 @@ ButtonWidget::draw(DrawingContext& context)
   }
 
   if (m_grab) {
-    context.color().draw_filled_rect(m_rect, Color(g_config->editorcolor.red + 0.4f, g_config->editorcolor.green + 0.4f,
-      g_config->editorcolor.blue + 0.4f, g_config->editorcolor.alpha + 0.1f), 4.0f,
+    context.color().draw_filled_rect(m_rect, Color(g_config->editorgrabcolor), 4.0f,
                                      LAYER_GUI-5);
   } else if (m_hover) {
-    context.color().draw_filled_rect(m_rect, Color(g_config->editorcolor.red + 0.4f, g_config->editorcolor.green + 0.4f,
-      g_config->editorcolor.blue + 0.4f, g_config->editorcolor.alpha - 0.2f), 4.0f,
+    context.color().draw_filled_rect(m_rect, Color(g_config->editorhovercolor), 4.0f,
                                      LAYER_GUI-5);
   }
 }

--- a/src/editor/button_widget.cpp
+++ b/src/editor/button_widget.cpp
@@ -43,10 +43,10 @@ ButtonWidget::draw(DrawingContext& context)
   }
 
   if (m_grab) {
-    context.color().draw_filled_rect(m_rect, Color(g_config->editorgrabcolor), 4.0f,
+    context.color().draw_filled_rect(m_rect, g_config->editorgrabcolor, 4.0f,
                                      LAYER_GUI-5);
   } else if (m_hover) {
-    context.color().draw_filled_rect(m_rect, Color(g_config->editorhovercolor), 4.0f,
+    context.color().draw_filled_rect(m_rect, g_config->editorhovercolor, 4.0f,
                                      LAYER_GUI-5);
   }
 }

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -98,8 +98,7 @@ EditorLayersWidget::draw(DrawingContext& context)
 
   if (draw_rect)
   {
-    context.color().draw_filled_rect(target_rect, Color(g_config->editorcolor.red + 0.4f, g_config->editorcolor.green + 0.4f,
-      g_config->editorcolor.blue + 0.4f, g_config->editorcolor.alpha - 0.2f), 0.0f,
+    context.color().draw_filled_rect(target_rect, Color(g_config->editorhovercolor), 0.0f,
                                        LAYER_GUI-5);
   }
 

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -65,7 +65,7 @@ EditorLayersWidget::draw(DrawingContext& context)
 
   context.color().draw_filled_rect(Rectf(Vector(0, static_cast<float>(m_Ypos)),
                                          Vector(static_cast<float>(m_Width), static_cast<float>(SCREEN_HEIGHT))),
-                                     Color(g_config->editorcolor),
+                                     g_config->editorcolor,
                                      0.0f,
                                      LAYER_GUI-10);
 
@@ -98,7 +98,7 @@ EditorLayersWidget::draw(DrawingContext& context)
 
   if (draw_rect)
   {
-    context.color().draw_filled_rect(target_rect, Color(g_config->editorhovercolor), 0.0f,
+    context.color().draw_filled_rect(target_rect, g_config->editorhovercolor, 0.0f,
                                        LAYER_GUI-5);
   }
 

--- a/src/editor/tip.cpp
+++ b/src/editor/tip.cpp
@@ -68,7 +68,7 @@ Tip::draw(DrawingContext& context, const Vector& pos)
   auto position = pos;
   position.y += 35;
   context.color().draw_text(Resources::normal_font, m_header, position,
-                              ALIGN_LEFT, LAYER_GUI-11, Color(g_config->labeltextcolor));
+                              ALIGN_LEFT, LAYER_GUI-11, g_config->labeltextcolor);
 
   for (const auto& str : m_strings) {
     position.y += 22;

--- a/src/editor/tip.cpp
+++ b/src/editor/tip.cpp
@@ -18,6 +18,8 @@
 
 #include "supertux/colorscheme.hpp"
 #include "supertux/game_object.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "util/log.hpp"
 #include "video/drawing_context.hpp"
@@ -66,7 +68,7 @@ Tip::draw(DrawingContext& context, const Vector& pos)
   auto position = pos;
   position.y += 35;
   context.color().draw_text(Resources::normal_font, m_header, position,
-                              ALIGN_LEFT, LAYER_GUI-11, ColorScheme::Menu::label_color);
+                              ALIGN_LEFT, LAYER_GUI-11, Color(g_config->labeltextcolor));
 
   for (const auto& str : m_strings) {
     position.y += 22;

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -73,7 +73,7 @@ EditorToolboxWidget::draw(DrawingContext& context)
   context.color().draw_filled_rect(Rectf(Vector(static_cast<float>(m_Xpos), 0),
                                          Vector(static_cast<float>(context.get_width()),
                                                 static_cast<float>(context.get_height()))),
-                                     Color(g_config->editorcolor),
+                                     g_config->editorcolor,
                                      0.0f, LAYER_GUI-10);
   if (m_dragging) {
     context.color().draw_filled_rect(selection_draw_rect(), Color(0.2f, 0.4f, 1.0f, 0.6f),
@@ -83,7 +83,7 @@ EditorToolboxWidget::draw(DrawingContext& context)
   if (m_hovered_item != HoveredItem::NONE)
   {
     context.color().draw_filled_rect(get_item_rect(m_hovered_item),
-                                       Color(g_config->editorhovercolor),
+                                       g_config->editorhovercolor,
                                        0.0f, LAYER_GUI - 5);
   }
 

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -83,8 +83,7 @@ EditorToolboxWidget::draw(DrawingContext& context)
   if (m_hovered_item != HoveredItem::NONE)
   {
     context.color().draw_filled_rect(get_item_rect(m_hovered_item),
-                                       Color(g_config->editorcolor.red + 0.4f, g_config->editorcolor.green + 0.4f,
-                                         g_config->editorcolor.blue + 0.4f, g_config->editorcolor.alpha - 0.2f),
+                                       Color(g_config->editorhovercolor),
                                        0.0f, LAYER_GUI - 5);
   }
 

--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -220,7 +220,7 @@ Dialog::draw(DrawingContext& context)
   // draw HL line
   context.color().draw_filled_rect(Rectf(Vector(bg_rect.get_left(), bg_rect.get_bottom() - 35),
                                          Sizef(bg_rect.get_width(), 4)),
-                                   Color(g_config->hlcolor), LAYER_GUI);
+                                   g_config->hlcolor, LAYER_GUI);
   context.color().draw_filled_rect(Rectf(Vector(bg_rect.get_left(), bg_rect.get_bottom() - 35),
                                          Sizef(bg_rect.get_width(), 2)),
                                    Color(1.0f, 1.0f, 1.0f, 1.0f), LAYER_GUI);
@@ -252,7 +252,7 @@ Dialog::draw(DrawingContext& context)
     context.color().draw_text(Resources::normal_font, m_buttons[i].text,
                               Vector(pos.x, pos.y - static_cast<float>(int(Resources::normal_font->get_height() / 2))),
                               ALIGN_CENTER, LAYER_GUI,
-                              i == m_selected_button ? Color(g_config->activetextcolor) : ColorScheme::Menu::default_color);
+                              i == m_selected_button ? g_config->activetextcolor : ColorScheme::Menu::default_color);
   }
 }
 

--- a/src/gui/dialog.cpp
+++ b/src/gui/dialog.cpp
@@ -199,13 +199,13 @@ Dialog::draw(DrawingContext& context)
   // draw background rect
   context.color().draw_filled_rect(bg_rect.grown(12.0f),
                                      Color(g_config->menubackcolor.red, g_config->menubackcolor.green,
-                                       g_config->menubackcolor.blue, (g_config->menubackcolor.alpha - (m_passive ? 0.5f : 0.0f))),
+                                       g_config->menubackcolor.blue, (std::max(0.f, g_config->menubackcolor.alpha - (m_passive ? 0.5f : 0.0f)))),
                                        g_config->menuroundness + 4.f,
                                      LAYER_GUI-10);
 
   context.color().draw_filled_rect(bg_rect.grown(8.0f),
                                      Color(g_config->menufrontcolor.red, g_config->menufrontcolor.green,
-                                       g_config->menufrontcolor.blue, (g_config->menufrontcolor.alpha - (m_passive ? 0.3f : 0.0f))),
+                                       g_config->menufrontcolor.blue, (std::max(0.f, g_config->menufrontcolor.alpha - (m_passive ? 0.3f : 0.0f)))),
                                        g_config->menuroundness,
                                      LAYER_GUI-10);
 
@@ -252,7 +252,7 @@ Dialog::draw(DrawingContext& context)
     context.color().draw_text(Resources::normal_font, m_buttons[i].text,
                               Vector(pos.x, pos.y - static_cast<float>(int(Resources::normal_font->get_height() / 2))),
                               ALIGN_CENTER, LAYER_GUI,
-                              i == m_selected_button ? ColorScheme::Menu::active_color : ColorScheme::Menu::default_color);
+                              i == m_selected_button ? Color(g_config->activetextcolor) : ColorScheme::Menu::default_color);
   }
 }
 

--- a/src/gui/item_back.cpp
+++ b/src/gui/item_back.cpp
@@ -36,7 +36,7 @@ ItemBack::draw(DrawingContext& context, const Vector& pos, int menu_width, bool 
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector( pos.x + static_cast<float>(menu_width) / 2.0f,
                                     pos.y - static_cast<float>(int(Resources::normal_font->get_height()/2))),
-                            ALIGN_CENTER, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_CENTER, LAYER_GUI, active ? g_config->activetextcolor : get_color());
   context.color().draw_surface(Resources::back,
                                Vector(pos.x + static_cast<float>(menu_width) / 2.0f + text_width / 2.0f  + 16.0f,
                                       pos.y - 8.0f),

--- a/src/gui/item_back.cpp
+++ b/src/gui/item_back.cpp
@@ -18,6 +18,8 @@
 
 #include "gui/menu_manager.hpp"
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 #include "video/surface.hpp"
@@ -34,7 +36,7 @@ ItemBack::draw(DrawingContext& context, const Vector& pos, int menu_width, bool 
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector( pos.x + static_cast<float>(menu_width) / 2.0f,
                                     pos.y - static_cast<float>(int(Resources::normal_font->get_height()/2))),
-                            ALIGN_CENTER, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_CENTER, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
   context.color().draw_surface(Resources::back,
                                Vector(pos.x + static_cast<float>(menu_width) / 2.0f + text_width / 2.0f  + 16.0f,
                                       pos.y - 8.0f),

--- a/src/gui/item_controlfield.cpp
+++ b/src/gui/item_controlfield.cpp
@@ -17,6 +17,8 @@
 #include "gui/item_controlfield.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 
@@ -36,7 +38,7 @@ ItemControlField::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, get_text(),
                               Vector(pos.x + 16.0f,
                                      pos.y - static_cast<float>(int(Resources::normal_font->get_height()/2))),
-                              ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                              ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 int

--- a/src/gui/item_controlfield.cpp
+++ b/src/gui/item_controlfield.cpp
@@ -38,7 +38,7 @@ ItemControlField::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, get_text(),
                               Vector(pos.x + 16.0f,
                                      pos.y - static_cast<float>(int(Resources::normal_font->get_height()/2))),
-                              ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                              ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 int

--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -17,6 +17,7 @@
 #include "gui/item_floatfield.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
@@ -56,7 +57,7 @@ ItemFloatField::draw(DrawingContext& context, const Vector& pos, int menu_width,
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 int

--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -57,7 +57,7 @@ ItemFloatField::draw(DrawingContext& context, const Vector& pos, int menu_width,
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 int

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -17,6 +17,7 @@
 #include "gui/item_intfield.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
@@ -43,7 +44,7 @@ ItemIntField::draw(DrawingContext& context, const Vector& pos, int menu_width, b
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 int

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -44,7 +44,7 @@ ItemIntField::draw(DrawingContext& context, const Vector& pos, int menu_width, b
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 int

--- a/src/gui/item_label.cpp
+++ b/src/gui/item_label.cpp
@@ -17,6 +17,8 @@
 #include "gui/item_label.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 
@@ -35,7 +37,7 @@ ItemLabel::draw(DrawingContext& context, const Vector& pos, int menu_width, bool
 
 Color
 ItemLabel::get_color() const {
-  return ColorScheme::Menu::label_color;
+  return Color(g_config->labeltextcolor);
 }
 
 int

--- a/src/gui/item_label.cpp
+++ b/src/gui/item_label.cpp
@@ -37,7 +37,7 @@ ItemLabel::draw(DrawingContext& context, const Vector& pos, int menu_width, bool
 
 Color
 ItemLabel::get_color() const {
-  return Color(g_config->labeltextcolor);
+  return g_config->labeltextcolor;
 }
 
 int

--- a/src/gui/item_stringselect.cpp
+++ b/src/gui/item_stringselect.cpp
@@ -18,6 +18,8 @@
 
 #include "gui/menu_manager.hpp"
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 #include "video/surface.hpp"
@@ -38,7 +40,7 @@ ItemStringSelect::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, get_text(),
                               Vector(pos.x + 16.0f,
                                      pos.y - Resources::normal_font->get_height() / 2.0f),
-                              ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                              ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 
   // Draw right side
   context.color().draw_surface(Resources::arrow_left,
@@ -52,7 +54,7 @@ ItemStringSelect::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, list[*selected],
                             Vector(pos.x + static_cast<float>(menu_width) - roff - 8.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_RIGHT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_RIGHT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 int

--- a/src/gui/item_stringselect.cpp
+++ b/src/gui/item_stringselect.cpp
@@ -40,7 +40,7 @@ ItemStringSelect::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, get_text(),
                               Vector(pos.x + 16.0f,
                                      pos.y - Resources::normal_font->get_height() / 2.0f),
-                              ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                              ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 
   // Draw right side
   context.color().draw_surface(Resources::arrow_left,
@@ -54,7 +54,7 @@ ItemStringSelect::draw(DrawingContext& context, const Vector& pos, int menu_widt
   context.color().draw_text(Resources::normal_font, list[*selected],
                             Vector(pos.x + static_cast<float>(menu_width) - roff - 8.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_RIGHT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_RIGHT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 int

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -43,7 +43,7 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - static_cast<float>(Resources::normal_font->get_height()) / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 int

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -17,6 +17,7 @@
 #include "gui/item_textfield.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
@@ -42,7 +43,7 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16.0f,
                                    pos.y - static_cast<float>(Resources::normal_font->get_height()) / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 int

--- a/src/gui/item_toggle.cpp
+++ b/src/gui/item_toggle.cpp
@@ -17,6 +17,8 @@
 #include "gui/item_toggle.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 #include "video/surface.hpp"
@@ -43,7 +45,7 @@ ItemToggle::draw(DrawingContext& context, const Vector& pos, int menu_width, boo
 {
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16, pos.y - (Resources::normal_font->get_height()/2)),
-                            ALIGN_LEFT, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 
   if (m_get_func()) {
     context.color().draw_surface(Resources::checkbox_checked,

--- a/src/gui/item_toggle.cpp
+++ b/src/gui/item_toggle.cpp
@@ -45,7 +45,7 @@ ItemToggle::draw(DrawingContext& context, const Vector& pos, int menu_width, boo
 {
   context.color().draw_text(Resources::normal_font, get_text(),
                             Vector(pos.x + 16, pos.y - (Resources::normal_font->get_height()/2)),
-                            ALIGN_LEFT, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 
   if (m_get_func()) {
     context.color().draw_surface(Resources::checkbox_checked,

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -613,18 +613,12 @@ Menu::draw(DrawingContext& context)
 
     context.color().draw_filled_rect(Rectf(text_rect.p1() - Vector(4,4),
                                            text_rect.p2() + Vector(4,4)),
-                                     Color(g_config->menubackcolor.red + 0.3f,
-                                       g_config->menubackcolor.green + 0.3f,
-                                       g_config->menubackcolor.blue + 0.3f,
-                                       g_config->menubackcolor.alpha),
+                                     Color(g_config->menuhelpbackcolor),
                                      g_config->menuroundness + 4.f,
                                      LAYER_GUI);
 
     context.color().draw_filled_rect(text_rect,
-                                     Color(g_config->menufrontcolor.red + 0.2f,
-                                       g_config->menufrontcolor.green + 0.2f,
-                                       g_config->menufrontcolor.blue + 0.2f,
-                                       g_config->menufrontcolor.alpha),
+                                     Color(g_config->menuhelpfrontcolor),
                                      g_config->menuroundness,
                                      LAYER_GUI);
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -613,12 +613,12 @@ Menu::draw(DrawingContext& context)
 
     context.color().draw_filled_rect(Rectf(text_rect.p1() - Vector(4,4),
                                            text_rect.p2() + Vector(4,4)),
-                                     Color(g_config->menuhelpbackcolor),
+                                     g_config->menuhelpbackcolor,
                                      g_config->menuroundness + 4.f,
                                      LAYER_GUI);
 
     context.color().draw_filled_rect(text_rect,
-                                     Color(g_config->menuhelpfrontcolor),
+                                     g_config->menuhelpfrontcolor,
                                      g_config->menuroundness,
                                      LAYER_GUI);
 

--- a/src/gui/menu_item.cpp
+++ b/src/gui/menu_item.cpp
@@ -18,6 +18,8 @@
 #include "gui/menu_item.hpp"
 
 #include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 
@@ -52,7 +54,7 @@ MenuItem::draw(DrawingContext& context, const Vector& pos, int menu_width, bool 
   context.color().draw_text(Resources::normal_font, m_text,
                             Vector( pos.x + static_cast<float>(menu_width) / 2.0f,
                                     pos.y - static_cast<float>(Resources::normal_font->get_height()) / 2.0f ),
-                            ALIGN_CENTER, LAYER_GUI, active ? ColorScheme::Menu::active_color : get_color());
+                            ALIGN_CENTER, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
 }
 
 Color

--- a/src/gui/menu_item.cpp
+++ b/src/gui/menu_item.cpp
@@ -54,7 +54,7 @@ MenuItem::draw(DrawingContext& context, const Vector& pos, int menu_width, bool 
   context.color().draw_text(Resources::normal_font, m_text,
                             Vector( pos.x + static_cast<float>(menu_width) / 2.0f,
                                     pos.y - static_cast<float>(Resources::normal_font->get_height()) / 2.0f ),
-                            ALIGN_CENTER, LAYER_GUI, active ? Color(g_config->activetextcolor) : get_color());
+                            ALIGN_CENTER, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
 Color

--- a/src/gui/menu_manager.cpp
+++ b/src/gui/menu_manager.cpp
@@ -120,13 +120,13 @@ public:
     // draw menu background rectangles
     context.color().draw_filled_rect(Rectf(rect.get_left() - 4, rect.get_top() - 10-4,
                                              rect.get_right() + 4, rect.get_bottom() + 10 + 4),
-                                       Color(g_config->menubackcolor),
+                                       g_config->menubackcolor,
                                        g_config->menuroundness + 4.f,
                                        LAYER_GUI-10);
 
     context.color().draw_filled_rect(Rectf(rect.get_left(), rect.get_top() - 10,
                                              rect.get_right(), rect.get_bottom() + 10),
-                                       Color(g_config->menufrontcolor),
+                                       g_config->menufrontcolor,
                                        g_config->menuroundness,
                                        LAYER_GUI-10);
   }

--- a/src/supertux/colorscheme.cpp
+++ b/src/supertux/colorscheme.cpp
@@ -40,6 +40,8 @@ Color Statistics::perfect_color(0.4f,1.f,0.4f);
 
 Color ColorScheme::Menu::back_color(0.2f, 0.3f, 0.4f, 0.8f);
 Color ColorScheme::Menu::front_color(0.6f, 0.7f, 0.8f, 0.5f);
+Color ColorScheme::Menu::help_back_color(0.5f, 0.6f, 0.7f, 0.8f);
+Color ColorScheme::Menu::help_front_color(0.8f, 0.9f, 1.f, 0.5f);
 Color ColorScheme::Menu::hl_color(0.6f, 0.7f, 1.f, 1.f);
 Color ColorScheme::Menu::default_color(1.f,1.f,1.f);
 Color ColorScheme::Menu::active_color(0.4f,0.66f,1.f);
@@ -69,6 +71,8 @@ Color ColorScheme::Text::reference_color(0.2f,0.6f,1.f);
 Color ColorScheme::Text::normal_color(1.f,1.f,1.f);
 
 Color ColorScheme::Editor::default_color(0.9f, 0.9f, 1.0f, 0.6f);
+Color ColorScheme::Editor::hover_color(1.f, 1.f, 1.f, 0.4f);
+Color ColorScheme::Editor::grab_color(1.f, 1.f, 1.f, 0.7f);
 Color EditorOverlayWidget::text_autotile_available_color(1.f,1.f,0.6f);
 Color EditorOverlayWidget::text_autotile_active_color(1.f,1.f,1.f);
 Color EditorOverlayWidget::text_autotile_error_color(1.f,0.2f,0.1f);

--- a/src/supertux/colorscheme.hpp
+++ b/src/supertux/colorscheme.hpp
@@ -27,6 +27,8 @@ public:
   public:
     static Color back_color;
     static Color front_color;
+    static Color help_back_color;
+    static Color help_front_color;
     static Color hl_color;
     static Color default_color;
     static Color active_color;
@@ -48,6 +50,8 @@ public:
   {
   public:
     static Color default_color;
+    static Color hover_color;
+    static Color grab_color;
   };
 };
 

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -142,27 +142,26 @@ Config::load()
   boost::optional<ReaderMapping> interface_colors_mapping;
   if (config_mapping.get("interface_colors", interface_colors_mapping))
   {
-    menubackcolor = Color(interface_colors_mapping->get("menubackcolor", menubackcolor_) ?
-      menubackcolor_ : ColorScheme::Menu::back_color);
-    menufrontcolor = Color(interface_colors_mapping->get("menufrontcolor", menufrontcolor_) ?
-      menufrontcolor_ : ColorScheme::Menu::front_color);
-    menuhelpbackcolor = Color(interface_colors_mapping->get("menuhelpbackcolor", menuhelpbackcolor_) ?
-      menuhelpbackcolor_ : ColorScheme::Menu::help_back_color);
-    menuhelpfrontcolor = Color(interface_colors_mapping->get("menuhelpfrontcolor", menuhelpfrontcolor_) ?
-      menuhelpfrontcolor_ : ColorScheme::Menu::help_front_color);
-    labeltextcolor = Color(interface_colors_mapping->get("labeltextcolor", labeltextcolor_) ?
-      labeltextcolor_ : ColorScheme::Menu::label_color);
-    activetextcolor = Color(interface_colors_mapping->get("activetextcolor", activetextcolor_) ?
-      activetextcolor_ : ColorScheme::Menu::active_color);
-    hlcolor = Color(interface_colors_mapping->get("hlcolor", hlcolor_) ?
-      hlcolor_ : ColorScheme::Menu::hl_color);
-    editorcolor = Color(interface_colors_mapping->get("editorcolor", editorcolor_) ?
-      editorcolor_ : ColorScheme::Editor::default_color);
-    editorhovercolor = Color(interface_colors_mapping->get("editorhovercolor", editorhovercolor_) ?
-      editorhovercolor_ : ColorScheme::Editor::hover_color);
-    editorgrabcolor = Color(interface_colors_mapping->get("editorgrabcolor", editorgrabcolor_) ?
-      editorgrabcolor_ : ColorScheme::Editor::grab_color);
-
+    interface_colors_mapping->get("menubackcolor", menubackcolor_, ColorScheme::Menu::back_color.toVector());
+    interface_colors_mapping->get("menufrontcolor", menufrontcolor_, ColorScheme::Menu::front_color.toVector());
+    interface_colors_mapping->get("menuhelpbackcolor", menuhelpbackcolor_, ColorScheme::Menu::help_back_color.toVector());
+    interface_colors_mapping->get("menuhelpfrontcolor", menuhelpfrontcolor_, ColorScheme::Menu::help_back_color.toVector());
+    interface_colors_mapping->get("labeltextcolor", labeltextcolor_, ColorScheme::Menu::label_color.toVector());
+    interface_colors_mapping->get("activetextkcolor", activetextcolor_, ColorScheme::Menu::active_color.toVector());
+    interface_colors_mapping->get("hlcolor", hlcolor_, ColorScheme::Menu::hl_color.toVector());
+    interface_colors_mapping->get("editorcolor", editorcolor_, ColorScheme::Editor::default_color.toVector());
+    interface_colors_mapping->get("editorhovercolor", editorhovercolor_, ColorScheme::Editor::hover_color.toVector());
+    interface_colors_mapping->get("editorgrabcolor", editorgrabcolor_, ColorScheme::Editor::grab_color.toVector());
+    menubackcolor = Color(menubackcolor_);
+    menufrontcolor = Color(menufrontcolor_);
+    menuhelpbackcolor = Color(menuhelpbackcolor_);
+    menuhelpfrontcolor = Color(menuhelpfrontcolor_);
+    labeltextcolor = Color(labeltextcolor_);
+    activetextcolor = Color(activetextcolor_);
+    hlcolor = Color(hlcolor_);
+    editorcolor = Color(editorcolor_);
+    editorhovercolor = Color(editorhovercolor_);
+    editorgrabcolor = Color(editorgrabcolor_);
     interface_colors_mapping->get("menuroundness", menuroundness, 16.f);
   }
 

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -25,6 +25,8 @@
 #include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
 #include "util/log.hpp"
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -76,8 +78,14 @@ Config::Config() :
   hide_editor_levelnames(false),
   menubackcolor(ColorScheme::Menu::back_color),
   menufrontcolor(ColorScheme::Menu::front_color),
+  menuhelpbackcolor(ColorScheme::Menu::help_back_color),
+  menuhelpfrontcolor(ColorScheme::Menu::help_front_color),
+  labeltextcolor(ColorScheme::Menu::label_color),
+  activetextcolor(ColorScheme::Menu::active_color),
   hlcolor(ColorScheme::Menu::hl_color),
   editorcolor(ColorScheme::Editor::default_color),
+  editorhovercolor(ColorScheme::Editor::hover_color),
+  editorgrabcolor(ColorScheme::Editor::grab_color),
   menuroundness(16.f),
   editor_selected_snap_grid_size(3),
   editor_render_grid(true),
@@ -126,36 +134,37 @@ Config::load()
 #endif
   }
 
-  //menu colors
-  float menubackcolor_r, menubackcolor_g, menubackcolor_b, menubackcolor_a;
-  config_mapping.get("menubackcolor_r", menubackcolor_r, 0.2f);
-  config_mapping.get("menubackcolor_g", menubackcolor_g, 0.3f);
-  config_mapping.get("menubackcolor_b", menubackcolor_b, 0.4f);
-  config_mapping.get("menubackcolor_a", menubackcolor_a, 0.8f);
-  menubackcolor = Color(menubackcolor_r, menubackcolor_g, menubackcolor_b, menubackcolor_a);
+  // menu colors
 
-  float menufrontcolor_r, menufrontcolor_g, menufrontcolor_b, menufrontcolor_a;
-  config_mapping.get("menufrontcolor_r", menufrontcolor_r, 0.6f);
-  config_mapping.get("menufrontcolor_g", menufrontcolor_g, 0.7f);
-  config_mapping.get("menufrontcolor_b", menufrontcolor_b, 0.8f);
-  config_mapping.get("menufrontcolor_a", menufrontcolor_a, 0.5f);
-  menufrontcolor = Color(menufrontcolor_r, menufrontcolor_g, menufrontcolor_b, menufrontcolor_a);
+  std::vector<float> menubackcolor_, menufrontcolor_, menuhelpbackcolor_, menuhelpfrontcolor_,
+    labeltextcolor_, activetextcolor_, hlcolor_, editorcolor_, editorhovercolor_, editorgrabcolor_;
 
-  float hlcolor_r, hlcolor_g, hlcolor_b, hlcolor_a;
-  config_mapping.get("hlcolor_r", hlcolor_r, 0.6f);
-  config_mapping.get("hlcolor_g", hlcolor_g, 0.7f);
-  config_mapping.get("hlcolor_b", hlcolor_b, 1.f);
-  config_mapping.get("hlcolor_a", hlcolor_a, 1.f);
-  hlcolor = Color(hlcolor_r, hlcolor_g, hlcolor_b, hlcolor_a);
+  boost::optional<ReaderMapping> interface_colors_mapping;
+  if (config_mapping.get("interface_colors", interface_colors_mapping))
+  {
+    menubackcolor = Color(interface_colors_mapping->get("menubackcolor", menubackcolor_) ?
+      menubackcolor_ : ColorScheme::Menu::back_color);
+    menufrontcolor = Color(interface_colors_mapping->get("menufrontcolor", menufrontcolor_) ?
+      menufrontcolor_ : ColorScheme::Menu::front_color);
+    menuhelpbackcolor = Color(interface_colors_mapping->get("menuhelpbackcolor", menuhelpbackcolor_) ?
+      menuhelpbackcolor_ : ColorScheme::Menu::help_back_color);
+    menuhelpfrontcolor = Color(interface_colors_mapping->get("menuhelpfrontcolor", menuhelpfrontcolor_) ?
+      menuhelpfrontcolor_ : ColorScheme::Menu::help_front_color);
+    labeltextcolor = Color(interface_colors_mapping->get("labeltextcolor", labeltextcolor_) ?
+      labeltextcolor_ : ColorScheme::Menu::label_color);
+    activetextcolor = Color(interface_colors_mapping->get("activetextcolor", activetextcolor_) ?
+      activetextcolor_ : ColorScheme::Menu::active_color);
+    hlcolor = Color(interface_colors_mapping->get("hlcolor", hlcolor_) ?
+      hlcolor_ : ColorScheme::Menu::hl_color);
+    editorcolor = Color(interface_colors_mapping->get("editorcolor", editorcolor_) ?
+      editorcolor_ : ColorScheme::Editor::default_color);
+    editorhovercolor = Color(interface_colors_mapping->get("editorhovercolor", editorhovercolor_) ?
+      editorhovercolor_ : ColorScheme::Editor::hover_color);
+    editorgrabcolor = Color(interface_colors_mapping->get("editorgrabcolor", editorgrabcolor_) ?
+      editorgrabcolor_ : ColorScheme::Editor::grab_color);
 
-  float editorcolor_r, editorcolor_g, editorcolor_b, editorcolor_a;
-  config_mapping.get("editorcolor_r", editorcolor_r, 0.9f);
-  config_mapping.get("editorcolor_g", editorcolor_g, 0.9f);
-  config_mapping.get("editorcolor_b", editorcolor_b, 1.f);
-  config_mapping.get("editorcolor_a", editorcolor_a, 0.6f);
-  editorcolor = Color(editorcolor_r, editorcolor_g, editorcolor_b, editorcolor_a);
-
-  config_mapping.get("menuroundness", menuroundness, 16.f);
+    interface_colors_mapping->get("menuroundness", menuroundness, 16.f);
+  }
 
   // Compatibility; will be overwritten by the "editor" category
   
@@ -301,24 +310,6 @@ Config::save()
   }
   writer.end_list("integrations");
 
-  writer.write("menubackcolor_r", menubackcolor.red);
-  writer.write("menubackcolor_g", menubackcolor.green);
-  writer.write("menubackcolor_b", menubackcolor.blue);
-  writer.write("menubackcolor_a", menubackcolor.alpha);
-  writer.write("menufrontcolor_r", menufrontcolor.red);
-  writer.write("menufrontcolor_g", menufrontcolor.green);
-  writer.write("menufrontcolor_b", menufrontcolor.blue);
-  writer.write("menufrontcolor_a", menufrontcolor.alpha);
-  writer.write("hlcolor_r", hlcolor.red);
-  writer.write("hlcolor_g", hlcolor.green);
-  writer.write("hlcolor_b", hlcolor.blue);
-  writer.write("hlcolor_a", hlcolor.alpha);
-  writer.write("editorcolor_r", editorcolor.red);
-  writer.write("editorcolor_g", editorcolor.green);
-  writer.write("editorcolor_b", editorcolor.blue);
-  writer.write("editorcolor_a", editorcolor.alpha);
-  writer.write("menuroundness", menuroundness);
-
   writer.write("editor_autosave_frequency", editor_autosave_frequency);
 
   if (is_christmas()) {
@@ -327,6 +318,20 @@ Config::save()
   writer.write("transitions_enabled", transitions_enabled);
   writer.write("locale", locale);
   writer.write("repository_url", repository_url);
+
+  writer.start_list("interface_colors");
+  writer.write("menubackcolor", menubackcolor.toVector());
+  writer.write("menufrontcolor", menufrontcolor.toVector());
+  writer.write("menuhelpbackcolor", menuhelpbackcolor.toVector());
+  writer.write("menuhelpfrontcolor", menuhelpfrontcolor.toVector());
+  writer.write("labeltextcolor", labeltextcolor.toVector());
+  writer.write("activetextcolor", activetextcolor.toVector());
+  writer.write("hlcolor", hlcolor.toVector());
+  writer.write("editorcolor", editorcolor.toVector());
+  writer.write("editorhovercolor", editorhovercolor.toVector());
+  writer.write("editorgrabcolor", editorgrabcolor.toVector());
+  writer.write("menuroundness", menuroundness);
+  writer.end_list("interface_colors");
 
   writer.start_list("video");
   writer.write("fullscreen", use_fullscreen);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -115,8 +115,14 @@ public:
   bool hide_editor_levelnames;
   Color menubackcolor;
   Color menufrontcolor;
+  Color menuhelpbackcolor;
+  Color menuhelpfrontcolor;
+  Color labeltextcolor;
+  Color activetextcolor;
   Color hlcolor;
   Color editorcolor;
+  Color editorhovercolor;
+  Color editorgrabcolor;
   float menuroundness;
 
   int editor_selected_snap_grid_size;

--- a/src/supertux/menu/custom_menu_menu.cpp
+++ b/src/supertux/menu/custom_menu_menu.cpp
@@ -33,8 +33,14 @@ enum CustomMenuMenuIDs {
   MNID_RESET,
   MNID_MENUBACKCOLOR,
   MNID_MENUFRONTCOLOR,
+  MNID_MENUHELPBACKCOLOR,
+  MNID_MENUHELPFRONTCOLOR,
+  MNID_LABELTEXTCOLOR,
+  MNID_ACTIVETEXTCOLOR,
   MNID_HLCOLOR,
   MNID_EDITORCOLOR,
+  MNID_EDITORHOVERCOLOR,
+  MNID_EDITORGRABCOLOR,
   MNID_MENUROUNDNESS
 };
 
@@ -44,9 +50,16 @@ CustomMenuMenu::CustomMenuMenu()
   add_hl();
   add_color(_("Menu Back Color"), &g_config->menubackcolor, MNID_MENUBACKCOLOR);
   add_color(_("Menu Front Color"), &g_config->menufrontcolor, MNID_MENUFRONTCOLOR);
+  add_color(_("Menu Help Back Color"), &g_config->menuhelpbackcolor, MNID_MENUHELPBACKCOLOR);
+  add_color(_("Menu Help Front Color"), &g_config->menuhelpfrontcolor, MNID_MENUHELPFRONTCOLOR);
+  add_color(_("Label Text Color"), &g_config->labeltextcolor, MNID_LABELTEXTCOLOR);
+  add_color(_("Active Text Color"), &g_config->activetextcolor, MNID_ACTIVETEXTCOLOR);
   add_color(_("Divider Line Color"), &g_config->hlcolor, MNID_HLCOLOR);
-  add_color(_("Editor Color Scheme"), &g_config->editorcolor, MNID_EDITORCOLOR);
   add_floatfield(_("Menu Roundness"), &g_config->menuroundness, MNID_MENUROUNDNESS);
+  add_hl();
+  add_color(_("Editor Interface Color"), &g_config->editorcolor, MNID_EDITORCOLOR);
+  add_color(_("Editor Hover Color"), &g_config->editorhovercolor, MNID_EDITORHOVERCOLOR);
+  add_color(_("Editor Grab Color"), &g_config->editorgrabcolor, MNID_EDITORGRABCOLOR);
   add_hl();
   add_entry(MNID_RESET, _("Reset to defaults"));
   add_back(_("Back"));
@@ -64,8 +77,14 @@ CustomMenuMenu::menu_action(MenuItem& item)
   case MNID_RESET:
     g_config->menubackcolor = ColorScheme::Menu::back_color;
     g_config->menufrontcolor = ColorScheme::Menu::front_color;
+    g_config->menuhelpbackcolor = ColorScheme::Menu::help_back_color;
+    g_config->menuhelpfrontcolor = ColorScheme::Menu::help_front_color;
+    g_config->labeltextcolor = ColorScheme::Menu::label_color;
+    g_config->activetextcolor = ColorScheme::Menu::active_color;
     g_config->hlcolor = ColorScheme::Menu::hl_color;
     g_config->editorcolor = ColorScheme::Editor::default_color;
+    g_config->editorhovercolor = ColorScheme::Editor::hover_color;
+    g_config->editorgrabcolor = ColorScheme::Editor::grab_color;
     g_config->menuroundness = 16.f;
     break;
 

--- a/src/util/colorspace_oklab.cpp
+++ b/src/util/colorspace_oklab.cpp
@@ -27,6 +27,7 @@
 
 #include "util/colorspace_oklab.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cfloat>
 

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -142,11 +142,14 @@ ReaderMapping::get(const char* key, std::string& value, const boost::optional<co
 #define GET_VALUES_MACRO(type, checker, getter)                         \
   auto const sx = get_item(key);                                        \
   if (!sx) {                                                            \
+    if (default_value) {                                                \
+      value = *default_value;                                           \
+    }                                                                   \
     return false;                                                       \
   } else {                                                              \
     assert_is_array(m_doc, *sx);                                        \
     auto const& item = sx->as_array();                                  \
-    for (size_t i = 1; i < item.size(); ++i)                             \
+    for (size_t i = 1; i < item.size(); ++i)                            \
     {                                                                   \
       assert_##checker(m_doc, item[i]);                                 \
       value.emplace_back(item[i].getter());                             \
@@ -155,14 +158,16 @@ ReaderMapping::get(const char* key, std::string& value, const boost::optional<co
   }
 
 bool
-ReaderMapping::get(const char* key, std::vector<bool>& value) const
+ReaderMapping::get(const char* key, std::vector<bool>& value,
+                   const boost::optional<std::vector<bool>>& default_value) const
 {
   value.clear();
   GET_VALUES_MACRO("bool", is_boolean, as_bool)
 }
 
 bool
-ReaderMapping::get(const char* key, std::vector<int>& value) const
+ReaderMapping::get(const char* key, std::vector<int>& value,
+                   const boost::optional<std::vector<int>>& default_value) const
 {
   value.clear();
   GET_VALUES_MACRO("int", is_integer, as_int)
@@ -170,21 +175,24 @@ ReaderMapping::get(const char* key, std::vector<int>& value) const
 
 
 bool
-ReaderMapping::get(const char* key, std::vector<float>& value) const
+ReaderMapping::get(const char* key, std::vector<float>& value,
+                   const boost::optional<std::vector<float>>& default_value) const
 {
   value.clear();
   GET_VALUES_MACRO("float", is_real, as_float)
 }
 
 bool
-ReaderMapping::get(const char* key, std::vector<std::string>& value) const
+ReaderMapping::get(const char* key, std::vector<std::string>& value,
+                   const boost::optional<std::vector<std::string>>& default_value) const
 {
   value.clear();
   GET_VALUES_MACRO("string", is_string, as_string)
 }
 
 bool
-ReaderMapping::get(const char* key, std::vector<unsigned int>& value) const
+ReaderMapping::get(const char* key, std::vector<unsigned int>& value,
+                   const boost::optional<std::vector<unsigned int>>& default_value) const
 {
   value.clear();
   GET_VALUES_MACRO("unsigned int", is_integer, as_int)

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -45,11 +45,11 @@ public:
   bool get(const char* key, float& value, const boost::optional<float>& default_value = boost::none) const;
   bool get(const char* key, std::string& value, const boost::optional<const char*>& default_value = boost::none) const;
 
-  bool get(const char* key, std::vector<bool>& value) const;
-  bool get(const char* key, std::vector<int>& value) const;
-  bool get(const char* key, std::vector<float>& value) const;
-  bool get(const char* key, std::vector<std::string>& value) const;
-  bool get(const char* key, std::vector<unsigned int>& value) const;
+  bool get(const char* key, std::vector<bool>& value, const boost::optional<std::vector<bool>>& default_value = boost::none) const;
+  bool get(const char* key, std::vector<int>& value, const boost::optional<std::vector<int>>& default_value = boost::none) const;
+  bool get(const char* key, std::vector<float>& value, const boost::optional<std::vector<float>>& default_value = boost::none) const;
+  bool get(const char* key, std::vector<std::string>& value, const boost::optional<std::vector<std::string>>& default_value = boost::none) const;
+  bool get(const char* key, std::vector<unsigned int>& value, const boost::optional<std::vector<unsigned int>>& default_value = boost::none) const;
 
   bool get(const char* key, boost::optional<ReaderMapping>&) const;
   bool get(const char* key, boost::optional<ReaderCollection>&) const;


### PR DESCRIPTION
This PR makes the color-customizable menus more efficient, allows for more colors to customize (which should fix a crash one user was experiencing but that I could not reproduce) and allows the customization of non-neutral-colored text.  