### PR TITLE
Group repeating tiles to render long strips of tiles as a single GL rectangle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ supertux.*
 
 # Useful Customization Files
 data/levels/more/
+data/tilecache
 *.patch
 *.zip
 *.diff

--- a/data/shader/shader100.frag
+++ b/data/shader/shader100.frag
@@ -12,18 +12,19 @@ uniform vec2 animate;
 uniform vec2 displacement_animate;
 
 varying vec2 texcoord_var;
+varying vec4 texcoord_repeat_var;
 varying vec4 diffuse_var;
 
 void main(void)
 {
   if (backbuffer == 0.0)
   {
-    vec4 color = diffuse_var * texture2D(diffuse_texture, texcoord_var.st + (animate * game_time));
+    vec4 color = diffuse_var * texture2D(diffuse_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (animate * game_time));
     gl_FragColor = color;
   }
   else
   {
-    vec4 pixel = texture2D(displacement_texture, texcoord_var.st + (displacement_animate * game_time));
+    vec4 pixel = texture2D(displacement_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (displacement_animate * game_time));
     vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * 255.0;
     float alpha = pixel.a;
 
@@ -31,7 +32,7 @@ void main(void)
     uv = vec2(uv.x, 1.0 - uv.y);
     vec4 back_color = texture2D(framebuffer_texture, uv);
 
-    vec4 color =  diffuse_var * texture2D(diffuse_texture, texcoord_var.st + (animate * game_time));
+    vec4 color =  diffuse_var * texture2D(diffuse_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (animate * game_time));
     gl_FragColor = vec4(mix(color.rgb, back_color.rgb, alpha), color.a);
   }
 }

--- a/data/shader/shader100.vert
+++ b/data/shader/shader100.vert
@@ -1,10 +1,12 @@
 #version 100
 
 attribute vec2 texcoord;
+attribute vec4 texcoord_repeat;
 attribute vec2 position;
 attribute vec4 diffuse;
 
 varying mediump vec2 texcoord_var;
+varying mediump vec4 texcoord_repeat_var;
 varying lowp vec4 diffuse_var;
 
 uniform mat3 modelviewprojection;
@@ -12,6 +14,7 @@ uniform mat3 modelviewprojection;
 void main(void)
 {
   texcoord_var = texcoord;
+  texcoord_repeat_var = texcoord_repeat;
   diffuse_var = diffuse;
   gl_Position = vec4(vec3(position, 1) * modelviewprojection, 1.0);
 }

--- a/data/shader/shader330.frag
+++ b/data/shader/shader330.frag
@@ -10,6 +10,7 @@ uniform vec2 animate;
 uniform vec2 displacement_animate;
 
 in vec4 diffuse_var;
+in vec4 texcoord_repeat_var;
 in vec2 texcoord_var;
 
 out vec4 fragColor;
@@ -18,12 +19,12 @@ void main(void)
 {
   if (backbuffer == 0.0)
   {
-    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_var.st + (animate * game_time));
+    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (animate * game_time));
     fragColor = color;
   }
   else if (true)
   {
-    vec4 pixel = texture(displacement_texture, texcoord_var.st + (displacement_animate * game_time));
+    vec4 pixel = texture(displacement_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (displacement_animate * game_time));
     vec2 displacement = (pixel.rg - vec2(0.5, 0.5)) * 255;
     float alpha = pixel.a;
 
@@ -31,13 +32,13 @@ void main(void)
     uv = vec2(uv.x, 1.0 - uv.y);
     vec4 back_color = texture(framebuffer_texture, uv);
 
-    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_var.st + (animate * game_time));
+    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq) + (animate * game_time));
     fragColor = vec4(mix(color.rgb, back_color.rgb, alpha), color.a);
   }
   else
   {
     // water reflection
-    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_var.st);
+    vec4 color =  diffuse_var * texture(diffuse_texture, texcoord_repeat_var.st + mod(texcoord_var.st, texcoord_repeat_var.pq));
     vec2 uv = (fragcoord2uv * gl_FragCoord.xyw).xy + vec2(0, 0.05);
     uv.x = uv.x + 0.005 * sin(game_time + uv.y * 100);
     uv = vec2(uv.x, 1.0 - uv.y);

--- a/data/shader/shader330.vert
+++ b/data/shader/shader330.vert
@@ -1,17 +1,20 @@
 #version 330 core
 
 in vec2 texcoord;
+in vec4 texcoord_repeat;
 in vec2 position;
 in vec4 diffuse;
 
-out vec2 texcoord_var;
 out vec4 diffuse_var;
