### PR TITLE
More forgiving explosions, less bouncy bombs

### DIFF
--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -47,7 +47,7 @@ Bomb::collision_solid(const CollisionHit& hit)
   if (hit.top || hit.bottom)
     m_physic.set_velocity_y(0);
   if (hit.left || hit.right)
-    m_physic.set_velocity_x(-m_physic.get_velocity_x());
+    m_physic.set_velocity_x(-m_physic.get_velocity_x() * 0.5f);
   if (hit.crush)
     m_physic.set_velocity(0, 0);
 

--- a/src/object/brick.cpp
+++ b/src/object/brick.cpp
@@ -62,6 +62,17 @@ Brick::hit(Player& player)
   try_break(&player);
 }
 
+void
+Brick::update(float dt_sec)
+{
+  for (auto& explosion : Sector::get().get_objects_by_type<Explosion>())
+  {
+    if (get_bbox().grown(8).contains(explosion.get_bbox()))
+      try_break(nullptr);
+  }
+  Block::update(dt_sec);
+}
+
 HitResponse
 Brick::collision(GameObject& other, const CollisionHit& hit)
 {
@@ -86,10 +97,6 @@ Brick::collision(GameObject& other, const CollisionHit& hit)
     if (moving->get_bbox().get_top() > m_col.m_bbox.get_bottom() - SHIFT_DELTA) {
       try_break(nullptr);
     }
-  }
-  auto explosion = dynamic_cast<Explosion*> (&other);
-  if (explosion && explosion->hurts()) {
-    try_break(nullptr);
   }
   auto icecrusher = dynamic_cast<IceCrusher*> (&other);
   if (icecrusher && m_coin_counter == 0)

--- a/src/object/brick.hpp
+++ b/src/object/brick.hpp
@@ -25,6 +25,7 @@ public:
   Brick(const Vector& pos, int data, const std::string& spriteName);
   Brick(const ReaderMapping& mapping, const std::string& spriteName = "images/objects/bonus_block/brick.sprite");
 
+  virtual void update(float dt_sec) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual ObjectSettings get_settings() override;
   virtual std::string get_class() const override { return "brick"; }

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -96,10 +96,6 @@ WeakBlock::collision(GameObject& other, const CollisionHit& hit)
         if (auto bullet = dynamic_cast<Bullet*> (&other)) {
           return collision_bullet(*bullet, hit);
         }
-        //Explosions destroy weakblocks as well
-        if (dynamic_cast<Explosion*> (&other)) {
-          startBurning();
-        }
         break;
 
       case STATE_BURNING:
@@ -127,6 +123,11 @@ WeakBlock::update(float )
   switch (state) {
 
       case STATE_NORMAL:
+        for (auto& explosion : Sector::get().get_objects_by_type<Explosion>())
+        {
+          if (get_bbox().grown(8).contains(explosion.get_bbox()))
+            startBurning();
+        }
         break;
 
       case STATE_BURNING:


### PR DESCRIPTION
This PR makes throwing bombs to activate bricks/weak blocks more forgiving by giving the explosions a larger affect range and making bombs bounce less intensely when hitting solids.