### PR TITLE
Tux will not drop an object when releasing Action button

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -189,6 +189,7 @@ Player::Player(PlayerStatus& player_status, const std::string& name_) :
   m_visible(true),
   m_grabbed_object(nullptr),
   m_grabbed_object_remove_listener(new GrabListener(*this)),
+  m_released_object(false),
   // if/when we have complete penny gfx, we can
   // load those instead of Tux's sprite in the
   // constructor
@@ -1135,9 +1136,12 @@ Player::handle_input()
   /* Handle vertical movement: */
   if (!m_stone && !m_swimming) handle_vertical_input();
 
+  /* grabbing */
+  bool just_grabbed = try_grab();
+
   /* Shoot! */
   auto active_bullets = Sector::get().get_object_count<Bullet>();
-  if (m_controller->pressed(Control::ACTION) && (m_player_status.bonus == FIRE_BONUS || m_player_status.bonus == ICE_BONUS)) {
+  if (m_controller->pressed(Control::ACTION) && (m_player_status.bonus == FIRE_BONUS || m_player_status.bonus == ICE_BONUS) && !m_grabbed_object) {
     if ((m_player_status.bonus == FIRE_BONUS &&
       active_bullets < m_player_status.max_fire_bullets) ||
       (m_player_status.bonus == ICE_BONUS &&
@@ -1200,10 +1204,7 @@ Player::handle_input()
     do_standup(false);
   }
 
-  /* grabbing */
-  try_grab();
-
-  if (!m_controller->hold(Control::ACTION) && m_grabbed_object) {
+  if (m_controller->pressed(Control::ACTION) && m_grabbed_object && !just_grabbed) {
     auto moving_object = dynamic_cast<MovingObject*> (m_grabbed_object);
     if (moving_object) {
       // move the grabbed object a bit away from tux
@@ -1256,10 +1257,15 @@ Player::handle_input()
         }
         moving_object->del_remove_listener(m_grabbed_object_remove_listener.get());
         m_grabbed_object = nullptr;
+        m_released_object = true;
       }
     } else {
       log_debug << "Non MovingObject grabbed?!?" << std::endl;
     }
+  }
+
+  if (!m_controller->hold(Control::ACTION) && m_released_object) {
+    m_released_object = false;
   }
 
   /* stop backflipping at will */
@@ -1293,10 +1299,10 @@ Player::position_grabbed_object()
   }
 }
 
-void
+bool
 Player::try_grab()
 {
-  if (m_controller->hold(Control::ACTION) && !m_grabbed_object && !m_duck)
+  if (m_controller->hold(Control::ACTION) && !m_grabbed_object && !m_duck && !m_released_object)
   {
 
     Vector pos(0.0f, 0.0f);
@@ -1335,11 +1341,12 @@ Player::try_grab()
           moving_object.add_remove_listener(m_grabbed_object_remove_listener.get());
 
           position_grabbed_object();
-          break;
+          return true;
         }
       }
     }
   }
+  return false;
 }
 
 void

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -216,7 +216,7 @@ public:
   void stop_backflipping();
 
   void position_grabbed_object();
-  void try_grab();
+  bool try_grab();
 
   /** Boosts Tux in a certain direction, sideways. Useful for bumpers/walljumping. */
   void sideways_push(float delta);
@@ -326,6 +326,7 @@ private:
 
   Portable* m_grabbed_object;
   std::unique_ptr<ObjectRemoveListener> m_grabbed_object_remove_listener;
+  bool m_released_object;
 
   SpritePtr m_sprite; /**< The main sprite representing Tux */
 


### PR DESCRIPTION
You need to press the button again to drop the object
Holding the Action button on a phone makes it impossible to press the Jump button
Also prevents Tux from blasting a stunned Mr. Ice Block with a fireball when trying to pick him up