+out vec4 texcoord_repeat_var;
+out vec2 texcoord_var;
 
 uniform mat3 modelviewprojection;
 
 void main(void)
 {
   texcoord_var = texcoord;
+  texcoord_repeat_var = texcoord_repeat;
   diffuse_var = diffuse;
   gl_Position = vec4(vec3(position, 1) * modelviewprojection, 1.0);
 }

--- a/src/math/find_rects.cpp
+++ b/src/math/find_rects.cpp
@@ -1,0 +1,195 @@
+// This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+// Algorithm was taken from here: http://stackoverflow.com/a/20039017/624766
+// http://www.drdobbs.com/database/the-maximal-rectangle-problem/184410529
+
+#include <stdlib.h>
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+#include "find_rects.hpp"
+
+namespace FindRects {
+
+struct Pair {
+	int x;
+	int y;
+	Pair(int a, int b): x(a), y(b) {}
+};
+
+/** A rectangle, (x,y) is the upper-left corner, coordinates start at (0,0)
+	TODO: replace it with Rect from rect.hpp */
+struct Rect {
+	int x;
+	int y;
+	int w;
+	int h;
+	Rect(int X, int Y, int W, int H): x(X), y(Y), w(W), h(H) {}
+};
+
+static void update_cache(std::vector<int> *c, int n, int M, int rowWidth, const InputType* input) {
+	for (int m = 0; m != M; ++m) {
+		if (input[n * rowWidth + m] != 0) {
+			(*c)[m]++;
+		} else {
+			(*c)[m] = 0;
+		}
+	}
+}
+
+static Rect findBiggest(const InputType* input, int M, int N, int rowWidth) {
+
+	Pair best_ll(0, 0); /* Lower-left corner */
+	Pair best_ur(-1, -1); /* Upper-right corner */
+	int best_area = 0;
+	int best_perimeter = 0;
+
+	std::vector<int> c(M + 1, 0); /* Cache */
+	std::vector<Pair> s; /* Stack */
+	s.reserve(M + 1);
+
+	int m, n;
+
+	/* Main algorithm: */
+	for (n = 0; n != N; ++n) {
+		int open_width = 0;
+		update_cache(&c, n, M, rowWidth, input);
+		for (m = 0; m != M + 1; ++m) {
+			if (c[m] > open_width) { /* Open new rectangle? */
+				s.push_back(Pair(m, open_width));
+				open_width = c[m];
+			} else if (c[m] < open_width) { /* Close rectangle(s)? */
+				int m0, w0, area, perimeter;
+				do {
+					m0 = s.back().x;
+					w0 = s.back().y;
+					s.pop_back();
+					area = open_width * (m - m0);
+					perimeter = open_width + (m - m0);
+					/* If the area is the same, prefer squares over long narrow rectangles,
+						it finds more rectangles this way when calling findAll() with minLength == 2 or more */
+					if (area > best_area || (area == best_area && perimeter < best_perimeter)) {
+						best_area = area;
+						best_perimeter = perimeter;
+						best_ll.x = m0;
+						best_ll.y = n;
+						best_ur.x = m - 1;
+						best_ur.y = n - open_width + 1;
+					}
+					open_width = w0;
+				} while (c[m] < open_width);
+				open_width = c[m];
+				if (open_width != 0) {
+					s.push_back(Pair(m0, w0));
+				}
+			}
+		}
+	}
+	return Rect(best_ll.x, std::max(0, best_ur.y), 1 + best_ur.x - best_ll.x, 1 + best_ll.y - best_ur.y);
+}
+
+//#define CHECK_BOTH_WAYS 1 /* This will make the algorithm terribly slow, with a factorial complexity */
+
+/** Find biggest rectangle, then recursively search area to the left/right and to the top/bottom of that rectangle
+	for smaller rectangles, and choose the one that covers biggest area.
+	@return biggest area size, covered by rectangles with side length = maxLength or bigger,
+	@param search: limit searching for the following area
+	@param output: may be nullptr, then the function will only return the area size
+*/
+
+static long long findRectsInArea (const InputType* input, int rowWidth, int minLength, OutputType* output, Rect search) {
+	if (search.w < minLength || search.h < minLength) {
+		return 0; // We reached a size limit
+	}
+	Rect biggest = findBiggest(input + search.y * rowWidth + search.x, search.w, search.h, rowWidth);
+
+	if (biggest.w < minLength || biggest.h < minLength) {
+		return 0; // No rectangles here
+	}
+	biggest.x += search.x;
+	biggest.y += search.y;
+	if (biggest.w > OUTPUT_MAX_LENGTH) {
+		biggest.w = OUTPUT_MAX_LENGTH;
+	}
+	if (biggest.h > OUTPUT_MAX_LENGTH) {
+		biggest.h = OUTPUT_MAX_LENGTH;
+	}
+	/* We got two choices to split remaining area into four rectangular regions, where (B) is the biggest rectangle:
+		****|***|***				************
+		****|***|***				************
+		****BBBBB***				----BBBBB---
+		****BBBBB***		vs		****BBBBB***
+		****BBBBB***				----BBBBB---
+		****|***|***				************
+		We are not filling the output array in the first recursive call, it's just for determining the resulting area size
+	*/
+
+	if (output != nullptr) {
+		for (int y = biggest.y; y < biggest.y + biggest.h; y++) {
+			for (int x = biggest.x; x < biggest.x + biggest.w; x++) {
+				output[(y * rowWidth + x) * 2] = 0;
+				output[(y * rowWidth + x) * 2 + 1] = 0;
+			}
+		}
+		output[(biggest.y * rowWidth + biggest.x) * 2] = static_cast<OutputType>(biggest.w);
+		output[(biggest.y * rowWidth + biggest.x) * 2 + 1] = static_cast<OutputType>(biggest.h);
+	}
+
+#ifdef CHECK_BOTH_WAYS
+	long long splitHorizArea =
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(search.x, search.y, biggest.x - search.x, search.h)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(biggest.x + biggest.w, search.y, search.x + search.w - biggest.x - biggest.w, search.h)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(biggest.x, search.y, biggest.w, biggest.y - search.y)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(biggest.x, biggest.y + biggest.h, biggest.w, search.y + search.h - biggest.y - biggest.h));
+
+	long long splitVertArea =
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(search.x, search.y, search.w, biggest.y - search.y)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(search.x, biggest.y + biggest.h, search.w, search.y + search.h - biggest.y - biggest.h)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(search.x, biggest.y, biggest.x - search.x, biggest.h)) +
+		findRectsInArea(input, rowWidth, minLength, nullptr,
+			Rect(biggest.x + biggest.w, biggest.y, search.x + search.w - biggest.x - biggest.w, biggest.h));
+
+	/* Inefficiently perform the recursive call again, this time with non-nullptr output array */
+	if (splitHorizArea > splitVertArea) {
+		if (output != nullptr) {
+#endif
+			return static_cast<long long>(biggest.w) * biggest.h +
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(search.x, search.y, biggest.x - search.x, search.h)) +
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(biggest.x + biggest.w, search.y, search.x + search.w - biggest.x - biggest.w, search.h)) +
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(biggest.x, search.y, biggest.w, biggest.y - search.y)) +
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(biggest.x, biggest.y + biggest.h, biggest.w, search.y + search.h - biggest.y - biggest.h));
+#ifdef CHECK_BOTH_WAYS
+		}
+		return splitHorizArea + static_cast<long long>(biggest.w) * biggest.h;
+	} else {
+		if (output != nullptr) {
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(search.x, search.y, search.w, biggest.y - search.y));
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(search.x, biggest.y + biggest.h, search.w, search.y + search.h - biggest.y - biggest.h));
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(search.x, biggest.y, biggest.x - search.x, biggest.h));
+			findRectsInArea(input, rowWidth, minLength, output,
+				Rect(biggest.x + biggest.w, biggest.y, search.x + search.w - biggest.x - biggest.w, biggest.h));
+		}
+		return splitVertArea + static_cast<long long>(biggest.w) * biggest.h;
+	}
+#endif
+}
+
+long long findAll (const InputType* input, int width, int height, int minLength, OutputType* output) {
+	return findRectsInArea(input, width, minLength, output, Rect(0, 0, width, height));
+}
+
+} /* namespace */

