### PR TITLE
Hidden levelsets made visible with Developer Mode

### DIFF
--- a/data/levels/misc/info
+++ b/data/levels/misc/info
@@ -1,6 +1,7 @@
 (supertux-world
   (title (_ "Misc"))
   (description (_ "How did you get here?"))
+  (contrib-type "official")
   (levelset #t)
   (hide-from-contribs #t)
 )

--- a/data/levels/test/info
+++ b/data/levels/test/info
@@ -1,6 +1,7 @@
 (supertux-level-subset
   (title (_ "Test Levels"))
   (description (_ ""))
+  (contrib-type "official")
   (levelset #t)
   (hide-from-contribs #t)
 )

--- a/data/levels/world1/info
+++ b/data/levels/world1/info
@@ -1,6 +1,7 @@
 (supertux-world
   (title (_ "Icy Island"))
   (description "The first world of SuperTux.")
+  (contrib-type "official")
   (hide-from-contribs #t)
   (levelset #f)
 )

--- a/data/levels/world2/info
+++ b/data/levels/world2/info
@@ -1,6 +1,7 @@
 (supertux-world
   (title (_ "Rooted Forest"))
   (description "The second world of SuperTux.")
+  (contrib-type "official")
   (hide-from-contribs #t)
   (levelset #f)
 )

--- a/data/levels/world3/info
+++ b/data/levels/world3/info
@@ -1,6 +1,7 @@
 (supertux-world
   (title (_ "Tropical Paradise"))
   (description "The third world of SuperTux.")
+  (contrib-type "official")
   (hide-from-contribs #t)
   (levelset #f)
 )

--- a/data/levels/world4/info
+++ b/data/levels/world4/info
@@ -1,6 +1,7 @@
 (supertux-world
   (title (_ "Mountain Peak"))
   (description "The fourth world of SuperTux.")
+  (contrib-type "official")
   (hide-from-contribs #t)
   (levelset #f)
 )

--- a/src/supertux/menu/contrib_menu.cpp
+++ b/src/supertux/menu/contrib_menu.cpp
@@ -30,6 +30,8 @@
 #include "supertux/player_status.hpp"
 #include "supertux/savegame.hpp"
 #include "supertux/world.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/gameconfig.hpp"
 #include "util/file_system.hpp"
 #include "util/gettext.hpp"
 #include "util/log.hpp"
@@ -91,7 +93,7 @@ ContribMenu::ContribMenu() :
         continue;
 
       std::unique_ptr<World> world = World::from_directory(*it);
-      if (!world->hide_from_contribs())
+      if (!world->hide_from_contribs() || g_config->developer_mode)
       {
         if (world->is_levelset() || world->is_worldmap())
         {

--- a/src/supertux/menu/editor_delete_levelset_menu.cpp
+++ b/src/supertux/menu/editor_delete_levelset_menu.cpp
@@ -21,6 +21,8 @@
 #include "physfs/util.hpp"
 #include "supertux/menu/editor_levelset_select_menu.hpp"
 #include "supertux/world.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/gameconfig.hpp"
 #include "util/gettext.hpp"
 #include "util/log.hpp"
 
@@ -44,7 +46,7 @@ EditorDeleteLevelsetMenu::refresh()
   for(std::string& level_world : contrib_worlds)
   {
     std::unique_ptr<World> world = World::from_directory(level_world);
-    if (world->hide_from_contribs())
+    if (world->hide_from_contribs() && !g_config->developer_mode)
     {
       continue;
     }

--- a/src/supertux/menu/editor_levelset_select_menu.cpp
+++ b/src/supertux/menu/editor_levelset_select_menu.cpp
@@ -29,6 +29,8 @@
 #include "supertux/menu/editor_delete_levelset_menu.hpp"
 #include "supertux/menu/menu_storage.hpp"
 #include "supertux/world.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/gameconfig.hpp"
 #include "util/file_system.hpp"
 #include "util/gettext.hpp"
 #include "util/log.hpp"
@@ -80,7 +82,7 @@ EditorLevelsetSelectMenu::initialize()
     try
     {
       std::unique_ptr<World> world = World::from_directory(level_world);
-      if (world->hide_from_contribs())
+      if (world->hide_from_contribs() && !g_config->developer_mode)
       {
         continue;
       }


### PR DESCRIPTION
Using Developer Mode will show levelsets, that have `hide-from-contribs` set to `true` and are not visible to the regular user. This applies to the "Contrib Levels" menus, as well as the level editor. Also adds `(contrib-type "official")` to some official levelsets, so they show up as "Official Contrib Levels".