### PR TITLE
Level time improvements

### DIFF
--- a/src/object/level_time.cpp
+++ b/src/object/level_time.cpp
@@ -60,6 +60,13 @@ LevelTime::update(float dt_sec)
 {
   if (!running) return;
 
+  int players_alive = Sector::current() ? Sector::current()->get_object_count<Player>([](const Player& p) {
+    return !p.is_dead() && !p.is_dying() && !p.is_winning();
+  }) : 0;
+
+  if (!players_alive)
+    return;
+
   int prev_time = static_cast<int>(floorf(time_left*5));
   time_left -= dt_sec;
   if (time_left <= 0) {

--- a/src/object/level_time.cpp
+++ b/src/object/level_time.cpp
@@ -20,6 +20,7 @@
 
 #include "editor/editor.hpp"
 #include "object/player.hpp"
+#include "supertux/game_session.hpp"
 #include "supertux/resources.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
@@ -62,6 +63,10 @@ LevelTime::update(float dt_sec)
   int prev_time = static_cast<int>(floorf(time_left*5));
   time_left -= dt_sec;
   if (time_left <= 0) {
+    // Needed to avoid charging a player coins if they had a checkpoint
+    if (GameSession::current())
+      GameSession::current()->set_reset_point("", Vector());
+
     if (time_left <= -5 || !Sector::get().get_player().get_coins())
     {
       Sector::get().get_player().kill(true);

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -161,6 +161,15 @@ GameSession::restart_level(bool after_death)
     music_object.play_music(LEVEL_MUSIC);
   }
 
+  auto level_times = m_currentsector->get_objects_by_type<LevelTime>();
+  auto it = level_times.begin();
+
+  while (it != level_times.end())
+  {
+    it->set_time(it->get_time() - m_play_time);
+    it++;
+  }
+
   start_recording();
 
   return (0);

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -141,6 +141,8 @@ private:
   Statistics* m_best_level_statistics;
   Savegame& m_savegame;
 
+  // Note: m_play_time should reset when a level is restarted from the beginning
+  //       but NOT if Tux respawns at a checkpoint (for LevelTimes to work)
   float m_play_time; /**< total time in seconds that this session ran interactively */
 
   bool m_edit_mode; /**< true if GameSession runs in level editor mode */


### PR DESCRIPTION
Fixes #2143 

As discussed in #2060, this implements the most popular opinion: Level Time is retained throughout deaths involving a respawn at a checkpoint. The time will keep running down and never go back up until checkpoints are cleared (either as a result of running out of time, or by resetting the level manually).

Note that this design involves code both in the LevelTime object and in the GameSession class; this is necessary because taking the checkpoint coins is handled directly in player.cpp, which happens at the moment of dying, not resetting. I would welcome a proposal that would help fix this, if any.

This also fixes a bug with the timer running despite all players being either dead, dying of winning.