### PR TITLE
Reset bumper velocity on climb

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2113,6 +2113,7 @@ Player::start_climbing(Climbable& climbable)
 
   m_climbing = &climbable;
   m_sprite->set_angle(0.0f);
+  m_boost = 0.f;
   m_physic.enable_gravity(false);
   m_physic.set_velocity(0, 0);
   m_physic.set_acceleration(0, 0);


### PR DESCRIPTION
When Tux grabs a climbable, the velocity and acceleration from the physics reset; however, the boost (set by a sideways bumper) does not. This PR fixes this oversight.

To reproduce: place a climbable next to a bumper, and try to grab the climbable while bumping. Tux will slip out of the climbable zone.