### PR TITLE
Keep music across sectors, if the name and path of music file match

### DIFF
--- a/data/levels/world2/lost_village.stl
+++ b/data/levels/world2/lost_village.stl
@@ -197,7 +197,7 @@
       (y 488)
     )
     (music
-      (file "forest\\shallow-green.music")
+      (file "music/forest/shallow-green.music")
     )
     (particles-rain
     )
@@ -1034,7 +1034,7 @@ tischsaege.goto_node( 0 ) 	")
       (y 1001.778)
     )
     (music
-      (file "/music/forest/shallow-green.music")
+      (file "music/forest/shallow-green.music")
     )
     (particles-ghosts
     )

--- a/data/levels/world2/tux_builder.stl
+++ b/data/levels/world2/tux_builder.stl
@@ -813,7 +813,7 @@
       (y 448)
     )
     (music
-      (file "/music/forest/forest2.music")
+      (file "music/forest/forest2.music")
     )
     (poisonivy
       (x 736)

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -378,6 +378,7 @@ GameSession::update(float dt_sec, const Controller& controller)
   // respawning in new sector?
   if (!m_newsector.empty() && !m_newspawnpoint.empty()) {
     auto sector = m_level->get_sector(m_newsector);
+    std::string current_music = m_currentsector->get_singleton_by_type<MusicObject>().get_music();
     if (sector == nullptr) {
       log_warning << "Sector '" << m_newsector << "' not found" << std::endl;
       sector = m_level->get_sector(m_start_sector);
@@ -385,7 +386,9 @@ GameSession::update(float dt_sec, const Controller& controller)
     assert(m_currentsector != nullptr);
     m_currentsector->stop_looping_sounds();
     sector->activate(m_newspawnpoint);
-    sector->get_singleton_by_type<MusicObject>().play_music(LEVEL_MUSIC);
+    // Start the new sector's music only if it's different from the current one
+    if (current_music != sector->get_singleton_by_type<MusicObject>().get_music())
+      sector->get_singleton_by_type<MusicObject>().play_music(LEVEL_MUSIC);
     m_currentsector = sector;
     m_currentsector->play_looping_sounds();
 


### PR DESCRIPTION
When there are two sectors and both have the same music, respawning in the other and noticing the music restarts from the beginning may be a bit unsatisfactory. This PR fixes that issue, by checking if the path to the music file, the sector's `MusicObject` uses, is equal to the one of the other sector.

Also modifies levels "Tux The Builder" and "Lost Village" from `world2`, to make them support this.

(@Zwatotem has requested a review for this PR, mentioning them here.)