### PR TITLE
Add controller rumble support

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -363,6 +363,7 @@ BadGuy::collision(GameObject& other, const CollisionHit& hit)
 
     // hit from above?
     if (player->get_bbox().get_bottom() < (m_col.m_bbox.get_top() + 16)) {
+      InputManager::current()->rumble_effect(RUMBLE_SQUISH);
       if (player->is_stone()) {
         kill_fall();
         return FORCE_MOVE;
@@ -408,6 +409,7 @@ HitResponse
 BadGuy::collision_player(Player& player, const CollisionHit& )
 {
   if (player.is_invincible()) {
+    InputManager::current()->rumble_effect(RUMBLE_SQUISH_INVINCIBLE);
     kill_fall();
     return ABORT_MOVE;
   }

--- a/src/control/game_controller_manager.cpp
+++ b/src/control/game_controller_manager.cpp
@@ -176,6 +176,42 @@ GameControllerManager::process_axis_event(const SDL_ControllerAxisEvent& ev)
 }
 
 void
+GameControllerManager::rumble_effect(int type)
+{
+  for (const auto& con : m_game_controllers)
+  {
+    switch (type) {
+      case RUMBLE_HURT:
+        SDL_GameControllerRumble(con, 0x9FFF, 0xBFFF, 400);
+        break;
+
+      case RUMBLE_KILL:
+        SDL_GameControllerRumble(con, 0x9FFF, 0xBFFF, 750);
+	break;
+
+      case RUMBLE_SQUISH:
+        SDL_GameControllerRumble(con, 0x2FFF, 0xBFFF, 200);
+	break;
+
+      case RUMBLE_SQUISH_INVINCIBLE:
+        SDL_GameControllerRumble(con, 0x2FFF, 0xBFFF, 150);
+        break;
+
+      case RUMBLE_BLOCK_HIT:
+        SDL_GameControllerRumble(con, 0x4FFF, 0x9FFF, 200);
+	break;
+
+      case RUMBLE_BUTTJUMP:
+        SDL_GameControllerRumble(con, 0xDFFF, 0xBFFF, 300);
+	break;
+
+      default:
+        break;
+    }
+  }
+}
+
+void
 GameControllerManager::on_controller_added(int joystick_index)
 {
   if (!SDL_IsGameController(joystick_index))

--- a/src/control/game_controller_manager.hpp
+++ b/src/control/game_controller_manager.hpp
@@ -37,6 +37,8 @@ public:
   void process_button_event(const SDL_ControllerButtonEvent& ev);
   void process_axis_event(const SDL_ControllerAxisEvent& ev);
 
+  void rumble_effect(int type);
+
   void on_controller_added(int joystick_index);
   void on_controller_removed(int instance_id);
 

--- a/src/control/input_manager.cpp
+++ b/src/control/input_manager.cpp
@@ -132,4 +132,10 @@ InputManager::process_event(const SDL_Event& event)
   }
 }
 
+void
+InputManager::rumble_effect(int type)
+{
+  game_controller_manager->rumble_effect(type);
+}
+
 /* EOF */

--- a/src/control/input_manager.hpp
+++ b/src/control/input_manager.hpp
@@ -35,6 +35,10 @@ class KeyboardMenu;
 class KeyboardConfig;
 class JoystickConfig;
 
+enum RumbleType {
+  RUMBLE_HURT, RUMBLE_KILL, RUMBLE_SQUISH, RUMBLE_SQUISH_INVINCIBLE, RUMBLE_BLOCK_HIT, RUMBLE_BUTTJUMP
+};
+
 class InputManager final : public Currenton<InputManager>
 {
 private:
@@ -56,6 +60,8 @@ public:
 
   const Controller& get_controller() const;
   Controller& get_controller();
+
+  void rumble_effect(int type);
 
 private:
   std::unique_ptr<Controller> controller;

--- a/src/object/block.cpp
+++ b/src/object/block.cpp
@@ -21,6 +21,7 @@
 #include "audio/sound_manager.hpp"
 #include "badguy/badguy.hpp"
 #include "badguy/bomb.hpp"
+#include "control/input_manager.hpp"
 #include "math/random.hpp"
 #include "object/coin.hpp"
 #include "object/growup.hpp"
@@ -102,6 +103,7 @@ Block::collision(GameObject& other, const CollisionHit& )
       if (player->get_bbox().get_top() > m_col.m_bbox.get_bottom() - SHIFT_DELTA &&
           x_coordinates_intersect)
       {
+        InputManager::current()->rumble_effect(RUMBLE_BLOCK_HIT);
         hit(*player);
       }
     }

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1802,6 +1802,7 @@ Player::collision_solid(const CollisionHit& hit)
         -70, -50, 260, 280, Vector(0, 300), 3,
         Color(.4f, .4f, .4f), 3, .8f, LAYER_OBJECTS+1);
       Sector::get().get_camera().shake(.1f, 0, 5);
+      InputManager::current()->rumble_effect(RUMBLE_BUTTJUMP);
     }
 
   } else if (hit.top) {
@@ -1902,6 +1903,7 @@ Player::kill(bool completely)
 
   if (!completely && is_big()) {
     SoundManager::current()->play("sounds/hurt.wav");
+    InputManager::current()->rumble_effect(RUMBLE_HURT);
 
     if (m_player_status.bonus == FIRE_BONUS
       || m_player_status.bonus == ICE_BONUS
@@ -1917,6 +1919,7 @@ Player::kill(bool completely)
     }
   } else {
     SoundManager::current()->play("sounds/kill.wav");
+    InputManager::current()->rumble_effect(RUMBLE_KILL);
 
     // do not die when in edit mode
     if (m_edit_mode) {


### PR DESCRIPTION
When using a controller, rumble events will be sent with
`SDL_GameControllerRumble()`.

Rumble events are sent in the following situations:
- player death
- player hurt
- bad guy squished
- bad guy killed
- block hit
- buttjump hit

Tested on Arch Linux, Linux 5.16.3, Xbox One Controller (version 1)