--- a/src/math/find_rects.hpp
+++ b/src/math/find_rects.hpp
@@ -1,0 +1,27 @@
+// This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+// Algorithm was taken from here: http://stackoverflow.com/a/20039017/624766
+// http://www.drdobbs.com/database/the-maximal-rectangle-problem/184410529
+
+#ifndef __FIND_RECTS_HPP__
+#define __FIND_RECTS_HPP__
+
+#include <climits>
+
+namespace FindRects {
+
+	/** Input aray type, typically the smallest integral type */
+	typedef unsigned char InputType;
+	/** Output array type, which consists of the width and height of any given rectangle at this point */
+	typedef unsigned char OutputType;
+	enum { OUTPUT_MAX_LENGTH = UCHAR_MAX };
+
+	/** Split an area into rectangles, trying to cover as much area as possible
+		@param minLength: minimal length of the rectangle side, can be 1 to count every element in the array
+		@param output: output array of width x height * 2, where each two elements are width/height of a rectangle's top-left corner, or 0 if the area is inside a rectangle
+		@return total area size of all rectangles, covered by rectangles with side length = maxLength or bigger,
+	*/
+	long long findAll (const InputType* input, int width, int height, int minLength, OutputType* output);
+
+}
+
+#endif

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -222,6 +222,10 @@ private:
   typedef std::vector<uint32_t> Tiles;
   Tiles m_tiles;
 
