### PR TITLE
Revert TextObject back to a singleton

### DIFF
--- a/data/images/engine/editor/objects.stoi
+++ b/data/images/engine/editor/objects.stoi
@@ -366,9 +366,6 @@
     (class "thunderstorm")
     (icon "images/engine/editor/thunderstorm.png"))
   (object
-    (class "textobject")
-    (icon "images/engine/editor/textarray.png"))
-  (object
     (class "textscroller")
     (icon "images/engine/editor/textscroller.png"))
  )

--- a/src/object/text_object.cpp
+++ b/src/object/text_object.cpp
@@ -24,31 +24,6 @@
 #include "supertux/resources.hpp"
 #include "video/drawing_context.hpp"
 
-TextObject::TextObject(const ReaderMapping& reader) :
-  GameObject(reader),
-  ExposedObject<TextObject, scripting::Text>(this),
-  m_font(Resources::normal_font),
-  m_text(),
-  m_wrapped_text(),
-  m_fade_progress(0),
-  m_fadetime(0),
-  m_visible(false),
-  m_centered(false),
-  m_anchor(ANCHOR_MIDDLE),
-  m_pos(0, 0),
-  m_front_fill_color(0.6f, 0.7f, 0.8f, 0.5f),
-  m_back_fill_color(0.2f, 0.3f, 0.4f, 0.8f),
-  m_text_color(1.f, 1.f, 1.f, 1.f),
-  m_roundness(16.f),
-  m_growing_in(),
-  m_growing_out(),
-  m_fading_in(),
-  m_fading_out(),
-  m_grower(),
-  m_fader()
-{
-}
-
 TextObject::TextObject(const std::string& name) :
   GameObject(name),
   ExposedObject<TextObject, scripting::Text>(this),
@@ -78,29 +53,17 @@ TextObject::~TextObject()
 {
 }
 
-ObjectSettings
-TextObject::get_settings()
-{
-  ObjectSettings result = GameObject::get_settings();
-
-  result.reorder({ "name" });
-
-  result.add_remove();
-
-  return result;
-}
-
 void
