### PR TITLE
Badguys no longer deactivate if they aren't alive

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -173,8 +173,9 @@ BadGuy::update(float dt_sec)
       return;
     }
   }
-  if ((m_state != STATE_INACTIVE) && is_offscreen()) {
-    if (m_state == STATE_ACTIVE) deactivate();
+
+  if (m_is_active_flag && is_offscreen()) {
+    deactivate();
     set_state(STATE_INACTIVE);
   }
 


### PR DESCRIPTION
Fixes #2050

This prevents dying/dead badguys from being deactivated at all, preventing their erroneous re-activation as "alive".