+  typedef std::vector<unsigned char> TilesDrawRects;
+  TilesDrawRects m_tiles_draw_rects; /**< Tiles draw cache, with adjacent tiles merged into big rectangles */
+  bool m_draw_rects_update;
+
   /* read solid: In *general*, is this a solid layer? effective solid:
      is the layer *currently* solid? A generally solid layer may be
      not solid when its alpha is low. See `is_solid' above. */
@@ -267,6 +271,9 @@ private:
 private:
   TileMap(const TileMap&) = delete;
   TileMap& operator=(const TileMap&) = delete;
+
+  void calculateDrawRects(bool useCache = false);
+  void calculateDrawRects(uint32_t oldtile, uint32_t newtile);
 };
 
 #endif

--- a/src/video/canvas.cpp
+++ b/src/video/canvas.cpp
@@ -132,6 +132,7 @@ Canvas::draw_surface(const SurfacePtr& surface,
                                  Sizef(static_cast<float>(surface->get_width()) * scale(),
                                        static_cast<float>(surface->get_height()) * scale())));
   request->angles.emplace_back(angle);
+  request->repeats.emplace_back(Size(1, 1));
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();
   request->color = color;
@@ -170,6 +171,7 @@ Canvas::draw_surface_part(const SurfacePtr& surface, const Rectf& srcrect, const
   request->srcrects.emplace_back(srcrect);
   request->dstrects.emplace_back(apply_translate(dstrect.p1())*scale(), dstrect.get_size()*scale());
   request->angles.emplace_back(0.0f);
+  request->repeats.emplace_back(Size(1, 1));
   request->texture = surface->get_texture().get();
   request->displacement_texture = surface->get_displacement_texture().get();
   request->color = style.get_color();
@@ -200,6 +202,41 @@ Canvas::draw_surface_batch(const SurfacePtr& surface,
                            const Color& color,
                            int layer)
 {
+  const size_t len = srcrects.size();
+  draw_surface_batch(surface,
+                     std::move(srcrects),
+                     std::move(dstrects),
+                     std::move(angles),
+                     std::vector<Size>(len, Size(1, 1)),
+                     color, layer);
+}
+
+void
+Canvas::draw_surface_batch(const SurfacePtr& surface,
+                           std::vector<Rectf> srcrects,
+                           std::vector<Rectf> dstrects,
+                           std::vector<Size> repeats,
+                           const Color& color,
+                           int layer)
+{
+  const size_t len = srcrects.size();
+  draw_surface_batch(surface,
+                     std::move(srcrects),
+                     std::move(dstrects),
+                     std::vector<float>(len, 0.0f),
+                     std::move(repeats),
+                     color, layer);
+}
+
+void
+Canvas::draw_surface_batch(const SurfacePtr& surface,
+                           std::vector<Rectf> srcrects,
+                           std::vector<Rectf> dstrects,
+                           std::vector<float> angles,
+                           std::vector<Size> repeats,
+                           const Color& color,
+                           int layer)
+{
   if (!surface) return;
 
   auto request = new(m_obst) TextureRequest();
@@ -213,6 +250,7 @@ Canvas::draw_surface_batch(const SurfacePtr& surface,
   request->srcrects = std::move(srcrects);
   request->dstrects = std::move(dstrects);
   request->angles = std::move(angles);
+  request->repeats = std::move(repeats);
 
   for (auto& dstrect : request->dstrects)
   {

--- a/src/video/canvas.hpp
+++ b/src/video/canvas.hpp
@@ -67,6 +67,19 @@ public:
                           std::vector<float> angles,
                           const Color& color,
                           int layer);
+  void draw_surface_batch(const SurfacePtr& surface,
+                          std::vector<Rectf> srcrects,
+                          std::vector<Rectf> dstrects,
+                          std::vector<Size> repeats,
+                          const Color& color,
+                          int layer);
+  void draw_surface_batch(const SurfacePtr& surface,
+                          std::vector<Rectf> srcrects,
+                          std::vector<Rectf> dstrects,
+                          std::vector<float> angles,
+                          std::vector<Size> repeats,
+                          const Color& color,
+                          int layer);
   void draw_text(const FontPtr& font, const std::string& text,
                  const Vector& position, FontAlignment alignment, int layer, const Color& color = Color(1.0,1.0,1.0));
   /** Draw text to the center of the screen */

--- a/src/video/compositor.cpp
+++ b/src/video/compositor.cpp
@@ -127,6 +127,7 @@ Compositor::render()
                                       static_cast<float>(texture->get_image_height()));
         request.dstrects.emplace_back(Vector(0.0f, 0.0f), lightmap.get_logical_size());
         request.angles.emplace_back(0.0f);
+        request.repeats.emplace_back(Size(1, 1));
 
         request.texture = texture.get();
         request.color = Color::WHITE;

--- a/src/video/drawing_request.hpp
+++ b/src/video/drawing_request.hpp
@@ -63,6 +63,7 @@ struct TextureRequest : public DrawingRequest
     srcrects(),
     dstrects(),
     angles(),
+    repeats(),
     color(1.0f, 1.0f, 1.0f)
   {}
 
@@ -71,6 +72,7 @@ struct TextureRequest : public DrawingRequest
   std::vector<Rectf> srcrects;
   std::vector<Rectf> dstrects;
   std::vector<float> angles;
+  std::vector<Size> repeats;
   Color color;
 
 private:

--- a/src/video/gl/gl20_context.cpp
+++ b/src/video/gl/gl20_context.cpp
@@ -104,6 +104,11 @@ GL20Context::set_texcoords(const float* data, size_t size)
 }
 
 void
+GL20Context::set_texcoords_repeat(const float* data, size_t size)
+{
+}
+
+void
 GL20Context::set_texcoord(float u, float v)
 {
   assert_gl();

--- a/src/video/gl/gl20_context.hpp
+++ b/src/video/gl/gl20_context.hpp
@@ -38,6 +38,7 @@ public:
   virtual void set_positions(const float* data, size_t size) override;
 
   virtual void set_texcoords(const float* data, size_t size) override;
+  virtual void set_texcoords_repeat(const float* data, size_t size) override;
   virtual void set_texcoord(float u, float v) override;
 
   virtual void set_colors(const float* data, size_t size) override;

--- a/src/video/gl/gl33core_context.cpp
+++ b/src/video/gl/gl33core_context.cpp
@@ -68,12 +68,12 @@ GL33CoreContext::bind()
   if (back_renderer->is_rendering() || !back_renderer->get_texture())
   {
     texture = m_black_texture.get();
-    glUniform1f(m_program->get_uniform_location("backbuffer"), 0.0f);
+    glUniform1f(m_program->get_uniform_location(GLProgram::uniform_backbuffer), 0.0f);
   }
   else
   {
     texture = static_cast<GLTexture*>(back_renderer->get_texture().get());
-    glUniform1f(m_program->get_uniform_location("backbuffer"), 1.0f);
+    glUniform1f(m_program->get_uniform_location(GLProgram::uniform_backbuffer), 1.0f);
   }
 
   glActiveTexture(GL_TEXTURE2);
@@ -99,14 +99,14 @@ GL33CoreContext::bind()
     0.0, sy, 0,
     tx, ty, 1.0,
   };
-  glUniformMatrix3fv(m_program->get_uniform_location("fragcoord2uv"),
+  glUniformMatrix3fv(m_program->get_uniform_location(GLProgram::uniform_fragcoord2uv),
                      1, false, matrix);
 
-  glUniform1i(m_program->get_uniform_location("diffuse_texture"), 0);
-  glUniform1i(m_program->get_uniform_location("displacement_texture"), 1);
-  glUniform1i(m_program->get_uniform_location("framebuffer_texture"), 2);
+  glUniform1i(m_program->get_uniform_location(GLProgram::uniform_diffuse_texture), 0);
+  glUniform1i(m_program->get_uniform_location(GLProgram::uniform_displacement_texture), 1);
+  glUniform1i(m_program->get_uniform_location(GLProgram::uniform_framebuffer_texture), 2);
 
-  glUniform1f(m_program->get_uniform_location("game_time"), g_game_time);
+  glUniform1f(m_program->get_uniform_location(GLProgram::uniform_game_time), g_game_time);
 
   assert_gl();
 }
@@ -128,7 +128,7 @@ GL33CoreContext::ortho(float width, float height, bool vflip)
     0, 0, 1
   };
 
