### PR TITLE
Fetch details concerning crashes for WASM builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,7 +930,7 @@ target_link_libraries(supertux2 supertux2_lib Boost::filesystem Boost::locale)
 set_target_properties(supertux2_lib PROPERTIES OUTPUT_NAME supertux2_lib)
 set_target_properties(supertux2_lib PROPERTIES COMPILE_FLAGS "${SUPERTUX2_EXTRA_WARNING_FLAGS}")
 if(EMSCRIPTEN)
-  target_link_options(supertux2 PUBLIC -sEXPORTED_FUNCTIONS=['_main','_set_resolution','_save_config','_onDownloadProgress','_onDownloadFinished','_onDownloadError','_onDownloadAborted'] PUBLIC -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] PUBLIC -sEXTRA_EXPORTED_RUNTIME_METHODS=['ccall','cwrap'])
+  target_link_options(supertux2 PUBLIC -sEXPORTED_FUNCTIONS=['_main','_set_resolution','_save_config','_onDownloadProgress','_onDownloadFinished','_onDownloadError','_onDownloadAborted','_getExceptionMessage'] PUBLIC -sEXPORTED_RUNTIME_METHODS=['ccall','cwrap'] PUBLIC -sEXTRA_EXPORTED_RUNTIME_METHODS=['ccall','cwrap'])
 endif(EMSCRIPTEN)
 
 if(WIN32 AND NOT VCPKG_BUILD)

--- a/mk/emscripten/template.html.in
+++ b/mk/emscripten/template.html.in
@@ -341,8 +341,10 @@
     };
 
     Module.setStatus("Downloading...");
-    window.onerror = function (e) {
-      Module.setStatus("Oops!<br><br>An error occured and SuperTux crashed.<br><br><pre>" + e + "</pre>");
+    window.onerror = function (message, source, line, col, error) {
+      if (typeof error == "number")
+        message = Module.ccall('getExceptionMessage', 'string', ['number'], [error]);
+      Module.setStatus("Oops!<br><br>An error occured and SuperTux crashed.<br><br><pre>" + message + "</pre>");
       spinnerElement.style.display = "none";
       Module.setStatus = function (e) {
         if (e)

--- a/src/port/emscripten.hpp
+++ b/src/port/emscripten.hpp
@@ -15,6 +15,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Export functions for emscripten
+// If you add functions here, make sure to make CMakeLists.txt export them!
 #ifdef __EMSCRIPTEN__
 
 #include <emscripten.h>
@@ -35,6 +36,7 @@ void onDownloadProgress(int id, int loaded, int total);
 void onDownloadFinished(int id);
 void onDownloadError(int id);
 void onDownloadAborted(int id);
+const char* getExceptionMessage(intptr_t address);
 
 EMSCRIPTEN_KEEPALIVE // This is probably not useful, I just want ppl to know it exists
 void
@@ -73,6 +75,12 @@ void
 onDownloadAborted(int id)
 {
   AddonManager::current()->onDownloadAborted(id);
+}
+
+const char*
+getExceptionMessage(intptr_t address)
+{
+  return reinterpret_cast<std::exception*>(address)->what();
 }
 
 } // extern "C"


### PR DESCRIPTION
By default, a C++ error thrown and caught by JavaScript would be translated by a number representing the address at which the exception is located.

This PR adds code to retrieve the message from a C++ exception, giving clearer messages.