### PR TITLE
Make displacement rendering consistent across different scale factors

### DIFF
--- a/data/shader/shader100.frag
+++ b/data/shader/shader100.frag
@@ -8,6 +8,7 @@ uniform sampler2D framebuffer_texture;
 uniform mat3 fragcoord2uv;
 uniform float backbuffer;
 uniform float game_time;
+uniform vec2 scale;
 uniform vec2 animate;
 uniform vec2 displacement_animate;
 
@@ -24,7 +25,7 @@ void main(void)
   else
   {
     vec4 pixel = texture2D(displacement_texture, texcoord_var.st + (displacement_animate * game_time));
-    vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * 255.0;
+    vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * scale * 255.0;
     float alpha = pixel.a;
 
     vec2 uv = (fragcoord2uv * (gl_FragCoord.xyw + vec3(displacement.xy * alpha, 0))).xy;

--- a/data/shader/shader330.frag
+++ b/data/shader/shader330.frag
@@ -6,6 +6,7 @@ uniform sampler2D framebuffer_texture;
 uniform mat3 fragcoord2uv;
 uniform float backbuffer;
 uniform float game_time;
+uniform vec2 scale;
 uniform vec2 animate;
 uniform vec2 displacement_animate;
 
@@ -24,7 +25,7 @@ void main(void)
   else if (true)
   {
     vec4 pixel = texture(displacement_texture, texcoord_var.st + (displacement_animate * game_time));
-    vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * 255;
+    vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * scale * 255;
     float alpha = pixel.a;
 
     vec2 uv = (fragcoord2uv * (gl_FragCoord.xyw + vec3(displacement.xy * alpha, 0))).xy;

--- a/src/video/gl/gl33core_context.cpp
+++ b/src/video/gl/gl33core_context.cpp
@@ -94,6 +94,8 @@ GL33CoreContext::bind()
   const float tx = -static_cast<float>(rect.left) / static_cast<float>(rect.get_width());
   const float ty = -static_cast<float>(rect.top) / static_cast<float>(rect.get_height());
 
+  const Vector scv = m_video_system.get_viewport().get_scale();
+
   const float matrix[3*3] = {
     sx, 0.0, 0,
     0.0, sy, 0,
@@ -102,6 +104,7 @@ GL33CoreContext::bind()
   glUniformMatrix3fv(m_program->get_uniform_location("fragcoord2uv"),
                      1, false, matrix);
 
+  glUniform2f(m_program->get_uniform_location("scale"), scv.x, scv.y);
   glUniform1i(m_program->get_uniform_location("diffuse_texture"), 0);
   glUniform1i(m_program->get_uniform_location("displacement_texture"), 1);
   glUniform1i(m_program->get_uniform_location("framebuffer_texture"), 2);


### PR DESCRIPTION
Well, a picture is worth a thousand words...

Before:

![image](https://user-images.githubusercontent.com/6276139/147863861-ff962387-69fd-46ff-b710-816a4ec1c47c.png)
![image](https://user-images.githubusercontent.com/6276139/147863862-84654eb4-c76b-4dd0-960f-7a33e5ce3a66.png)

After:

![image](https://user-images.githubusercontent.com/6276139/147863863-04c91b0e-110e-47bb-b982-e538287bab7d.png)