-  const GLint mvp_loc = m_program->get_uniform_location("modelviewprojection");
+  const GLint mvp_loc = m_program->get_uniform_location(GLProgram::uniform_modelviewprojection);
   glUniformMatrix3fv(mvp_loc, 1, false, mvp_matrix);
 
   assert_gl();
@@ -202,7 +202,7 @@ GL33CoreContext::bind_texture(const Texture& texture, const Texture* displacemen
     animate.x /= static_cast<float>(texture.get_image_width());
     animate.y /= static_cast<float>(texture.get_image_height());
 
-    glUniform2f(m_program->get_uniform_location("animate"), animate.x, animate.y);
+    glUniform2f(m_program->get_uniform_location(GLProgram::uniform_animate), animate.x, animate.y);
   }
 
   if (displacement_texture)
@@ -215,7 +215,7 @@ GL33CoreContext::bind_texture(const Texture& texture, const Texture* displacemen
     animate.x /= static_cast<float>(displacement_texture->get_image_width());
     animate.y /= static_cast<float>(displacement_texture->get_image_height());
 
-    glUniform2f(m_program->get_uniform_location("displacement_animate"), animate.x, animate.y);
+    glUniform2f(m_program->get_uniform_location(GLProgram::uniform_displacement_animate), animate.x, animate.y);
   }
   else
   {

--- a/src/video/gl/gl33core_context.cpp
+++ b/src/video/gl/gl33core_context.cpp
@@ -157,6 +157,12 @@ GL33CoreContext::set_texcoords(const float* data, size_t size)
 }
 
 void
