### PR TITLE
Fix WASD/IJKL moving the cursor in menus

### DIFF
--- a/src/control/keyboard_manager.cpp
+++ b/src/control/keyboard_manager.cpp
@@ -220,9 +220,12 @@ KeyboardManager::process_menu_key_event(const SDL_KeyboardEvent& event)
       break;
     default:
       if (m_keyboard_config.m_keymap.count(event.keysym.sym) == 0)
-      {
         return;
-      }
+
+      // Forbid events from players other than the first in menus
+      if (m_keyboard_config.m_keymap[event.keysym.sym].player != 0)
+        return;
+
       control = m_keyboard_config.m_keymap[event.keysym.sym].control;
       break;
   }


### PR DESCRIPTION
Fixes a bug where controls from players other than the first (notably, WASD and IJKL) would interact in menus, making it hard to input any text that contain those characters (WASD/IJKL).