### PR TITLE
"No levels available" message in level deletion menu

### DIFF
--- a/src/supertux/menu/editor_delete_level_menu.cpp
+++ b/src/supertux/menu/editor_delete_level_menu.cpp
@@ -36,6 +36,9 @@ EditorDeleteLevelMenu::EditorDeleteLevelMenu(std::unique_ptr<Levelset>& levelset
 {
   add_label(_("Delete level"));
   add_hl();
+  if (levelset->get_num_levels() == 0) {
+    add_inactive(_("No levels available"));
+  }
   for (int i = 0; i < levelset->get_num_levels(); i++)
   {
     std::string filename = levelset->get_level_filename(i);

--- a/src/supertux/menu/editor_delete_level_menu.cpp
+++ b/src/supertux/menu/editor_delete_level_menu.cpp
@@ -36,7 +36,8 @@ EditorDeleteLevelMenu::EditorDeleteLevelMenu(std::unique_ptr<Levelset>& levelset
 {
   add_label(_("Delete level"));
   add_hl();
-  if (levelset->get_num_levels() == 0) {
+  if (levelset->get_num_levels() == 0)
+  {
     add_inactive(_("No levels available"));
   }
   for (int i = 0; i < levelset->get_num_levels(); i++)


### PR DESCRIPTION
Shows a "No levels available" message, when the user is in the editor level deletion menu, and there are no levels to delete.