### PR TITLE
Tilemap tint also affect their lighting

### DIFF
--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -192,6 +192,8 @@ public:
       Destination opacity will be reached after @c seconds seconds. Doesn't influence solidity. */
   void tint_fade(const Color& new_tint, float seconds = 0);
 
+  Color get_current_tint() const { return m_current_tint; }
+
   /** Instantly switch tilemap's opacity to @c alpha. Also influences solidity. */
   void set_alpha(float alpha);
 

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -686,13 +686,13 @@ Sector::convert_tiles2gameobject()
                   && (tm.get_tile(x, y-1).get_attributes() != attributes || y%3 == 0)) {
                 float pseudo_rnd = static_cast<float>(static_cast<int>(pos.x) % 10) / 10;
                 add<PulsingLight>(center, 1.0f + pseudo_rnd, 0.8f, 1.0f,
-                                  Color(1.0f, 0.3f, 0.0f, 1.0f));
+                                  (Color(1.0f, 0.3f, 0.0f, 1.0f) * tm.get_current_tint()).validate());
               }
             } else {
               // torch
               float pseudo_rnd = static_cast<float>(static_cast<int>(pos.x) % 10) / 10;
               add<PulsingLight>(center, 1.0f + pseudo_rnd, 0.9f, 1.0f,
-                                Color(1.0f, 1.0f, 0.6f, 1.0f));
+                                (Color(1.0f, 1.0f, 0.6f, 1.0f) * tm.get_current_tint()).validate());
             }
           }
         }


### PR DESCRIPTION
Complements #2023 by allowing the lighting produced my a tilemap (e. g. torches and lava tiles) to be tinted according to the tilemap's tint.