### PR TITLE
Fixed panning of ambient sounds.

### DIFF
--- a/src/object/ambient_sound.cpp
+++ b/src/object/ambient_sound.cpp
@@ -149,6 +149,7 @@ AmbientSound::start_playing()
 
     sound_source->set_gain(0);
     sound_source->set_looping(true);
+    sound_source->set_relative(true);
     currentvolume=targetvolume=1e-20f;
     sound_source->play();
   } catch(std::exception& e) {


### PR DESCRIPTION
Fix panning for the ambient sound level object.

Before it used to come from the left more, most likely from the origin point.

This patch makes position-based stereo not apply to ambient sounds.

The change is most noticeable (and tested) in the starting area of `world2/lost_village.stl`.