### PR TITLE
Improvements to profile management + unlimited profiles

### DIFF
--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -138,12 +138,12 @@ Config::load()
     {
       if (profile_node.get_name() == "profile")
       {
-        auto profile = profile_node.get_mapping();
+        auto current_profile = profile_node.get_mapping();
 
         int id;
         std::string name;
-        if (profile.get("id", id) &&
-            profile.get("name", name))
+        if (current_profile.get("id", id) &&
+            current_profile.get("name", name))
         {
           profiles.push_back({id, name});
         }
@@ -333,11 +333,11 @@ Config::save()
   writer.write("profile", profile);
 
   writer.start_list("profiles");
-  for (const auto& profile : profiles)
+  for (const auto& current_profile : profiles)
   {
     writer.start_list("profile");
-    writer.write("id", profile.id);
-    writer.write("name", profile.name);
+    writer.write("id", current_profile.id);
+    writer.write("name", current_profile.name);
     writer.end_list("profile");
   }
   writer.end_list("profiles");

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -40,6 +40,13 @@ public:
 
   int profile;
 
+  struct Profile
+  {
+    int id;
+    std::string name;
+  };
+  std::vector<Profile> profiles;
+
   /** the width/height to be used to display the game in fullscreen */
   Size fullscreen_size;
 

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -224,7 +224,7 @@ namespace savegames_util {
   std::vector<int> get_savegames()
   {
     std::vector<int> savegames;
-    char **rc = PHYSFS_enumerateFiles("profiles");
+    char **rc = PHYSFS_enumerateFiles("/");
     char **i;
     for (i = rc; *i != nullptr; i++)
     if (std::string(*i).substr(0, 7) == "profile") savegames.push_back(std::stoi(std::string(*i).substr(7)));

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -170,7 +170,7 @@ ProfileMenu::menu_action(MenuItem& item)
       fmt::runtime(_("This will reset all game progress on the profile \"{}\".\nAre you sure?")),
       m_profile_names[g_config->profile - 1]);
 
-    Dialog::show_confirmation(message, [this]() {
+    Dialog::show_confirmation(message, []() {
       savegames_util::delete_savegames(g_config->profile, true);
     });
   }

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2008 Ingo Ruhnke <grumbel@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,6 +18,7 @@
 #include "supertux/menu/profile_menu.hpp"
 
 #include <fmt/format.h>
+#include <physfs.h>
 #include <sstream>
 
 #include "gui/dialog.hpp"
@@ -24,31 +26,116 @@
 #include "gui/menu_item.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
+#include "supertux/menu/profile_name_menu.hpp"
 #include "util/file_system.hpp"
 #include "util/gettext.hpp"
+#include "util/log.hpp"
 
-#include <physfs.h>
-
-ProfileMenu::ProfileMenu()
+ProfileMenu::ProfileMenu() :
+  m_profiles(),
+  m_profile_names()
 {
+  refresh();
+}
+
+void
+ProfileMenu::refresh()
+{
+  m_profiles = savegames_util::get_savegames();
+  m_profile_names.clear();
+
+  rebuild_menu();
+}
+
+void
+ProfileMenu::rebuild_menu()
+{
+  clear();
   add_label(_("Select Profile"));
   add_hl();
-  for (int i = 1; i <= 5; ++i)
+  if (m_profiles.empty()) add_inactive(_("No profiles found."));
+  bool has_selected_profile = false;
+  for (std::size_t i = 0; i < m_profiles.size(); ++i)
   {
-    std::ostringstream out;
-    if (i == g_config->profile)
+    int id = m_profiles[i];
+    std::string name;
+    for (std::size_t y = 0; y < g_config->profiles.size(); ++y)
     {
-      out << fmt::format(fmt::runtime(_("[Profile {}]")), i);
+      if (g_config->profiles[y].id == id)
+        name = g_config->profiles[y].name;
+    }
+    std::string text;
+    if (name.empty())
+    {
+      text = fmt::format(fmt::runtime(_("profile{}")), id);
     }
     else
     {
-      out << fmt::format(fmt::runtime(_("Profile {}")), i);
+      text = name;
     }
-    add_entry(i, out.str());
+    m_profile_names.push_back(text);
+
+    if (id == g_config->profile)
+    {
+      text = fmt::format(fmt::runtime(_("[{}]")), text);
+      has_selected_profile = true;
+    }
+    if (g_config->developer_mode && !name.empty())
+      text = fmt::format(fmt::runtime(_("{} (profile{})")), text, id);
+
+    add_entry(id, text);
+    if (id == g_config->profile) set_active_item(id);
+  }
+
+  if (!has_selected_profile && !m_profiles.empty())
+  {
+    add_hl();
+    add_inactive(_("No profile selected."));
+  }
+
+  add_hl();
+  add_entry(-1, _("Add"));
+  if (has_selected_profile)
+  {
+    add_entry(-2, _("Rename"));
+  }
+  else
+  {
+    add_inactive(_("Rename"));
   }
   add_hl();
-  add_entry(6, _("Reset profile"));
-  add_entry(7, _("Reset all profiles"));
+  if (has_selected_profile)
+  {
+    add_entry(-3, _("Reset"));
+  }
+  else
+  {
+    add_inactive(_("Reset"));
+  }
+  if (!m_profiles.empty())
+  {
+    add_entry(-4, _("Reset all"));
+  }
+  else
+  {
+    add_inactive(_("Reset all"));
+  }
+  if (has_selected_profile)
+  {
+    add_entry(-5, _("Delete"));
+  }
+  else
+  {
+    add_inactive(_("Delete"));
+  }
+  if (!m_profiles.empty())
+  {
+    add_entry(-6, _("Delete all"));
+  }
+  else
+  {
+    add_inactive(_("Delete all"));
+  }
 
   add_hl();
   add_back(_("Back"));
@@ -58,40 +145,107 @@ void
 ProfileMenu::menu_action(MenuItem& item)
 {
   const auto& id = item.get_id();
-  if(id <= 5)
+  if (id > 0)
   {
-    g_config->profile = item.get_id();
+    if (g_config->profile == id)
+    {
+      MenuManager::instance().clear_menu_stack();
+      return;
+    }
+    g_config->profile = id;
+    rebuild_menu();
   }
-  else if(id == 6)
+  else if (id == -1)
   {
-    Dialog::show_confirmation(_("Deleting your profile will reset your game progress. Are you sure?"), [this]() {
-      delete_savegames(g_config->profile);
+    MenuManager::instance().push_menu(std::make_unique<ProfileNameMenu>(false));
+  }
+  else if (id == -2)
+  {
+    MenuManager::instance().push_menu(std::make_unique<ProfileNameMenu>(true,
+    g_config->profile, m_profile_names[g_config->profile - 1]));
+  }
+  else if (id == -3)
+  {
+    const std::string message = fmt::format(
+      fmt::runtime(_("This will reset all game progress on the profile \"{}\".\nAre you sure?")),
+      m_profile_names[g_config->profile - 1]);
+
+    Dialog::show_confirmation(message, [this]() {
+      savegames_util::delete_savegames(g_config->profile, true);
     });
   }
-  else if(id == 7)
+  else if (id == -4)
   {
     Dialog::show_confirmation(_("This will reset your game progress on all profiles. Are you sure?"), [this]() {
-      for (int i = 1; i <= 5; i++) {
-        delete_savegames(i);
+      for (std::size_t i = 0; i <= m_profiles.size(); i++)
+      {
+        savegames_util::delete_savegames(m_profiles[i], true);
       }
     });
   }
-  MenuManager::instance().clear_menu_stack();
+  else if (id == -5)
+  {
+    const std::string message = fmt::format(
+    fmt::runtime(_("This will delete the profile \"{}\",\nincluding all game progress on it. Are you sure?")),
+    m_profile_names[g_config->profile - 1]);
+
+    Dialog::show_confirmation(message, [this]() {
+      savegames_util::delete_savegames(g_config->profile);
+      g_config->profiles.erase(
+        std::remove_if(g_config->profiles.begin(),
+          g_config->profiles.end(),
+          [](const auto& profile){
+            return profile.id == g_config->profile;
+          }),
+        g_config->profiles.end());
+      g_config->profile = 1;
+      refresh();
+    });
+  }
+  else if (id == -6)
+  {
+    Dialog::show_confirmation(_("This will delete all profiles, including all game progress on them.\nAre you sure?"), [this]() {
+      for (std::size_t i = 0; i <= m_profiles.size(); i++)
+      {
+        savegames_util::delete_savegames(m_profiles[i]);
+      }
+      g_config->profiles.clear();
+      g_config->profile = 1;
+      refresh();
+    });
+  }
+  else
+  {
+    log_warning << "Unknown menu item with id \"" << id << "\" pressed." << std::endl;
+  }
 }
 
-void
-ProfileMenu::delete_savegames(int idx) const
-{
-  const auto& profile_path = "profile" + std::to_string(idx);
-  std::unique_ptr<char*, decltype(&PHYSFS_freeList)>
-    files(PHYSFS_enumerateFiles(profile_path.c_str()),
-          PHYSFS_freeList);
-  for (const char* const* filename = files.get(); *filename != nullptr; ++filename)
+namespace savegames_util {
+  std::vector<int> get_savegames()
   {
-    std::string filepath = FileSystem::join(profile_path.c_str(), *filename);
-    PHYSFS_delete(filepath.c_str());
+    std::vector<int> savegames;
+    char **rc = PHYSFS_enumerateFiles("profiles");
+    char **i;
+    for (i = rc; *i != nullptr; i++)
+    if (std::string(*i).substr(0, 7) == "profile") savegames.push_back(std::stoi(std::string(*i).substr(7)));
+    PHYSFS_freeList(rc);
+    std::sort(savegames.begin(), savegames.end());
+    return savegames;
   }
-  PHYSFS_delete(profile_path.c_str());
-}
+
+  void delete_savegames(int idx, bool reset)
+  {
+    const auto& profile_path = "profiles/profile" + std::to_string(idx);
+    std::unique_ptr<char*, decltype(&PHYSFS_freeList)>
+    files(PHYSFS_enumerateFiles(profile_path.c_str()),
+        PHYSFS_freeList);
+    for (const char* const* filename = files.get(); *filename != nullptr; ++filename)
+    {
+      std::string filepath = FileSystem::join(profile_path.c_str(), *filename);
+      PHYSFS_delete(filepath.c_str());
+    }
+    if (!reset) PHYSFS_delete(profile_path.c_str());
+  }
+} // namespace savegames_util
 
 /* EOF */

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -162,7 +162,7 @@ ProfileMenu::menu_action(MenuItem& item)
   else if (id == -2)
   {
     MenuManager::instance().push_menu(std::make_unique<ProfileNameMenu>(true,
-    g_config->profile, m_profile_names[g_config->profile - 1]));
+      g_config->profile, m_profile_names[g_config->profile - 1]));
   }
   else if (id == -3)
   {
@@ -227,7 +227,9 @@ namespace savegames_util {
     char **rc = PHYSFS_enumerateFiles("/");
     char **i;
     for (i = rc; *i != nullptr; i++)
-    if (std::string(*i).substr(0, 7) == "profile") savegames.push_back(std::stoi(std::string(*i).substr(7)));
+    {
+      if (std::string(*i).substr(0, 7) == "profile") savegames.push_back(std::stoi(std::string(*i).substr(7)));
+    }
     PHYSFS_freeList(rc);
     std::sort(savegames.begin(), savegames.end());
     return savegames;

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -235,7 +235,7 @@ namespace savegames_util {
 
   void delete_savegames(int idx, bool reset)
   {
-    const auto& profile_path = "profiles/profile" + std::to_string(idx);
+    const auto& profile_path = "profile" + std::to_string(idx);
     std::unique_ptr<char*, decltype(&PHYSFS_freeList)>
     files(PHYSFS_enumerateFiles(profile_path.c_str()),
         PHYSFS_freeList);

--- a/src/supertux/menu/profile_name_menu.cpp
+++ b/src/supertux/menu/profile_name_menu.cpp
@@ -20,13 +20,13 @@
 #include <physfs.h>
 
 #include "gui/dialog.hpp"
+#include "gui/item_textfield.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/menu/profile_menu.hpp"
 #include "util/gettext.hpp"
-#include "util/file_system.hpp"
 #include "util/log.hpp"
 
 ProfileNameMenu::ProfileNameMenu(bool rename, int id, std::string name) :
@@ -38,7 +38,8 @@ ProfileNameMenu::ProfileNameMenu(bool rename, int id, std::string name) :
   add_label(m_rename ? fmt::format(fmt::runtime(_("Rename \"{}\"")), m_current_profile_name) : _("Add profile"));
   add_hl();
 
-  add_textfield(_("Name"), &m_profile_name);
+  add_textfield(_("Name"), &m_profile_name)
+    .set_help(_("Profile names must have a maximum of 20 characters."));
 
   add_entry(1, m_rename ? _("Rename") : _("Create"));
 
@@ -65,10 +66,10 @@ ProfileNameMenu::menu_action(MenuItem& item)
     int id = 1;
     if (!savegames.empty()) id = savegames.back() + 1;
 
-    const std::string profile_path = FileSystem::join("profiles", "profile" + std::to_string(id));
+    const std::string profile_path = "profile" + std::to_string(id);
     if (!PHYSFS_mkdir(profile_path.c_str()))
     {
-      log_warning << "Error creating folder for profile " << id << "." << std::endl;
+      log_warning << "Error creating folder for profile " << id << std::endl;
       Dialog::show_message(_("An error occured while creating the profile."));
       return;
     }

--- a/src/supertux/menu/profile_name_menu.cpp
+++ b/src/supertux/menu/profile_name_menu.cpp
@@ -1,0 +1,104 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/menu/profile_name_menu.hpp"
+
+#include <fmt/format.h>
+#include <physfs.h>
+
+#include "gui/dialog.hpp"
+#include "gui/menu_item.hpp"
+#include "gui/menu_manager.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/menu/profile_menu.hpp"
+#include "util/gettext.hpp"
+#include "util/file_system.hpp"
+#include "util/log.hpp"
+
+ProfileNameMenu::ProfileNameMenu(bool rename, int id, std::string name) :
+  m_rename(rename),
+  m_current_profile_id(id),
+  m_current_profile_name(name),
+  m_profile_name()
+{
+  add_label(m_rename ? fmt::format(fmt::runtime(_("Rename \"{}\"")), m_current_profile_name) : _("Add profile"));
+  add_hl();
+
+  add_textfield(_("Name"), &m_profile_name);
+
+  add_entry(1, m_rename ? _("Rename") : _("Create"));
+
+  add_hl();
+  add_back(_("Back"));
+}
+
+void
+ProfileNameMenu::menu_action(MenuItem& item)
+{
+  if (item.get_id() <= 0)
+    return;
+
+  if (m_profile_name.size() > 20)
+  {
+    Dialog::show_message(_("Profile names must have a maximum of 20 characters.\nPlease choose a different name."));
+    return;
+  }
+
+  if (!m_rename)
+  {
+    //Find the smallest available profile ID.
+    const std::vector<int> savegames = savegames_util::get_savegames();
+    int id = 1;
+    if (!savegames.empty()) id = savegames.back() + 1;
+
+    const std::string profile_path = FileSystem::join("profiles", "profile" + std::to_string(id));
+    if (!PHYSFS_mkdir(profile_path.c_str()))
+    {
+      log_warning << "Error creating folder for profile " << id << "." << std::endl;
+      Dialog::show_message(_("An error occured while creating the profile."));
+      return;
+    }
+
+    //Delete ID from profile config data, in case it exists.
+    g_config->profiles.erase(
+      std::remove_if(g_config->profiles.begin(),
+      g_config->profiles.end(),
+      [id](const auto& profile) { 
+          return profile.id == id;
+      }), g_config->profiles.end());
+
+    if (!m_profile_name.empty()) g_config->profiles.push_back({id, m_profile_name});
+    g_config->profile = id;
+  }
+  else
+  {
+    //Delete ID from profile config data, in case it exists.
+    g_config->profiles.erase(
+      std::remove_if(g_config->profiles.begin(),
+      g_config->profiles.end(),
+      [this](const auto& profile) { 
+          return profile.id == m_current_profile_id;
+      }), g_config->profiles.end());
+
+    if (!m_profile_name.empty()) g_config->profiles.push_back({m_current_profile_id, m_profile_name});
+  }
+
+  MenuManager::instance().pop_menu();
+  MenuManager::instance().current_menu()->refresh();
+}
+
+/* EOF */

--- a/src/supertux/menu/profile_name_menu.hpp
+++ b/src/supertux/menu/profile_name_menu.hpp
@@ -1,6 +1,5 @@
 //  SuperTux
-//  Copyright (C) 2008 Ingo Ruhnke <grumbel@gmail.com>
-//                2022 Vankata453
+//  Copyright (C) 2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -15,31 +14,30 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_PROFILE_MENU_HPP
-#define HEADER_SUPERTUX_SUPERTUX_MENU_PROFILE_MENU_HPP
+#ifndef HEADER_SUPERTUX_SUPERTUX_PROFILE_NAME_MENU_HPP
+#define HEADER_SUPERTUX_SUPERTUX_PROFILE_NAME_MENU_HPP
 
 #include "gui/menu.hpp"
 
-class ProfileMenu final : public Menu
+class ProfileNameMenu final : public Menu
 {
 private:
-  std::vector<int> m_profiles;
-  std::vector<std::string> m_profile_names;
+  const bool m_rename;
+  const int m_current_profile_id;
+  const std::string m_current_profile_name;
+  std::string m_profile_name;
 
 public:
-  ProfileMenu();
+  ProfileNameMenu(bool rename = false, int id = 0, std::string name = "");
 
-  void refresh() override;
-  void rebuild_menu();
   void menu_action(MenuItem& item) override;
-};
 
-namespace savegames_util
-{
-  std::vector<int> get_savegames();
-  void delete_savegames(int idx, bool reset = false);
-}
+private:
+  ProfileNameMenu(const ProfileNameMenu&) = delete;
+  ProfileNameMenu& operator=(const ProfileNameMenu&) = delete;
+};
 
 #endif
 
 /* EOF */
+ 

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -182,7 +182,7 @@ World::get_savegame_filename() const
 {
   const std::string worlddirname = FileSystem::basename(m_basedir);
   std::ostringstream stream;
-  stream << "profiles/profile" << g_config->profile << "/" << worlddirname << ".stsg";
+  stream << "profile" << g_config->profile << "/" << worlddirname << ".stsg";
   return stream.str();
 }
 

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -182,7 +182,7 @@ World::get_savegame_filename() const
 {
   const std::string worlddirname = FileSystem::basename(m_basedir);
   std::ostringstream stream;
-  stream << "profile" << g_config->profile << "/" << worlddirname << ".stsg";
+  stream << "profiles/profile" << g_config->profile << "/" << worlddirname << ".stsg";
   return stream.str();
 }
 


### PR DESCRIPTION
Makes additions to the profile management system:

1. Allows to create an unlimited amount of profiles, all of which are name-able. Profiles are created as folders in the format `profile{id}`, as well as added to the `profiles` section in the config file, where their respective IDs and names are stored. Names are limited to a maximum of 20 characters. The abilities to add and rename these profiles, as well as do so with a default name, were also added.
2. Aside from the "Reset" and "Reset All" options, "Delete" and "Delete All" were added, which allow the user to delete the currently selected profile, or all profiles. If all profiles are deleted, the next one to be created will be 1.

<details>
<summary>Screenshots</summary>

![Main profiles menu](https://user-images.githubusercontent.com/78196474/177310595-bdbca106-0a1d-4c90-a1e3-f1bcfd0175f9.png)
![Adding a new profile](https://user-images.githubusercontent.com/78196474/177310701-883fae57-8221-4a58-abd0-870eb965e97e.png)
![Renaming an existing profile](https://user-images.githubusercontent.com/78196474/177310804-619cb010-5bac-4598-9ce7-fa4be3e36b9b.png)
</details>

Closes #485.