+GL33CoreContext::set_texcoords_repeat(const float* data, size_t size)
+{
+  m_vertex_arrays->set_texcoords_repeat(data, size);
+}
+
+void
 GL33CoreContext::set_texcoord(float u, float v)
 {
   m_vertex_arrays->set_texcoord(u, v);

--- a/src/video/gl/gl33core_context.hpp
+++ b/src/video/gl/gl33core_context.hpp
@@ -43,6 +43,7 @@ public:
   virtual void set_positions(const float* data, size_t size) override;
 
   virtual void set_texcoords(const float* data, size_t size) override;
+  virtual void set_texcoords_repeat(const float* data, size_t size) override;
   virtual void set_texcoord(float u, float v) override;
 
   virtual void set_colors(const float* data, size_t size) override;

--- a/src/video/gl/gl_context.hpp
+++ b/src/video/gl/gl_context.hpp
@@ -43,6 +43,7 @@ public:
   virtual void set_positions(const float* data, size_t size) = 0;
 
   virtual void set_texcoords(const float* data, size_t size) = 0;
+  virtual void set_texcoords_repeat(const float* data, size_t size) = 0;
   virtual void set_texcoord(float u, float v) = 0;
 
   virtual void set_colors(const float* data, size_t size) = 0;

--- a/src/video/gl/gl_painter.hpp
+++ b/src/video/gl/gl_painter.hpp
@@ -50,6 +50,7 @@ private:
 private:
   std::vector<float> m_vertices;
   std::vector<float> m_uvs;
+  std::vector<float> m_uvs_repeat;
 
 private:
   GLPainter(const GLPainter&) = delete;

--- a/src/video/gl/gl_program.cpp
+++ b/src/video/gl/gl_program.cpp
@@ -50,6 +50,31 @@ GLProgram::GLProgram() :
   }
 
   assert_gl();
+
+  int i;
+  for (i = 0; i < attrib_max; i++)
+  {
+    m_attribs[i] = -1;
+  }
+  for (i = 0; i < uniform_max; i++)
+  {
+    m_uniforms[i] = -1;
+  }
+
+  m_attribs[attrib_position] = get_attrib_location("position");
+  m_attribs[attrib_texcoord] = get_attrib_location("texcoord");
+  m_attribs[attrib_texcoord_repeat] = get_attrib_location("texcoord_repeat");
+  m_attribs[attrib_diffuse] = get_attrib_location("diffuse");
+
+  m_uniforms[uniform_backbuffer] = get_uniform_location("backbuffer");
+  m_uniforms[uniform_fragcoord2uv] = get_uniform_location("fragcoord2uv");
+  m_uniforms[uniform_diffuse_texture] = get_uniform_location("diffuse_texture");
+  m_uniforms[uniform_displacement_texture] = get_uniform_location("displacement_texture");
+  m_uniforms[uniform_framebuffer_texture] = get_uniform_location("framebuffer_texture");
+  m_uniforms[uniform_game_time] = get_uniform_location("game_time");
+  m_uniforms[uniform_modelviewprojection] = get_uniform_location("modelviewprojection");
+  m_uniforms[uniform_animate] = get_uniform_location("animate");
+  m_uniforms[uniform_displacement_animate] = get_uniform_location("displacement_animate");
 }
 
 GLProgram::~GLProgram()

--- a/src/video/gl/gl_program.hpp
+++ b/src/video/gl/gl_program.hpp
@@ -34,10 +34,43 @@ public:
 
   GLuint get_handle() const { return m_program; }
 
+  enum GLAttribEnum
+  {
+    attrib_position,
+    attrib_texcoord,
+    attrib_texcoord_repeat,
+    attrib_diffuse,
+    attrib_max
+  };
+
+  enum GLUniformEnum
+  {
+    uniform_backbuffer,
+    uniform_fragcoord2uv,
+    uniform_diffuse_texture,
+    uniform_displacement_texture,
+    uniform_framebuffer_texture,
+    uniform_game_time,
+    uniform_modelviewprojection,
+    uniform_animate,
+    uniform_displacement_animate,
+    uniform_max
+  };
+
+  GLint get_attrib_location(GLAttribEnum name) const
+  {
+    return m_attribs[name];
+  }
+
+  GLint get_uniform_location(GLUniformEnum name) const
+  {
+    return m_uniforms[name];
+  }
+
+private:
   GLint get_attrib_location(const char* name) const;
   GLint get_uniform_location(const char* name) const;
 