-TextObject::set_font(const std::string& name_)
+TextObject::set_font(const std::string& name)
 {
-  if (name_ == "normal") {
+  if (name == "normal") {
     m_font = Resources::normal_font;
-  } else if (name_ == "big") {
+  } else if (name == "big") {
     m_font = Resources::big_font;
-  } else if (name_ == "small") {
+  } else if (name == "small") {
     m_font = Resources::small_font;
   } else {
-    log_warning << "Unknown font '" << name_ << "'." << std::endl;
+    log_warning << "Unknown font '" << name << "'." << std::endl;
     m_font = Resources::normal_font;
   }
 
@@ -139,16 +102,16 @@ TextObject::wrap_text()
 }
 
 void
-TextObject::set_text(const std::string& text_)
+TextObject::set_text(const std::string& text)
 {
-  m_text = text_;
+  m_text = text;
   wrap_text();
 }
 
 void
-TextObject::grow_in(float fadetime_)
+TextObject::grow_in(float fadetime)
 {
-  m_fadetime = fadetime_;
+  m_fadetime = fadetime;
   m_visible = true;
   m_fade_progress = 0;
   m_growing_in = true;
@@ -156,17 +119,17 @@ TextObject::grow_in(float fadetime_)
 }
 
 void
-TextObject::grow_out(float fadetime_)
+TextObject::grow_out(float fadetime)
 {
-  m_fadetime = fadetime_;
+  m_fadetime = fadetime;
   m_fade_progress = 1;
   m_growing_out = true;
 }
 
 void
-TextObject::fade_in(float fadetime_)
+TextObject::fade_in(float fadetime)
 {
-  m_fadetime = fadetime_;
+  m_fadetime = fadetime;
   m_visible = true;
   m_fade_progress = 0;
   m_fading_in = true;
@@ -174,48 +137,48 @@ TextObject::fade_in(float fadetime_)
 }
 
 void
-TextObject::fade_out(float fadetime_)
+TextObject::fade_out(float fadetime)
 {
-  m_fadetime = fadetime_;
+  m_fadetime = fadetime;
   m_fade_progress = 1;
   m_fading_out = true;
 }
 
 void
-TextObject::set_visible(bool visible_)
+TextObject::set_visible(bool visible)
 {
-  m_visible = visible_;
+  m_visible = visible;
   m_fade_progress = 1;
 }
 
 void
-TextObject::set_centered(bool centered_)
+TextObject::set_centered(bool centered)
 {
-  m_centered = centered_;
+  m_centered = centered;
 }
 
 void
-TextObject::set_front_fill_color(Color frontfill_)
+TextObject::set_front_fill_color(Color frontfill)
 {
-  m_front_fill_color = frontfill_;
+  m_front_fill_color = frontfill;
 }
 
 void
-TextObject::set_back_fill_color(Color backfill_)
+TextObject::set_back_fill_color(Color backfill)
 {
-  m_back_fill_color = backfill_;
+  m_back_fill_color = backfill;
 }
 
 void
-TextObject::set_text_color(Color textcolor_)
+TextObject::set_text_color(Color textcolor)
 {
-  m_text_color = textcolor_;
+  m_text_color = textcolor;
 }
 
 void
-TextObject::set_roundness(float roundness_)
+TextObject::set_roundness(float roundness)
 {
-  m_roundness = roundness_;
+  m_roundness = roundness;
 }
 
 void

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -42,11 +42,13 @@ public:
   virtual std::string get_class() const override { return "textobject"; }
   virtual std::string get_display_name() const override { return _("Text"); }
 
-  virtual ObjectSettings get_settings() override;
   virtual const std::string get_icon_path() const override { return "images/engine/editor/textarray.png"; }
 
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;
+  virtual bool is_singleton() const override { return true; }
+  virtual bool is_saveable() const override { return false; }
+
 
   void set_text(const std::string& text);
   void set_font(const std::string& name);

--- a/src/scripting/text.cpp
+++ b/src/scripting/text.cpp
@@ -22,11 +22,6 @@
 
 namespace scripting {
 
-Text::Text(const std::string& name) :
-  GameObject(get_game_object_manager().add<::TextObject>(name).get_uid())
-{
-}
-
 void
 Text::set_text(const std::string& text)
 {

--- a/src/scripting/text.hpp
+++ b/src/scripting/text.hpp
@@ -41,9 +41,6 @@ private:
 #endif
 
 public:
-  Text(const std::string& name);
-
-public:
   void set_text(const std::string& text);
   void set_font(const std::string& fontname);
   void fade_in(float fadetime);

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -9072,36 +9072,6 @@ static SQInteger Text_release_hook(SQUserPointer ptr, SQInteger )
   return 0;
 }
 
-static SQInteger Text_constructor_wrapper(HSQUIRRELVM vm)
-{
-  const SQChar* arg0;
-  if (SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not a string"));
-    return SQ_ERROR;
-  }
-
-  try {
-    auto _this = new scripting::Text(arg0);
-    if (SQ_FAILED(sq_setinstanceup(vm, 1, _this))) {
-      sq_throwerror(vm, _SC("Couldn't setup instance of 'Text' class"));
-      return SQ_ERROR;
-    }
-    sq_setreleasehook(vm, 1, Text_release_hook);
-
-    return 0;
-
-  }
-  catch (std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  }
-  catch (...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'constructor'"));
-    return SQ_ERROR;
-  }
-
-}
-
 static SQInteger Text_set_text_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -9241,7 +9211,7 @@ static SQInteger Text_fade_out_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_grow_in_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'grow_in' called without instance"));
     return SQ_ERROR;
   }
@@ -9252,7 +9222,7 @@ static SQInteger Text_grow_in_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
@@ -9262,12 +9232,10 @@ static SQInteger Text_grow_in_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'grow_in'"));
     return SQ_ERROR;
   }
