### PR TITLE
Fixing partio_zip bug

### DIFF
--- a/external/partio_zip/zip_manager.hpp
+++ b/external/partio_zip/zip_manager.hpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #ifndef __ZIP__
 #define __ZIP__
 
+#include <memory>
 #include <fstream>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Fixing error with zip_manager...

The Error:
```
In file included from /home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.cpp:51:
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.hpp:70:10: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   70 |     std::unique_ptr<std::ostream> Add_File(const std::string& filename,const bool binary=true);
      |          ^~~~~~~~~~
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.hpp:50:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   49 | #include <vector>
  +++ |+#include <memory>
   50 | 
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.hpp:86:10: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   86 |     std::unique_ptr<std::istream> Get_File(const std::string& filename,const bool binary=true);
      |          ^~~~~~~~~~
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.hpp:86:5: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   86 |     std::unique_ptr<std::istream> Get_File(const std::string& filename,const bool binary=true);
      |     ^~~
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.cpp:477:6: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
  477 | std::unique_ptr<std::ostream> ZipFileWriter::
      |      ^~~~~~~~~~
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.cpp:52:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   51 | #include "zip_manager.hpp"
  +++ |+#include <memory>
   52 | 
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.cpp:553:6: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
  553 | std::unique_ptr<std::istream> ZipFileReader::Get_File(const std::string& filename,const bool)
      |      ^~~~~~~~~~
/home/TheOceanBreeze/ghq/github.com/SuperTux/supertux/external/partio_zip/zip_manager.cpp:553:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
  553 | std::unique_ptr<std::istream> ZipFileReader::Get_File(const std::string& filename,const bool)
      | ^~~
make[2]: *** [CMakeFiles/LibPartioZip.dir/build.make:76: CMakeFiles/LibPartioZip.dir/external/partio_zip/zip_manager.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:229: CMakeFiles/LibPartioZip.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```