-private:
   bool get_link_status() const;
   bool get_validate_status() const;
   std::string get_info_log() const;
@@ -47,6 +80,9 @@ private:
 
   std::unique_ptr<GLShader> m_frag_shader;
   std::unique_ptr<GLShader> m_vert_shader;
+  // std::map is too good for this kind of lookup
+  GLint m_attribs[attrib_max];
+  GLint m_uniforms[uniform_max];
 
 private:
   GLProgram(const GLProgram&) = delete;

--- a/src/video/gl/gl_vertex_arrays.cpp
+++ b/src/video/gl/gl_vertex_arrays.cpp
@@ -68,7 +68,7 @@ GLVertexArrays::set_positions(const float* data, size_t size)
   glBindBuffer(GL_ARRAY_BUFFER, m_positions_buffer);
   glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
 
-  int loc = m_context.get_program().get_attrib_location("position");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_position);
   glVertexAttribPointer(loc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
   glEnableVertexAttribArray(loc);
 
@@ -83,7 +83,7 @@ GLVertexArrays::set_texcoords(const float* data, size_t size)
   glBindBuffer(GL_ARRAY_BUFFER, m_texcoords_buffer);
   glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
 
-  int loc = m_context.get_program().get_attrib_location("texcoord");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_texcoord);
   glVertexAttribPointer(loc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
   glEnableVertexAttribArray(loc);
 
@@ -98,7 +98,7 @@ GLVertexArrays::set_texcoords_repeat(const float* data, size_t size)
   glBindBuffer(GL_ARRAY_BUFFER, m_texcoords_repeat_buffer);
   glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
 
-  int loc = m_context.get_program().get_attrib_location("texcoord_repeat");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_texcoord_repeat);
   glVertexAttribPointer(loc, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
   glEnableVertexAttribArray(loc);
 
@@ -110,8 +110,12 @@ GLVertexArrays::set_texcoord(float u, float v)
 {
   assert_gl();
 
-  int loc = m_context.get_program().get_attrib_location("texcoord");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_texcoord);
   glVertexAttrib2f(loc, u, v);
+  glDisableVertexAttribArray(loc);
+
+  loc = m_context.get_program().get_attrib_location(GLProgram::attrib_texcoord_repeat);
+  glVertexAttrib4f(loc, 0.0f, 0.0f, 1.0f, 1.0f);
   glDisableVertexAttribArray(loc);
 
   assert_gl();
@@ -125,7 +129,7 @@ GLVertexArrays::set_colors(const float* data, size_t size)
   glBindBuffer(GL_ARRAY_BUFFER, m_color_buffer);
   glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
 
-  int loc = m_context.get_program().get_attrib_location("diffuse");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_diffuse);
   glVertexAttribPointer(loc, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
   glEnableVertexAttribArray(loc);
 
@@ -137,7 +141,7 @@ GLVertexArrays::set_color(const Color& color)
 {
   assert_gl();
 
-  int loc = m_context.get_program().get_attrib_location("diffuse");
+  int loc = m_context.get_program().get_attrib_location(GLProgram::attrib_diffuse);
   glVertexAttrib4f(loc, color.red, color.green, color.blue, color.alpha);
   glDisableVertexAttribArray(loc);
 

--- a/src/video/gl/gl_vertex_arrays.cpp
+++ b/src/video/gl/gl_vertex_arrays.cpp
@@ -27,6 +27,7 @@ GLVertexArrays::GLVertexArrays(GL33CoreContext& context) :
   m_vao(),
   m_positions_buffer(),
   m_texcoords_buffer(),
+  m_texcoords_repeat_buffer(),
   m_color_buffer()
 {
   assert_gl();
@@ -34,6 +35,7 @@ GLVertexArrays::GLVertexArrays(GL33CoreContext& context) :
   glGenVertexArrays(1, &m_vao);
   glGenBuffers(1, &m_positions_buffer);
   glGenBuffers(1, &m_texcoords_buffer);
+  glGenBuffers(1, &m_texcoords_repeat_buffer);
   glGenBuffers(1, &m_color_buffer);
 
   assert_gl();
@@ -43,6 +45,7 @@ GLVertexArrays::~GLVertexArrays()
 {
   glDeleteBuffers(1, &m_positions_buffer);
   glDeleteBuffers(1, &m_texcoords_buffer);
+  glDeleteBuffers(1, &m_texcoords_repeat_buffer);
   glDeleteBuffers(1, &m_color_buffer);
   glDeleteVertexArrays(1, &m_vao);
 }
@@ -82,6 +85,21 @@ GLVertexArrays::set_texcoords(const float* data, size_t size)
 
   int loc = m_context.get_program().get_attrib_location("texcoord");
   glVertexAttribPointer(loc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+  glEnableVertexAttribArray(loc);
+
+  assert_gl();
+}
+
+void
+GLVertexArrays::set_texcoords_repeat(const float* data, size_t size)
+{
+  assert_gl();
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_texcoords_repeat_buffer);
+  glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
+
+  int loc = m_context.get_program().get_attrib_location("texcoord_repeat");
+  glVertexAttribPointer(loc, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
   glEnableVertexAttribArray(loc);
 
   assert_gl();

--- a/src/video/gl/gl_vertex_arrays.hpp
+++ b/src/video/gl/gl_vertex_arrays.hpp
@@ -36,6 +36,7 @@ public:
 
   /** size is in bytes */
   void set_texcoords(const float* data, size_t size);
+  void set_texcoords_repeat(const float* data, size_t size);
   void set_texcoord(float u, float v);
 
   void set_colors(const float* data, size_t size);
@@ -46,6 +47,7 @@ private:
   GLuint m_vao;
   GLuint m_positions_buffer;
   GLuint m_texcoords_buffer;
+  GLuint m_texcoords_repeat_buffer;
   GLuint m_color_buffer;
 
 private:

--- a/update-tilecache.sh
+++ b/update-tilecache.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+[ -e supertux2-update-tilecache ] || {
+
+	patch -p1 <<===END===
+diff --git a/src/object/player.cpp b/src/object/player.cpp
+index 6d4bcd9ad..137ad4419 100644
+--- a/src/object/player.cpp
++++ b/src/object/player.cpp
+@@ -1086,6 +1086,7 @@ Player::handle_vertical_input()
+ void
+ Player::handle_input()
+ {
++  _exit(0);
+   if (m_ghost_mode) {
+     handle_input_ghost();
+     return;
+diff --git a/src/supertux/levelintro.cpp b/src/supertux/levelintro.cpp
+index 5a61afc7f..10098cc54 100644
+--- a/src/supertux/levelintro.cpp
++++ b/src/supertux/levelintro.cpp
+@@ -115,6 +115,11 @@ void LevelIntro::draw_stats_line(DrawingContext& context, int& py, const std::st
+ void
+ LevelIntro::draw(Compositor& compositor)
+ {
++  static int terminate = 0;
++  terminate++;
++  if (terminate > 30)
++    _exit(0);
++
+   auto& context = compositor.make_context();
+ 
+   const Statistics& stats = m_level.m_stats;
+===END===
+
+	mkdir -p build-tilecache
+	cd build-tilecache
+	cmake .. || exit 1
+	make -j8 || exit 1
+	mv -f supertux2 ../supertux2-update-tilecache || exit 1
+	cd ..
+}
+
+if parallel -h >/dev/null; then
+	find data -name '*.stl' | sort | while read LEVEL ; do echo ./supertux2-update-tilecache '"'"$LEVEL"'"' ; done | parallel -v
+else
+	COUNT=`find data -name '*.stl' | wc -l`
+	TOTAL=$COUNT
+	find data -name '*.stl' | sort | {
+		IDX=1
+		while read LEVEL ; do
+			echo "Level $IDX of $COUNT:"
+			echo "$LEVEL"
+			./supertux2-update-tilecache "$LEVEL"
+			IDX=`expr $IDX '+' 1`
+		done
+	}
+fi


### PR DESCRIPTION
You may have noticed that worldmap on Android renders terribly slowly.
That's because Android GL hardware cannot handle the amount of triangles that SuperTux pushes each frame.
This optimization will calculate the adjacent tiles into a bigger rectangle, and render them together as two GL triangles, with the repeating texture.
There is also a script update-tilecache.sh which will launch SuperTux with each level, which will calculate the big rectangles and save them into .local/share/supertux2/tilecache so the levels will load faster.
On the worldmap on "The Journey Begins" level this optimization reduces the amount of GL triangles from 8500 to 2860, and increases FPS from 6-7 to 43-48, when measured on my Poco X3 Pro, which is actually a gaming phone, but nowhere near a gaming laptop in terms of GL triangles output.
On the Forest worldmap on the level "Tower of Ghosts" FPS is 9-11, and 7-8 inside the level. With the optimization, FPS is 46-52 on the worldmap, and 39-42 inside the level.
Android app is compiled with LTO enabled. Without LTO, FPS drops miserably even with the GL optimization.
This is the last remaining Android patch, I've saved the biggest for last.