### PR TITLE
Detect touchscreen when enabling mobile controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,12 +152,9 @@ endif(WIN32)
 option(UBUNTU_TOUCH "Compile the project for an Ubuntu Touch target" OFF)
 
 # Mobile builds
-option(ENABLE_TOUCHSCREEN_SUPPORT "Enable on-screen controls and event detection for touchscreen devices" ON)
-if (UBUNTU_TOUCH OR ANDROID)
-  option(SHOW_TOUCHSCREEN_CONTROLS "Show mobile controls by default" ON)
+if (UBUNTU_TOUCH)
   option(HIDE_NONMOBILE_OPTIONS "Hide options that are impractical on mobile devices (e. g. changing screen resolution)" ON)
 else()
-  option(SHOW_TOUCHSCREEN_CONTROLS "Show mobile controls by default" OFF)
   option(HIDE_NONMOBILE_OPTIONS "Hide options that are impractical on mobile devices (e. g. changing screen resolution)" OFF)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif(WIN32)
 option(UBUNTU_TOUCH "Compile the project for an Ubuntu Touch target" OFF)
 
 # Mobile builds
-if (UBUNTU_TOUCH)
+if (UBUNTU_TOUCH OR ANDROID)
   option(HIDE_NONMOBILE_OPTIONS "Hide options that are impractical on mobile devices (e. g. changing screen resolution)" ON)
 else()
   option(HIDE_NONMOBILE_OPTIONS "Hide options that are impractical on mobile devices (e. g. changing screen resolution)" OFF)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -36,8 +36,6 @@
 #cmakedefine ENABLE_DISCORD
 
 #cmakedefine UBUNTU_TOUCH
-#cmakedefine ENABLE_TOUCHSCREEN_SUPPORT
-#cmakedefine SHOW_TOUCHSCREEN_CONTROLS
 #cmakedefine HIDE_NONMOBILE_OPTIONS
 
 #cmakedefine REMOVE_QUIT_BUTTON

--- a/src/control/mobile_controller.cpp
+++ b/src/control/mobile_controller.cpp
@@ -16,7 +16,6 @@
 
 #include "control/mobile_controller.hpp"
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
 
 #include <string>
 
@@ -247,6 +246,5 @@ MobileController::activate_widget_at_pos(float x, float y)
     m_right = true;
 }
 
-#endif
 
 /* EOF */

--- a/src/control/mobile_controller.hpp
+++ b/src/control/mobile_controller.hpp
@@ -19,7 +19,6 @@
 
 #include "config.h"
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
 
 #include "math/rectf.hpp"
 #include "video/surface_ptr.hpp"
@@ -54,8 +53,6 @@ private:
   MobileController(const MobileController&) = delete;
   MobileController& operator=(const MobileController&) = delete;
 };
-
-#endif
 
 #endif
 

--- a/src/gui/mousecursor.cpp
+++ b/src/gui/mousecursor.cpp
@@ -33,11 +33,9 @@ MouseCursor::MouseCursor(SpritePtr sprite) :
   m_state(MouseCursorState::NORMAL),
   m_applied_state(MouseCursorState::HIDE),
   m_sprite(std::move(sprite)),
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   m_x(),
   m_y(),
   m_mobile_mode(false),
-#endif
   m_icon()
 {
 }
@@ -90,13 +88,11 @@ MouseCursor::draw(DrawingContext& context)
     int x, y;
     Uint32 ispressed = SDL_GetMouseState(&x, &y);
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
     if (m_mobile_mode)
     {
       x = m_x;
       y = m_y;
     }
-#endif
 
     if (ispressed & SDL_BUTTON(1) || ispressed & SDL_BUTTON(2))
     {

--- a/src/gui/mousecursor.hpp
+++ b/src/gui/mousecursor.hpp
@@ -57,9 +57,7 @@ public:
   void set_state(MouseCursorState state);
   void set_icon(SurfacePtr icon);
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   void set_pos(int x, int y) { m_mobile_mode = true; m_x = x; m_y = y; }
-#endif
 
 private:
   void apply_state(MouseCursorState state);
@@ -68,10 +66,8 @@ private:
   MouseCursorState m_state;
   MouseCursorState m_applied_state;
   SpritePtr m_sprite;
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   int m_x, m_y;
   bool m_mobile_mode;
-#endif
   SurfacePtr m_icon;
 
 private:

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -67,9 +67,7 @@ Config::Config() :
   locale(),
   keyboard_config(),
   joystick_config(),
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   mobile_controls(SDL_GetNumTouchDevices() > 0),
-#endif
   addons(),
   developer_mode(false),
   christmas_mode(false),
@@ -259,13 +257,7 @@ Config::load()
       joystick_config.read(*joystick_mapping);
     }
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
-#ifdef SHOW_TOUCHSCREEN_CONTROLS
-    config_control_mapping->get("mobile_controls", mobile_controls, true);
-#else
-    config_control_mapping->get("mobile_controls", mobile_controls, false);
-#endif
-#endif
+    config_control_mapping->get("mobile_controls", mobile_controls, SDL_GetNumTouchDevices() > 0);
   }
 
   boost::optional<ReaderCollection> config_addons_mapping;
@@ -390,9 +382,7 @@ Config::save()
     joystick_config.write(writer);
     writer.end_list("joystick");
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
     writer.write("mobile_controls", mobile_controls);
-#endif
   }
   writer.end_list("control");
 

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -68,7 +68,7 @@ Config::Config() :
   keyboard_config(),
   joystick_config(),
 #ifdef ENABLE_TOUCHSCREEN_SUPPORT
