### PR TITLE
Allow vertical peeking even if Tux isn't standing on the ground

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1105,25 +1105,20 @@ Player::handle_input()
   }
 
   /* Peeking */
-  if ( m_controller->released( Control::PEEK_LEFT ) || m_controller->released( Control::PEEK_RIGHT ) ) {
+  if (m_controller->released( Control::PEEK_LEFT ) || m_controller->released( Control::PEEK_RIGHT))
     m_peekingX = Direction::AUTO;
-  }
-  if ( m_controller->released( Control::PEEK_UP ) || m_controller->released( Control::PEEK_DOWN ) ) {
+  else if (m_controller->released( Control::PEEK_UP ) || m_controller->released( Control::PEEK_DOWN))
     m_peekingY = Direction::AUTO;
-  }
-  if ( m_controller->pressed( Control::PEEK_LEFT ) ) {
+
+  if (m_controller->pressed(Control::PEEK_LEFT))
     m_peekingX = Direction::LEFT;
-  }
-  if ( m_controller->pressed( Control::PEEK_RIGHT ) ) {
+  else if (m_controller->pressed(Control::PEEK_RIGHT))
     m_peekingX = Direction::RIGHT;
-  }
-  if (!m_backflipping && !m_jumping && on_ground()) {
-    if ( m_controller->pressed( Control::PEEK_UP ) ) {
-      m_peekingY = Direction::UP;
-    } else if ( m_controller->pressed( Control::PEEK_DOWN ) ) {
-      m_peekingY = Direction::DOWN;
-    }
-  }
+
+  if (m_controller->pressed(Control::PEEK_UP))
+    m_peekingY = Direction::UP;
+  else if (m_controller->pressed(Control::PEEK_DOWN))
+    m_peekingY = Direction::DOWN;
 
   /* Handle horizontal movement: */
   if (!m_backflipping && !m_stone && !m_swimming) handle_horizontal_input();


### PR DESCRIPTION
I've got no idea why this wasn't always the case, if there's a reason and this PR breaks something, please let me know. The inability to peek up/down mid-air always bothered me a bit, but now swimming is a thing, and the inability to use this feature in water just creates a bad player experience.

This PR removes the check that prevented vertical peeking unless Tux was standing on solid ground.