### PR TITLE
Opening language packs from options only focuses on language packs

### DIFF
--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -120,7 +120,7 @@ void
 AddonMenu::rebuild_menu()
 {
   clear();
-  add_label(m_langpacks_only?_("Language Packs") :_("Add-ons"));
+  add_label(m_langpacks_only ? _("Language Packs") : _("Add-ons"));
   add_hl();
 
   if (m_installed_addons.empty())

--- a/src/supertux/menu/addon_menu.cpp
+++ b/src/supertux/menu/addon_menu.cpp
@@ -127,11 +127,11 @@ AddonMenu::rebuild_menu()
   {
     if (!m_repository_addons.empty())
     {
-      add_inactive(m_langpacks_only?_("No language packs installed") :_("No Add-ons installed"));
+      add_inactive(m_langpacks_only ? _("No language packs installed") : _("No Add-ons installed"));
     }
     else
     {
-      add_inactive(m_langpacks_only?_("No language packs found") :_("No Add-ons found"));
+      add_inactive(m_langpacks_only ? _("No language packs found") : _("No Add-ons found"));
     }
   }
   else
@@ -206,7 +206,7 @@ AddonMenu::rebuild_menu()
 
     if (!have_new_stuff && m_addon_manager.has_been_updated())
     {
-      add_inactive(m_langpacks_only?_("No new language packs found") :_("No new Add-ons found"));
+      add_inactive(m_langpacks_only ? _("No new language packs found") : _("No new Add-ons found"));
     }
   }
 

--- a/src/supertux/menu/addon_menu.hpp
+++ b/src/supertux/menu/addon_menu.hpp
@@ -38,9 +38,10 @@ private:
   std::vector<std::string> m_repository_addons;
   std::unique_ptr<bool[]> m_addons_enabled;
   bool m_auto_install_langpack;
+  bool m_langpacks_only;
 
 public:
-  AddonMenu(bool auto_install_langpack = false);
+  AddonMenu(bool auto_install_langpack = false, bool language_packs_only = false);
   ~AddonMenu() override;
 
   void refresh() override;

--- a/src/supertux/menu/menu_storage.cpp
+++ b/src/supertux/menu/menu_storage.cpp
@@ -127,7 +127,7 @@ MenuStorage::create(MenuId menu_id)
       return std::make_unique<AddonMenu>();
 
     case LANGPACK_MENU:
-      return std::unique_ptr<Menu>(new AddonMenu);
+      return std::unique_ptr<Menu>(new AddonMenu(false, true));
 
     case EDITOR_LEVELSET_SELECT_MENU:
       return std::make_unique<EditorLevelsetSelectMenu>();
@@ -136,7 +136,7 @@ MenuStorage::create(MenuId menu_id)
       return std::make_unique<EditorNewLevelsetMenu>();
 
     case LANGPACK_AUTO_UPDATE_MENU:
-      return std::unique_ptr<Menu>(new AddonMenu(true));
+      return std::unique_ptr<Menu>(new AddonMenu(true, true));
 
     case EDITOR_LEVEL_SELECT_MENU:
       return std::make_unique<EditorLevelSelectMenu>();


### PR DESCRIPTION
Closes #2124.

Makes "Language packs" from options only focus on language packs from the add-ons menu, when opened. Also makes some strings change, depending on where the menu has been opened from ("Add-ons" or "Language packs").