-  mobile_controls(true),
+  mobile_controls(SDL_GetNumTouchDevices() > 0),
 #endif
   addons(),
   developer_mode(false),
@@ -263,7 +263,7 @@ Config::load()
 #ifdef SHOW_TOUCHSCREEN_CONTROLS
     config_control_mapping->get("mobile_controls", mobile_controls, true);
 #else
-    config_control_mapping->get("mobile_controls", mobile_controls, SDL_GetNumTouchDevices() > 0);
+    config_control_mapping->get("mobile_controls", mobile_controls, false);
 #endif
 #endif
   }

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -263,7 +263,7 @@ Config::load()
 #ifdef SHOW_TOUCHSCREEN_CONTROLS
     config_control_mapping->get("mobile_controls", mobile_controls, true);
 #else
-    config_control_mapping->get("mobile_controls", mobile_controls, false);
+    config_control_mapping->get("mobile_controls", mobile_controls, SDL_GetNumTouchDevices() > 0);
 #endif
 #endif
   }

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -91,9 +91,7 @@ public:
   KeyboardConfig keyboard_config;
   JoystickConfig joystick_config;
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   bool mobile_controls;
-#endif
 
   struct Addon
   {

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -73,10 +73,8 @@ enum OptionsMenuIDs {
   MNID_TRANSITIONS,
   MNID_CONFIRMATION_DIALOG,
   MNID_PAUSE_ON_FOCUSLOSS,
-  MNID_CUSTOM_CURSOR
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
-  , MNID_MOBILE_CONTROLS
-#endif
+  MNID_CUSTOM_CURSOR,
+  MNID_MOBILE_CONTROLS
 };
 
 OptionsMenu::OptionsMenu(bool complete) :
@@ -413,10 +411,9 @@ OptionsMenu::OptionsMenu(bool complete) :
     .set_help(_("Configure joystick control-action mappings"));
 #endif
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   add_toggle(MNID_MOBILE_CONTROLS, _("On-screen controls"), &g_config->mobile_controls)
       .set_help(_("Toggle on-screen controls for mobile devices"));
-#endif
+
   MenuItem& enable_transitions = add_toggle(MNID_TRANSITIONS, _("Enable transitions"), &g_config->transitions_enabled);
   enable_transitions.set_help(_("Enable screen transitions and smooth menu animation"));
 

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -136,9 +136,7 @@ ScreenManager::ScreenManager(VideoSystem& video_system, InputManager& input_mana
   m_menu_storage(new MenuStorage),
   m_menu_manager(new MenuManager()),
   m_controller_hud(new ControllerHUD),
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   m_mobile_controller(),
-#endif
   last_ticks(0),
   elapsed_ticks(0),
   ms_per_step(static_cast<Uint32>(1000.0f / LOGICAL_FPS)),
@@ -279,9 +277,8 @@ ScreenManager::draw(Compositor& compositor, FPS_Stats& fps_statistics)
 
   Console::current()->draw(context);
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
-  m_mobile_controller.draw(context);
-#endif
+  if (g_config->mobile_controls)
+    m_mobile_controller.draw(context);
 
   if (g_config->show_fps)
     draw_fps(context, fps_statistics);
@@ -303,10 +300,11 @@ ScreenManager::update_gamelogic(float dt_sec)
 {
   Controller& controller = m_input_manager.get_controller();
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
-  m_mobile_controller.update();
-  m_mobile_controller.apply(controller);
-#endif
+  if (g_config->mobile_controls)
+  {
+    m_mobile_controller.update();
+    m_mobile_controller.apply(controller);
+  }
 
   SquirrelVirtualMachine::current()->update(g_game_time);
 
@@ -333,7 +331,6 @@ ScreenManager::process_events()
   auto session = GameSession::current();
   while (SDL_PollEvent(&event))
   {
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
     switch (event.type)
     {
       case SDL_FINGERDOWN:
@@ -383,7 +380,6 @@ ScreenManager::process_events()
         MouseCursor::current()->set_pos(event.motion.x, event.motion.y);
         break;
     }
-#endif
     m_input_manager.process_event(event);
 
     m_menu_manager->event(event);

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -74,9 +74,7 @@ private:
   std::unique_ptr<MenuStorage> m_menu_storage;
   std::unique_ptr<MenuManager> m_menu_manager;
   std::unique_ptr<ControllerHUD> m_controller_hud;
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   MobileController m_mobile_controller;
-#endif
 
   Uint32 last_ticks;
   Uint32 elapsed_ticks;

--- a/src/video/viewport.cpp
+++ b/src/video/viewport.cpp
@@ -84,10 +84,8 @@ calculate_scale(const Size& min_size, const Size& max_size,
     }
   }
 
-#ifdef ENABLE_TOUCHSCREEN_SUPPORT
   if (g_config->mobile_controls)
     scale = std::max(scale, 1.f);
-#endif
 
   return scale;
 }

--- a/src/video/viewport.cpp
+++ b/src/video/viewport.cpp
@@ -85,7 +85,8 @@ calculate_scale(const Size& min_size, const Size& max_size,
   }
 
 #ifdef ENABLE_TOUCHSCREEN_SUPPORT
-  scale = std::max(scale, 1.f);
+  if (g_config->mobile_controls)
+    scale = std::max(scale, 1.f);
 #endif
 
   return scale;


### PR DESCRIPTION
Fixes issue when mobile controller is enabled by default on devices without touchscreen