@@ -9277,7 +9245,7 @@ static SQInteger Text_grow_in_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_grow_out_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'grow_out' called without instance"));
     return SQ_ERROR;
   }
@@ -9288,7 +9256,7 @@ static SQInteger Text_grow_out_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
@@ -9298,12 +9266,10 @@ static SQInteger Text_grow_out_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'grow_out'"));
     return SQ_ERROR;
   }
@@ -9544,7 +9510,7 @@ static SQInteger Text_get_anchor_point_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_set_front_fill_color_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'set_front_fill_color' called without instance"));
     return SQ_ERROR;
   }
@@ -9555,22 +9521,22 @@ static SQInteger Text_set_front_fill_color_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg1;
-  if (SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
     sq_throwerror(vm, _SC("Argument 2 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg2;
-  if (SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
     sq_throwerror(vm, _SC("Argument 3 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg3;
-  if (SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
     sq_throwerror(vm, _SC("Argument 4 not a float"));
     return SQ_ERROR;
   }
@@ -9580,12 +9546,10 @@ static SQInteger Text_set_front_fill_color_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_front_fill_color'"));
     return SQ_ERROR;
   }
@@ -9595,7 +9559,7 @@ static SQInteger Text_set_front_fill_color_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_set_back_fill_color_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'set_back_fill_color' called without instance"));
     return SQ_ERROR;
   }
@@ -9606,22 +9570,22 @@ static SQInteger Text_set_back_fill_color_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg1;
-  if (SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
     sq_throwerror(vm, _SC("Argument 2 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg2;
-  if (SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
     sq_throwerror(vm, _SC("Argument 3 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg3;
-  if (SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
     sq_throwerror(vm, _SC("Argument 4 not a float"));
     return SQ_ERROR;
   }
@@ -9631,12 +9595,10 @@ static SQInteger Text_set_back_fill_color_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_back_fill_color'"));
     return SQ_ERROR;
   }
@@ -9646,7 +9608,7 @@ static SQInteger Text_set_back_fill_color_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_set_text_color_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'set_text_color' called without instance"));
     return SQ_ERROR;
   }
@@ -9657,22 +9619,22 @@ static SQInteger Text_set_text_color_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg1;
-  if (SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
     sq_throwerror(vm, _SC("Argument 2 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg2;
-  if (SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
     sq_throwerror(vm, _SC("Argument 3 not a float"));
     return SQ_ERROR;
   }
   SQFloat arg3;
-  if (SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
     sq_throwerror(vm, _SC("Argument 4 not a float"));
     return SQ_ERROR;
   }
@@ -9682,12 +9644,10 @@ static SQInteger Text_set_text_color_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_text_color'"));
     return SQ_ERROR;
   }
@@ -9697,7 +9657,7 @@ static SQInteger Text_set_text_color_wrapper(HSQUIRRELVM vm)
 static SQInteger Text_set_roundness_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
-  if (SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
     sq_throwerror(vm, _SC("'set_roundness' called without instance"));
     return SQ_ERROR;
   }
@@ -9708,7 +9668,7 @@ static SQInteger Text_set_roundness_wrapper(HSQUIRRELVM vm)
   }
 
   SQFloat arg0;
-  if (SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
     sq_throwerror(vm, _SC("Argument 1 not a float"));
     return SQ_ERROR;
   }
@@ -9718,12 +9678,10 @@ static SQInteger Text_set_roundness_wrapper(HSQUIRRELVM vm)
 
     return 0;
 
-  }
-  catch (std::exception& e) {
+  } catch(std::exception& e) {
     sq_throwerror(vm, e.what());
     return SQ_ERROR;
-  }
-  catch (...) {
+  } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_roundness'"));
     return SQ_ERROR;
   }
@@ -11381,6 +11339,66 @@ static SQInteger WorldMap_release_hook(SQUserPointer ptr, SQInteger )
   auto _this = reinterpret_cast<scripting::WorldMap*> (ptr);
   delete _this;
   return 0;
+}
+
+static SQInteger WorldMap_get_tux_x_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_tux_x' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::WorldMap*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_tux_x();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_tux_x'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger WorldMap_get_tux_y_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr)) || !data) {
+    sq_throwerror(vm, _SC("'get_tux_y' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::WorldMap*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+
+  try {
+    float return_value = _this->get_tux_y();
+
+    sq_pushfloat(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_tux_y'"));
+    return SQ_ERROR;
+  }
+
 }
 
 static SQInteger display_wrapper(HSQUIRRELVM vm)
@@ -15083,6 +15101,20 @@ void register_supertux_wrapper(HSQUIRRELVM v)
     msg << "Couldn't create new class 'WorldMap'";
     throw SquirrelError(v, msg.str());
   }
+  sq_pushstring(v, "get_tux_x", -1);
+  sq_newclosure(v, &WorldMap_get_tux_x_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_tux_x'");
+  }
+
+  sq_pushstring(v, "get_tux_y", -1);
+  sq_newclosure(v, &WorldMap_get_tux_y_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_tux_y'");
+  }
+
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register class 'WorldMap'");
   }
@@ -15746,14 +15778,6 @@ void register_supertux_wrapper(HSQUIRRELVM v)
     msg << "Couldn't create new class 'Text'";
     throw SquirrelError(v, msg.str());
   }
-
-  sq_pushstring(v, "constructor", -1);
-  sq_newclosure(v, &Text_constructor_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
-    throw SquirrelError(v, "Couldn't register function 'constructor'");
-  }
-
   sq_pushstring(v, "set_text", -1);
   sq_newclosure(v, &Text_set_text_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|ts");
@@ -15785,14 +15809,14 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_pushstring(v, "grow_in", -1);
   sq_newclosure(v, &Text_grow_in_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'grow_in'");
   }
 
   sq_pushstring(v, "grow_out", -1);
   sq_newclosure(v, &Text_grow_out_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'grow_out'");
   }
 
@@ -15848,28 +15872,28 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_pushstring(v, "set_front_fill_color", -1);
   sq_newclosure(v, &Text_set_front_fill_color_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_front_fill_color'");
   }
 
   sq_pushstring(v, "set_back_fill_color", -1);
   sq_newclosure(v, &Text_set_back_fill_color_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_back_fill_color'");
   }
 
   sq_pushstring(v, "set_text_color", -1);
   sq_newclosure(v, &Text_set_text_color_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_text_color'");
   }
 
   sq_pushstring(v, "set_roundness", -1);
   sq_newclosure(v, &Text_set_roundness_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
-  if (SQ_FAILED(sq_createslot(v, -3))) {
+  if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_roundness'");
   }
 

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -254,7 +254,6 @@ GameObjectFactory::init_factories()
   add_factory<SkullTile>("skull_tile");
   add_factory<SnowParticleSystem>("particles-snow");
   add_factory<Spotlight>("spotlight");
-  add_factory<TextObject>("textobject");
   add_factory<TextScroller>("textscroller");
   add_factory<TextArrayObject>("text-array");
   add_factory<Thunderstorm>("thunderstorm");

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -88,6 +88,7 @@ Sector::Sector(Level& parent) :
   }
   add<Player>(player_status, "Tux");
   add<DisplayEffect>("Effect");
+  add<TextObject>("Text");
   add<TextArrayObject>("TextArray");
 
   SoundManager::current()->preload("sounds/shoot.wav");
@@ -146,11 +147,6 @@ Sector::finish_construction(bool editable)
 
   if (!get_object_by_type<MusicObject>()) {
     add<MusicObject>();
-  }
-
-  if (!get_object_by_type<TextObject>())
-  {
-    add<TextObject>("Text");
   }
 
   if (!get_object_by_type<VerticalStripes>()) {


### PR DESCRIPTION
Fixes #2069

It has been suggested that a level should be able to use multiple TextObjects at once; I recommend investigating if it would be possible to simulate this using scripting functions on the singleton.