### PR TITLE
List object names within editor toolbox

### DIFF
--- a/src/badguy/angrystone.hpp
+++ b/src/badguy/angrystone.hpp
@@ -32,9 +32,12 @@ public:
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "angrystone"; }
-  virtual std::string get_display_name() const override { return _("Angry Stone"); }
+
   virtual std::string get_overlay_size() const override { return "3x3"; }
+  static std::string class_name() { return "angrystone"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Angry Stone"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   enum AngryStoneState {

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1082,7 +1082,7 @@ BadGuy::after_editor_set()
     } else if (m_sprite->has_action("standing-left")) {
       m_sprite->set_action("standing-left");
     } else {
-      log_warning << "couldn't find editor sprite for badguy direction='auto': " << get_class() << std::endl;
+      log_warning << "couldn't find editor sprite for badguy direction='auto': " << get_class_name() << std::endl;
     }
   }
   else
@@ -1111,7 +1111,7 @@ BadGuy::after_editor_set()
       m_sprite->set_action("flying");
     } else {
       log_warning << "couldn't find editor sprite for badguy direction='" << action_str << "': "
-                  << get_class() << std::endl;
+                  << get_class_name() << std::endl;
     }
   }
 }

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -54,8 +54,10 @@ public:
       state and calls active_update and inactive_update */
   virtual void update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "badguy"; }
-  virtual std::string get_display_name() const override { return _("Badguy"); }
+  static std::string class_name() { return "badguy"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Badguy"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual std::string get_overlay_size() const { return "1x1"; }
 

--- a/src/badguy/bouncing_snowball.hpp
+++ b/src/badguy/bouncing_snowball.hpp
@@ -28,8 +28,10 @@ public:
   virtual void active_update(float) override;
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "bouncingsnowball"; }
-  virtual std::string get_display_name() const override { return _("Bouncing Snowball"); }
+  static std::string class_name() { return "bouncingsnowball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Bouncing Snowball"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void after_editor_set() override;
 

--- a/src/badguy/captainsnowball.hpp
+++ b/src/badguy/captainsnowball.hpp
@@ -27,8 +27,10 @@ public:
   virtual void active_update(float dt_sec) override;
   virtual void collision_solid(const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "captainsnowball"; }
-  virtual std::string get_display_name() const override { return _("Captain Snowball"); }
+  static std::string class_name() { return "captainsnowball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Captain Snowball"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   bool might_climb(int width, int height) const;
 

--- a/src/badguy/crystallo.hpp
+++ b/src/badguy/crystallo.hpp
@@ -26,8 +26,10 @@ public:
   Crystallo(const ReaderMapping& reader);
 
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "crystallo"; }
-  virtual std::string get_display_name() const override { return _("Crystallo"); }
+  static std::string class_name() { return "crystallo"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Crystallo"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void active_update(float dt_sec) override;
   virtual bool is_flammable() const override;

--- a/src/badguy/dart.hpp
+++ b/src/badguy/dart.hpp
@@ -39,8 +39,10 @@ public:
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;
 
   virtual bool updatePointers(const GameObject* from_object, GameObject* to_object);
-  virtual std::string get_class() const override { return "dart"; }
-  virtual std::string get_display_name() const override { return _("Dart"); }
+  static std::string class_name() { return "dart"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Dart"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual bool is_flammable() const override;
 

--- a/src/badguy/darttrap.hpp
+++ b/src/badguy/darttrap.hpp
@@ -30,8 +30,10 @@ public:
   virtual void active_update(float dt_sec) override;
 
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "darttrap"; }
-  virtual std::string get_display_name() const override { return _("Dart Trap"); }
+  static std::string class_name() { return "darttrap"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Dart Trap"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/dispenser.hpp
+++ b/src/badguy/dispenser.hpp
@@ -45,8 +45,11 @@ public:
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
   virtual bool is_portable() const override;
-  virtual std::string get_class() const override { return "dispenser"; }
-  virtual std::string get_display_name() const override { return _("Dispenser"); }
+
+  static std::string class_name() { return "dispenser"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Dispenser"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/badguy/fish_chasing.hpp
+++ b/src/badguy/fish_chasing.hpp
@@ -27,8 +27,10 @@ public:
 
   virtual void active_update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "fish-chasing"; }
-  virtual std::string get_display_name() const override { return _("Chasing Fish"); }
+  static std::string class_name() { return "fish-chasing"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Chasing Fish"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "2x2"; }
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/fish_harmless.hpp
+++ b/src/badguy/fish_harmless.hpp
@@ -27,8 +27,10 @@ public:
 
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "fish-harmless"; }
-  virtual std::string get_display_name() const override { return _("Harmless Fish"); }
+  static std::string class_name() { return "fish-harmless"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Harmless Fish"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "1x1"; }
 
 private:

--- a/src/badguy/fish_jumping.hpp
+++ b/src/badguy/fish_jumping.hpp
@@ -36,9 +36,9 @@ public:
   virtual bool is_freezable() const override;
 
   virtual std::string get_overlay_size() const override { return "1x2"; }
-  static std::string class_name() { return "fish"; }
+  static std::string class_name() { return "fish-jumping"; }
   virtual std::string get_class_name() const override { return class_name(); }
-  static std::string display_name() { return _("Fish"); }
+  static std::string display_name() { return _("Jumping Fish"); }
   virtual std::string get_display_name() const override { return display_name(); }
 
 private:

--- a/src/badguy/fish_jumping.hpp
+++ b/src/badguy/fish_jumping.hpp
@@ -34,9 +34,12 @@ public:
   virtual void unfreeze(bool melt = true) override;
   virtual void kill_fall() override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "fish-jumping"; }
-  virtual std::string get_display_name() const override { return _("Jumping Fish"); }
+
   virtual std::string get_overlay_size() const override { return "1x2"; }
+  static std::string class_name() { return "fish"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Fish"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   HitResponse hit(const CollisionHit& );

--- a/src/badguy/fish_swimming.hpp
+++ b/src/badguy/fish_swimming.hpp
@@ -34,8 +34,10 @@ public:
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "fish-swimming"; }
-  virtual std::string get_display_name() const override { return _("Swimming Fish"); }
+  static std::string class_name() { return "fish-swimming"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Swimming Fish"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "2x1"; }
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/flame.hpp
+++ b/src/badguy/flame.hpp
@@ -38,8 +38,10 @@ public:
   virtual bool is_flammable() const override;
 
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "flame"; }
-  virtual std::string get_display_name() const override { return _("Flame"); }
+  static std::string class_name() { return "flame"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/flyingsnowball.hpp
+++ b/src/badguy/flyingsnowball.hpp
@@ -28,8 +28,10 @@ public:
   virtual void activate() override;
   virtual void active_update(float dt_sec) override;
   virtual void collision_solid(const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "flyingsnowball"; }
-  virtual std::string get_display_name() const override { return _("Flying Snowball"); }
+  static std::string class_name() { return "flyingsnowball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Flying Snowball"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/ghostflame.hpp
+++ b/src/badguy/ghostflame.hpp
@@ -26,8 +26,10 @@ public:
 
   virtual bool is_flammable() const override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "ghostflame"; }
-  virtual std::string get_display_name() const override { return _("Ghost Flame"); }
+  static std::string class_name() { return "ghostflame"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ghost Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   Ghostflame(const Ghostflame&) = delete;

--- a/src/badguy/ghosttree.hpp
+++ b/src/badguy/ghosttree.hpp
@@ -38,8 +38,10 @@ public:
   virtual bool collides(GameObject& other, const CollisionHit& hit) const override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "ghosttree"; }
-  virtual std::string get_display_name() const override { return _("Ghost Tree"); }
+  static std::string class_name() { return "ghosttree"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ghost Tree"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
 

--- a/src/badguy/ghoul.hpp
+++ b/src/badguy/ghoul.hpp
@@ -26,8 +26,10 @@ class Ghoul final : public BadGuy,
 {
 public:
   Ghoul(const ReaderMapping& reader);
-  std::string get_class() const override { return "ghoul"; }
-  std::string get_display_name() const override { return _("Ghoul"); }
+  static std::string class_name() { return "ghoul"; }
+  static std::string display_name() { return _("Ghoul"); }
+  std::string get_class_name() const override { return class_name(); }
+  std::string get_display_name() const override { return display_name(); }
   bool is_freezable() const override;
   bool is_flammable() const override;
 

--- a/src/badguy/goldbomb.hpp
+++ b/src/badguy/goldbomb.hpp
@@ -44,8 +44,10 @@ public:
 
   virtual void kill_fall() override;
   virtual void ignite() override;
-  virtual std::string get_class() const override { return "goldbomb"; }
-  virtual std::string get_display_name() const override { return _("Gold Bomb"); }
+  static std::string class_name() { return "goldbomb"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Gold Bomb"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -41,8 +41,10 @@ public:
 
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "haywire"; }
-  virtual std::string get_display_name() const override { return _("Haywire"); }
+  static std::string class_name() { return "haywire"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Haywire"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/icecrusher.cpp
+++ b/src/badguy/icecrusher.cpp
@@ -204,7 +204,7 @@ IceCrusher::update(float dt_sec)
 
     if (brickbox.contains(brick.get_bbox()))
     {
-      if (brick.get_class() != "heavy-brick")
+      if (brick.get_class_name() != "heavy-brick")
       {
         brick.break_for_crusher(this);
       }

--- a/src/badguy/icecrusher.hpp
+++ b/src/badguy/icecrusher.hpp
@@ -55,10 +55,15 @@ public:
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
+
   virtual void after_editor_set() override;
   virtual bool is_sideways() const { return m_sideways; }
-  virtual std::string get_class() const override { return "icecrusher"; }
-  virtual std::string get_display_name() const override { return _("Icecrusher"); }
+
+  static std::string class_name() { return "icecrusher"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Icecrusher"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;

--- a/src/badguy/iceflame.hpp
+++ b/src/badguy/iceflame.hpp
@@ -29,8 +29,10 @@ public:
   virtual void ignite() override;
   virtual bool is_flammable() const override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "iceflame"; }
-  virtual std::string get_display_name() const override { return _("Ice Flame"); }
+  static std::string class_name() { return "iceflame"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ice Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   Iceflame(const Iceflame&) = delete;

--- a/src/badguy/igel.hpp
+++ b/src/badguy/igel.hpp
@@ -30,9 +30,12 @@ public:
   virtual void active_update(float dt_sec) override;
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "igel"; }
-  virtual std::string get_display_name() const override { return _("Igel"); }
+
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  static std::string class_name() { return "igel"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Igel"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   //  virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/jumpy.hpp
+++ b/src/badguy/jumpy.hpp
@@ -33,9 +33,12 @@ public:
   virtual void freeze() override;
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "jumpy"; }
-  virtual std::string get_display_name() const override { return _("Jumpy"); }
+
   virtual std::string get_overlay_size() const override { return "1x2"; }
+  static std::string class_name() { return "jumpy"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Jumpy"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   HitResponse hit(const CollisionHit& hit);

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -53,6 +53,7 @@ public:
 
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
+  virtual void kill_collision() override;
 
   virtual std::string get_overlay_size() const override { return "2x1"; }
   static std::string class_name() { return "leafshot"; }

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -53,7 +53,6 @@ public:
 
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
-  virtual void kill_collision() override;
 
   virtual std::string get_overlay_size() const override { return "2x1"; }
   static std::string class_name() { return "leafshot"; }

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -28,8 +28,10 @@ public:
 
   virtual void initialize() override;
   virtual void collision_solid(const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "kamikazesnowball"; }
-  virtual std::string get_display_name() const override { return _("Snowshot"); }
+  static std::string class_name() { return "kamikazesnowball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Snowshot"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;
@@ -48,12 +50,16 @@ public:
 
   virtual void initialize() override;
   virtual bool is_freezable() const override;
+
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
   virtual void kill_collision() override;
-  virtual std::string get_class() const override { return "leafshot"; }
-  virtual std::string get_display_name() const override { return _("Leafshot"); }
+
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  static std::string class_name() { return "leafshot"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Leafshot"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/kugelblitz.hpp
+++ b/src/badguy/kugelblitz.hpp
@@ -35,8 +35,10 @@ public:
   virtual bool is_flammable() const override;
 
   virtual void draw(DrawingContext& context) override;
-  virtual std::string get_class() const override { return "kugelblitz"; }
-  virtual std::string get_display_name() const override { return _("Kugelblitz"); }
+  static std::string class_name() { return "kugelblitz"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Kugelblitz"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   void explode();
 

--- a/src/badguy/livefire.hpp
+++ b/src/badguy/livefire.hpp
@@ -33,8 +33,10 @@ public:
   virtual bool is_flammable() const override;
 
   virtual void kill_fall() override;
-  virtual std::string get_class() const override { return "livefire"; }
-  virtual std::string get_display_name() const override { return _("Walking Flame"); }
+  static std::string class_name() { return "livefire"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Walking Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   std::string death_sound;
@@ -64,8 +66,10 @@ public:
   virtual void draw(DrawingContext& context) override;
 
   virtual void initialize() override;
-  virtual std::string get_class() const override { return "livefire_asleep"; }
-  virtual std::string get_display_name() const override { return _("Sleeping Flame"); }
+  static std::string class_name() { return "livefire_asleep"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Sleeping Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   LiveFireAsleep(const LiveFireAsleep&) = delete;
@@ -80,8 +84,10 @@ public:
   virtual void draw(DrawingContext& context) override;
 
   virtual void initialize() override;
-  virtual std::string get_class() const override { return "livefire_dormant"; }
-  virtual std::string get_display_name() const override { return _("Dormant Flame"); }
+  static std::string class_name() { return "livefire_dormant"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Dormant Flame"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   LiveFireDormant(const LiveFireDormant&) = delete;

--- a/src/badguy/mole.hpp
+++ b/src/badguy/mole.hpp
@@ -33,8 +33,10 @@ public:
 
   virtual void ignite() override;
 
-  virtual std::string get_class() const override { return "mole"; }
-  virtual std::string get_display_name() const override { return _("Mole"); }
+  static std::string class_name() { return "mole"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Mole"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
 

--- a/src/badguy/mole_rock.hpp
+++ b/src/badguy/mole_rock.hpp
@@ -39,8 +39,10 @@ public:
 
   virtual bool is_flammable() const override;
   virtual bool is_hurtable() const override { return false; }
-  virtual std::string get_class() const override { return "mole_rock"; }
-  virtual std::string get_display_name() const override { return _("Mole's rock"); }
+  static std::string class_name() { return "mole_rock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Mole's rock"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   const BadGuy* parent; /**< collisions with this BadGuy will be ignored */

--- a/src/badguy/mrbomb.hpp
+++ b/src/badguy/mrbomb.hpp
@@ -35,8 +35,10 @@ public:
   virtual bool is_portable() const override;
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "mrbomb"; }
-  virtual std::string get_display_name() const override { return _("Bomb"); }
+  static std::string class_name() { return "mrbomb"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Bomb"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -40,8 +40,10 @@ public:
 
   virtual void ignite() override;
 
-  virtual std::string get_class() const override { return "mriceblock"; }
-  virtual std::string get_display_name() const override { return _("Iceblock"); }
+  static std::string class_name() { return "mriceblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Iceblock"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   bool can_break();
 

--- a/src/badguy/mrtree.hpp
+++ b/src/badguy/mrtree.hpp
@@ -25,9 +25,12 @@ public:
   MrTree(const ReaderMapping& reader);
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "mrtree"; }
-  virtual std::string get_display_name() const override { return _("Walking Tree"); }
+
   virtual std::string get_overlay_size() const override { return "3x3"; }
+  static std::string class_name() { return "mrtree"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Walking Tree"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/owl.hpp
+++ b/src/badguy/owl.hpp
@@ -35,9 +35,13 @@ public:
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
   virtual void ignite() override;
-  virtual std::string get_class() const override { return "owl"; }
-  virtual std::string get_display_name() const override { return _("Owl"); }
+
   virtual std::string get_overlay_size() const override { return "2x2"; }
+  static std::string class_name() { return "owl"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Owl"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
   virtual ObjectSettings get_settings() override;
 
 protected:

--- a/src/badguy/plant.hpp
+++ b/src/badguy/plant.hpp
@@ -29,8 +29,10 @@ public:
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
   virtual void active_update(float dt_sec) override;
   virtual void ignite() override;
-  virtual std::string get_class() const override { return "plant"; }
-  virtual std::string get_display_name() const override { return _("Plant"); }
+  static std::string class_name() { return "plant"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Plant"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   enum PlantState {

--- a/src/badguy/poisonivy.hpp
+++ b/src/badguy/poisonivy.hpp
@@ -26,9 +26,12 @@ public:
   PoisonIvy(const Vector& pos, Direction d);
   
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "poisonivy"; }
-  virtual std::string get_display_name() const override { return _("Spring Leaf"); }
+
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  static std::string class_name() { return "poisonivy"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spring Leaf"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/rcrystallo.hpp
+++ b/src/badguy/rcrystallo.hpp
@@ -26,8 +26,10 @@ public:
 
   virtual void initialize() override;
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "rcrystallo"; }
-  virtual std::string get_display_name() const override { return _("Roof Crystallo"); }
+  static std::string class_name() { return "rcrystallo"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Roof Crystallo"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void active_update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/badguy/scrystallo.hpp
+++ b/src/badguy/scrystallo.hpp
@@ -26,8 +26,10 @@ public:
 
   virtual void initialize() override;
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "scrystallo"; }
-  virtual std::string get_display_name() const override { return _("Sleeping Crystallo"); }
+  static std::string class_name() { return "scrystallo"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Sleeping Crystallo"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;

--- a/src/badguy/short_fuse.hpp
+++ b/src/badguy/short_fuse.hpp
@@ -25,8 +25,10 @@ class ShortFuse final : public WalkingBadguy
 public:
   ShortFuse(const ReaderMapping& reader);
 
-  virtual std::string get_class() const override { return "short_fuse"; }
-  virtual std::string get_display_name() const override { return _("Short Fuse"); }
+  static std::string class_name() { return "short_fuse"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Short Fuse"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual HitResponse collision_player (Player& player, const CollisionHit& hit) override;

--- a/src/badguy/skullyhop.hpp
+++ b/src/badguy/skullyhop.hpp
@@ -33,8 +33,10 @@ public:
 
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "skullyhop"; }
-  virtual std::string get_display_name() const override { return _("Skullyhop"); }
+  static std::string class_name() { return "skullyhop"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Skullyhop"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   enum SkullyHopState {

--- a/src/badguy/skydive.hpp
+++ b/src/badguy/skydive.hpp
@@ -35,9 +35,13 @@ public:
   virtual void ungrab(MovingObject& object, Direction dir) override;
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "skydive"; }
-  virtual std::string get_display_name() const override { return _("Skydive"); }
+
   virtual std::string get_overlay_size() const override { return "2x2"; }
+  static std::string class_name() { return "skydive"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Skydive"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
 private:
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;
   virtual bool collision_squished (GameObject& obj) override;

--- a/src/badguy/smartball.hpp
+++ b/src/badguy/smartball.hpp
@@ -27,8 +27,10 @@ public:
 
   virtual std::string get_water_sprite() const override { return "images/objects/water_drop/pink_drop.sprite"; }
 
-  virtual std::string get_class() const override { return "smartball"; }
-  virtual std::string get_display_name() const override { return _("Smartball"); }
+  static std::string class_name() { return "smartball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Smartball"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/smartblock.hpp
+++ b/src/badguy/smartblock.hpp
@@ -25,8 +25,10 @@ public:
   SmartBlock(const ReaderMapping& reader);
 
   virtual std::string get_water_sprite() const override { return "images/objects/water_drop/pink_drop.sprite"; }
-  virtual std::string get_class() const override { return "smartblock"; }
-  virtual std::string get_display_name() const override { return _("Smartblock"); }
+  static std::string class_name() { return "smartblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Smartblock"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   SmartBlock(const SmartBlock&) = delete;

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -36,8 +36,10 @@ public:
   virtual void active_update(float dt_sec) override;
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "snail"; }
-  virtual std::string get_display_name() const override { return _("Snail"); }
+  static std::string class_name() { return "snail"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Snail"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual bool is_portable() const override;
   virtual void ungrab(MovingObject& , Direction dir_) override;

--- a/src/badguy/snowball.hpp
+++ b/src/badguy/snowball.hpp
@@ -25,8 +25,10 @@ public:
   SnowBall(const ReaderMapping& reader);
   SnowBall(const Vector& pos, Direction d, const std::string& script);
 
-  virtual std::string get_class() const override { return "snowball"; }
-  virtual std::string get_display_name() const override { return _("Snowball"); }
+  static std::string class_name() { return "snowball"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Snowball"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/snowman.hpp
+++ b/src/badguy/snowman.hpp
@@ -24,8 +24,10 @@ class Snowman final : public WalkingBadguy
 public:
   Snowman(const ReaderMapping& reader);
 
-  virtual std::string get_class() const override { return "snowman"; }
-  virtual std::string get_display_name() const override { return _("Snowman"); }
+  static std::string class_name() { return "snowman"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Snowman"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   void loose_head();

--- a/src/badguy/spidermite.hpp
+++ b/src/badguy/spidermite.hpp
@@ -31,9 +31,13 @@ public:
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "spidermite"; }
-  virtual std::string get_display_name() const override { return _("Spider"); }
+
   virtual std::string get_overlay_size() const override { return "2x2"; }
+  static std::string class_name() { return "spidermite"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spider"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
 protected:
   enum SpiderMiteMode {
     FLY_UP,

--- a/src/badguy/spiky.hpp
+++ b/src/badguy/spiky.hpp
@@ -26,8 +26,10 @@ public:
 
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "spiky"; }
-  virtual std::string get_display_name() const override { return _("Spiky"); }
+  static std::string class_name() { return "spiky"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spiky"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   Spiky(const Spiky&) = delete;

--- a/src/badguy/sspiky.hpp
+++ b/src/badguy/sspiky.hpp
@@ -32,8 +32,10 @@ public:
   virtual void freeze() override;
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "sspiky"; }
-  virtual std::string get_display_name() const override { return _("Sleeping Spiky"); }
+  static std::string class_name() { return "sspiky"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Sleeping Spiky"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   enum SSpikyState {

--- a/src/badguy/stalactite.hpp
+++ b/src/badguy/stalactite.hpp
@@ -34,8 +34,10 @@ public:
   virtual void draw(DrawingContext& context) override;
   virtual void deactivate() override;
 
-  virtual std::string get_class() const override { return "stalactite"; }
-  virtual std::string get_display_name() const override { return _("Stalactite"); }
+  static std::string class_name() { return "stalactite"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Stalactite"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
 

--- a/src/badguy/stumpy.hpp
+++ b/src/badguy/stumpy.hpp
@@ -31,9 +31,13 @@ public:
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "stumpy"; }
-  virtual std::string get_display_name() const override { return _("Walking Stump"); }
+
   virtual std::string get_overlay_size() const override { return "2x2"; }
+  static std::string class_name() { return "stumpy"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Walking Stump"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
 protected:
   enum MyState {
     STATE_INVINCIBLE, STATE_NORMAL

--- a/src/badguy/toad.hpp
+++ b/src/badguy/toad.hpp
@@ -33,8 +33,10 @@ public:
 
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "toad"; }
-  virtual std::string get_display_name() const override { return _("Toad"); }
+  static std::string class_name() { return "toad"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Toad"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   enum ToadState {

--- a/src/badguy/totem.hpp
+++ b/src/badguy/totem.hpp
@@ -32,8 +32,10 @@ public:
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
 
   virtual bool updatePointers(const GameObject* from_object, GameObject* to_object);
-  virtual std::string get_class() const override { return "totem"; }
-  virtual std::string get_display_name() const override { return _("Totem"); }
+  static std::string class_name() { return "totem"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Totem"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/walking_candle.hpp
+++ b/src/badguy/walking_candle.hpp
@@ -36,8 +36,10 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
-  virtual std::string get_class() const override { return "walking_candle"; }
-  virtual std::string get_display_name() const override { return _("Walking Candle"); }
+  static std::string class_name() { return "walking_candle"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Walking Candle"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   Color lightcolor;

--- a/src/badguy/walkingleaf.hpp
+++ b/src/badguy/walkingleaf.hpp
@@ -26,9 +26,12 @@ public:
   WalkingLeaf(const ReaderMapping& reader);
 
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "walkingleaf"; }
-  virtual std::string get_display_name() const override { return _("Autumn Leaf"); }
+
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  static std::string class_name() { return "walkingleaf"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Autumn Leaf"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/willowisp.hpp
+++ b/src/badguy/willowisp.hpp
@@ -52,8 +52,10 @@ public:
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;
 
-  virtual std::string get_class() const override { return "willowisp"; }
-  virtual std::string get_display_name() const override { return _("Will o' Wisp"); }
+  static std::string class_name() { return "willowisp"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Will o' Wisp"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void move_to(const Vector& pos) override;

--- a/src/badguy/yeti.hpp
+++ b/src/badguy/yeti.hpp
@@ -33,8 +33,10 @@ public:
   virtual void kill_fall() override;
 
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "yeti"; }
-  virtual std::string get_display_name() const override { return _("Yeti"); }
+  static std::string class_name() { return "yeti"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Yeti"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/yeti_stalactite.hpp
+++ b/src/badguy/yeti_stalactite.hpp
@@ -29,8 +29,10 @@ public:
   virtual void update(float dt_sec) override;
 
   virtual bool is_flammable() const override;
-  virtual std::string get_class() const override { return "yeti_stalactite"; }
-  virtual std::string get_display_name() const override { return _("Yeti's Stalactite"); }
+  static std::string class_name() { return "yeti_stalactite"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Yeti's Stalactite"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   void start_shaking();
   bool is_hanging() const;

--- a/src/badguy/zeekling.hpp
+++ b/src/badguy/zeekling.hpp
@@ -32,9 +32,12 @@ public:
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
-  virtual std::string get_class() const override { return "zeekling"; }
-  virtual std::string get_display_name() const override { return _("Zeekling"); }
+
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  static std::string class_name() { return "zeekling"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Zeekling"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -97,6 +97,8 @@ public:
 
   EditorToolboxWidget::InputType get_tileselect_input_type() const { return m_toolbox_widget->get_input_type(); }
 
+  bool has_active_toolbox_tip() const { return m_toolbox_widget->has_active_object_tip(); }
+
   int get_tileselect_select_mode() const;
   int get_tileselect_move_mode() const;
 

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -483,7 +483,7 @@ EditorOverlayWidget::hover_object()
     }
   }
 
-  if (m_hovered_object && m_hovered_object->has_settings()) {
+  if (m_hovered_object && m_hovered_object->has_settings() && !m_editor.has_active_toolbox_tip()) {
     m_object_tip = std::make_unique<Tip>(*m_hovered_object);
   }
 

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -596,9 +596,9 @@ EditorOverlayWidget::clone_object()
       auto game_object_uptr = [this]{
         std::stringstream stream;
         Writer writer(stream);
-        writer.start_list(m_hovered_object->get_class());
+        writer.start_list(m_hovered_object->get_class_name());
         m_hovered_object->save(writer);
-        writer.end_list(m_hovered_object->get_class());
+        writer.end_list(m_hovered_object->get_class_name());
 
         auto doc = ReaderDocument::from_stream(stream);
         auto object_sx = doc.get_root();

--- a/src/editor/tip.cpp
+++ b/src/editor/tip.cpp
@@ -63,25 +63,25 @@ Tip::Tip(std::string header, std::vector<std::string> text) :
 }
 
 void
-Tip::draw(DrawingContext& context, const Vector& pos)
+Tip::draw(DrawingContext& context, const Vector& pos, const bool align_right)
 {
   auto position = pos;
   position.y += 35;
   context.color().draw_text(Resources::normal_font, m_header, position,
-                              ALIGN_LEFT, LAYER_GUI-11, g_config->labeltextcolor);
+                              align_right ? ALIGN_RIGHT : ALIGN_LEFT, LAYER_GUI + 10, g_config->labeltextcolor);
 
   for (const auto& str : m_strings) {
     position.y += 22;
     context.color().draw_text(Resources::normal_font, str, position,
-                                ALIGN_LEFT, LAYER_GUI-11, ColorScheme::Menu::default_color);
+                                align_right ? ALIGN_RIGHT : ALIGN_LEFT, LAYER_GUI + 10, ColorScheme::Menu::default_color);
   }
 }
 
 void
-Tip::draw_up(DrawingContext& context, const Vector& pos)
+Tip::draw_up(DrawingContext& context, const Vector& pos, const bool align_right)
 {
   auto position = Vector(pos.x, pos.y - (static_cast<float>(m_strings.size()) + 1.0f) * 22.0f - 35.0f);
-  draw(context, position);
+  draw(context, position, align_right);
 }
 
 /* EOF */

--- a/src/editor/tip.hpp
+++ b/src/editor/tip.hpp
@@ -32,8 +32,8 @@ public:
   Tip(std::string text);
   Tip(std::string header, std::vector<std::string> text);
 
-  void draw(DrawingContext& context, const Vector& pos);
-  void draw_up(DrawingContext& context, const Vector& pos);
+  void draw(DrawingContext& context, const Vector& pos, const bool align_right = false);
+  void draw_up(DrawingContext& context, const Vector& pos, const bool align_right = false);
 
 private:
   std::vector<std::string> m_strings;

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -444,7 +444,14 @@ EditorToolboxWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
       const auto& icons = m_object_info->m_groups[m_active_objectgroup].get_icons();
       if (m_hovered_tile + m_starting_tile < static_cast<int>(icons.size())) {
         const std::string obj_class = icons[m_hovered_tile + m_starting_tile].get_object_class();
-        const std::string obj_name = GameObjectFactory::instance().create(obj_class, Vector(0, 0))->get_display_name();
+        std::string obj_name;
+        try {
+          obj_name = GameObjectFactory::instance().create(obj_class, Vector(0, 0))->get_display_name();
+        }
+        catch (std::exception& err) {
+          log_warning << "Unable to find name for object with class \"" << obj_class << "\": " << err.what() << std::endl;
+          obj_name = obj_class;
+        }
         m_object_tip = std::make_unique<Tip>(obj_name);
       }
       else {

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -19,6 +19,7 @@
 #include "editor/editor.hpp"
 #include "editor/object_info.hpp"
 #include "editor/tile_selection.hpp"
+#include "editor/tip.hpp"
 #include "editor/tool_icon.hpp"
 #include "editor/util.hpp"
 #include "gui/menu_manager.hpp"
@@ -26,6 +27,7 @@
 #include "supertux/colorscheme.hpp"
 #include "supertux/console.hpp"
 #include "supertux/gameconfig.hpp"
+#include "supertux/game_object_factory.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/level.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -40,6 +42,7 @@ EditorToolboxWidget::EditorToolboxWidget(Editor& editor) :
   m_editor(editor),
   m_tiles(new TileSelection()),
   m_object(),
+  m_object_tip(),
   m_input_type(InputType::NONE),
   m_active_tilegroup(),
   m_active_objectgroup(-1),
@@ -57,6 +60,7 @@ EditorToolboxWidget::EditorToolboxWidget(Editor& editor) :
   m_dragging(false),
   m_drag_start(0, 0),
   m_Xpos(512),
+  m_mouse_pos(0, 0),
   m_has_mouse_focus(false)
 {
   m_select_mode->push_mode("images/engine/editor/select-mode1.png");
@@ -82,6 +86,10 @@ EditorToolboxWidget::draw(DrawingContext& context)
 
   if (m_hovered_item != HoveredItem::NONE)
   {
+    if (m_object_tip) {
+      m_object_tip->draw(context, Vector(m_mouse_pos.x + 25, m_mouse_pos.y), true);
+    }
+
     context.color().draw_filled_rect(get_item_rect(m_hovered_item),
                                        g_config->editorhovercolor,
                                        0.0f, LAYER_GUI - 5);
@@ -398,14 +406,15 @@ EditorToolboxWidget::on_mouse_button_down(const SDL_MouseButtonEvent& button)
 bool
 EditorToolboxWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
 {
-  Vector mouse_pos = VideoSystem::current()->get_viewport().to_logical(motion.x, motion.y);
-  float x = mouse_pos.x - static_cast<float>(m_Xpos);
-  float y = mouse_pos.y - static_cast<float>(m_Ypos);
+  m_mouse_pos = VideoSystem::current()->get_viewport().to_logical(motion.x, motion.y);
+  float x = m_mouse_pos.x - static_cast<float>(m_Xpos);
+  float y = m_mouse_pos.y - static_cast<float>(m_Ypos);
 
   if (x < 0) {
     m_hovered_item = HoveredItem::NONE;
     m_tile_scrolling = TileScrolling::NONE;
     m_has_mouse_focus = false;
+    m_object_tip = nullptr;
     return false;
   }
 
@@ -419,15 +428,28 @@ EditorToolboxWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
       m_hovered_item = HoveredItem::OBJECTS;
     } else {
       m_hovered_item = HoveredItem::TOOL;
-      m_hovered_tile = get_tool_pos(mouse_pos);
+      m_hovered_tile = get_tool_pos(m_mouse_pos);
     }
     m_tile_scrolling = TileScrolling::NONE;
+    m_object_tip = nullptr;
     return false;
   } else {
+    const int prev_hovered_tile = std::move(m_hovered_tile);
     m_hovered_item = HoveredItem::TILE;
-    m_hovered_tile = get_tile_pos(mouse_pos);
+    m_hovered_tile = get_tile_pos(m_mouse_pos);
     if (m_dragging && m_input_type == InputType::TILE) {
       update_selection();
+    }
+    else if (m_input_type == InputType::OBJECT && m_hovered_tile != prev_hovered_tile) {
+      const auto& icons = m_object_info->m_groups[m_active_objectgroup].get_icons();
+      if (m_hovered_tile + m_starting_tile < static_cast<int>(icons.size())) {
+        const std::string obj_class = icons[m_hovered_tile + m_starting_tile].get_object_class();
+        const std::string obj_name = GameObjectFactory::instance().create(obj_class, Vector(0, 0))->get_display_name();
+        m_object_tip = std::make_unique<Tip>(obj_name);
+      }
+      else {
+        m_object_tip = nullptr;
+      }
     }
   }
 

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -446,7 +446,7 @@ EditorToolboxWidget::on_mouse_motion(const SDL_MouseMotionEvent& motion)
         const std::string obj_class = icons[m_hovered_tile + m_starting_tile].get_object_class();
         std::string obj_name;
         try {
-          obj_name = GameObjectFactory::instance().create(obj_class, Vector(0, 0))->get_display_name();
+          obj_name = GameObjectFactory::instance().get_display_name(obj_class);
         }
         catch (std::exception& err) {
           log_warning << "Unable to find name for object with class \"" << obj_class << "\": " << err.what() << std::endl;

--- a/src/editor/toolbox_widget.hpp
+++ b/src/editor/toolbox_widget.hpp
@@ -30,6 +30,7 @@ class ObjectInfo;
 class Rectf;
 class TileSelection;
 class ToolIcon;
+class Tip;
 
 /** The toolbox is on the right side of the screen and allows
     selection of the current tool and contains the object or tile
@@ -79,6 +80,7 @@ public:
   TileSelection* get_tiles() const { return m_tiles.get(); }
 
   bool has_mouse_focus() const;
+  bool has_active_object_tip() const { return m_object_tip != nullptr; }
 
 private:
   Vector get_tile_coords(const int pos) const;
@@ -101,6 +103,7 @@ private:
   std::unique_ptr<TileSelection> m_tiles;
 
   std::string m_object;
+  std::unique_ptr<Tip> m_object_tip;
   InputType m_input_type;
 
   std::unique_ptr<Tilegroup> m_active_tilegroup;
@@ -124,6 +127,7 @@ private:
   int m_Xpos;
   const int m_Ypos = 96;
 
+  Vector m_mouse_pos;
   bool m_has_mouse_focus;
 
 private:

--- a/src/editor/toolbox_widget.hpp
+++ b/src/editor/toolbox_widget.hpp
@@ -24,6 +24,7 @@
 #include "math/vector.hpp"
 #include "supertux/screen.hpp"
 #include "supertux/tile_set.hpp"
+#include "util/log.hpp"
 
 class Editor;
 class ObjectInfo;

--- a/src/editor/worldmap_objects.hpp
+++ b/src/editor/worldmap_objects.hpp
@@ -32,7 +32,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override { return FORCE_MOVE; }
-  virtual std::string get_class() const override { return "worldmap-object"; }
+  static std::string class_name() { return "worldmap-object"; }
+  virtual std::string get_class_name() const override { return class_name(); }
   virtual void move_to(const Vector& pos) override;
 
 private:
@@ -52,8 +53,10 @@ public:
 
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "level"; }
-  virtual std::string get_display_name() const override { return _("Level"); }
+  static std::string class_name() { return "level"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Level"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
 private:
@@ -74,8 +77,10 @@ public:
 
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "teleporter"; }
-  virtual std::string get_display_name() const override { return _("Teleporter"); }
+  static std::string class_name() { return "teleporter"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Teleporter"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
 private:
@@ -96,8 +101,10 @@ public:
   WorldmapSpawnPoint(const ReaderMapping& mapping);
   WorldmapSpawnPoint(const std::string& name_, const Vector& pos);
 
-  virtual std::string get_class() const override { return "worldmap-spawnpoint"; }
-  virtual std::string get_display_name() const override { return _("Spawn point"); }
+  static std::string class_name() { return "worldmap-spawnpoint"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spawn point"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 
@@ -114,8 +121,10 @@ class SpriteChange final : public WorldmapObject
 public:
   SpriteChange(const ReaderMapping& mapping);
 
-  virtual std::string get_class() const override { return "sprite-change"; }
-  virtual std::string get_display_name() const override { return _("Sprite Change"); }
+  static std::string class_name() { return "sprite-change"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Sprite Change"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
 private:
@@ -135,8 +144,10 @@ class SpecialTile final : public WorldmapObject
 public:
   SpecialTile(const ReaderMapping& mapping);
 
-  virtual std::string get_class() const override { return "special-tile"; }
-    virtual std::string get_display_name() const override { return _("Special tile"); }
+  static std::string class_name() { return "special-tile"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+    static std::string display_name() { return _("Special tile"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
 private:

--- a/src/object/ambient_light.hpp
+++ b/src/object/ambient_light.hpp
@@ -32,8 +32,10 @@ public:
 
   virtual bool is_singleton() const override { return true; }
 
-  virtual std::string get_class() const override { return "ambient-light"; }
-  virtual std::string get_display_name() const override { return _("Ambient Light"); }
+  static std::string class_name() { return "ambient-light"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ambient Light"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/ambient_light.png"; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/ambient_sound.hpp
+++ b/src/object/ambient_sound.hpp
@@ -59,8 +59,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit_) override;
 
-  virtual std::string get_class() const override { return "ambient-sound"; }
-  virtual std::string get_display_name() const override { return _("Ambient Sound"); }
+  static std::string class_name() { return "ambient-sound"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ambient Sound"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
   /** @name Scriptable Methods

--- a/src/object/background.hpp
+++ b/src/object/background.hpp
@@ -40,8 +40,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "background"; }
-  virtual std::string get_display_name() const override { return _("Background"); }
+  static std::string class_name() { return "background"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Background"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/background.png";

--- a/src/object/bicycle_platform.hpp
+++ b/src/object/bicycle_platform.hpp
@@ -62,8 +62,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void on_flip(float height) override;
 
-  virtual std::string get_class() const override { return "bicycle-platform"; }
-  virtual std::string get_display_name() const override { return _("Bicycle Platform"); }
+  static std::string class_name() { return "bicycle-platform"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Bicycle Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void editor_delete() override;

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -52,8 +52,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "bonusblock"; }
-  virtual std::string get_display_name() const override { return _("Bonus Block"); }
+  static std::string class_name() { return "bonusblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Bonus Block"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/brick.hpp
+++ b/src/object/brick.hpp
@@ -28,8 +28,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "brick"; }
-  virtual std::string get_display_name() const override { return _("Brick"); }
+  static std::string class_name() { return "brick"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Brick"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   void try_break(Player* player);
   void break_for_crusher(IceCrusher* icecrusher);
@@ -53,8 +55,10 @@ public:
   HeavyBrick(const ReaderMapping& mapping);
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "heavy-brick"; }
-  virtual std::string get_display_name() const override { return _("Heavy Brick"); }
+  static std::string class_name() { return "heavy-brick"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Heavy Brick"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   void ricochet(GameObject* collider);

--- a/src/object/bumper.hpp
+++ b/src/object/bumper.hpp
@@ -31,8 +31,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   
-  virtual std::string get_class() const override { return "bumper"; }
-  virtual std::string get_display_name() const override { return _("Bumper"); }
+  static std::string class_name() { return "bumper"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Bumper"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
 

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -63,8 +63,10 @@ public:
   virtual bool is_singleton() const override { return true; }
   virtual bool is_saveable() const override;
 
-  virtual std::string get_class() const override { return "camera"; }
-  virtual std::string get_display_name() const override { return _("Camera"); }
+  static std::string class_name() { return "camera"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Camera"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/candle.hpp
+++ b/src/object/candle.hpp
@@ -32,8 +32,10 @@ public:
   virtual void draw(DrawingContext& context) override;
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "candle"; }
-  virtual std::string get_display_name() const override { return _("Candle"); }
+  static std::string class_name() { return "candle"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Candle"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/circleplatform.hpp
+++ b/src/object/circleplatform.hpp
@@ -29,8 +29,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void on_flip(float height) override;
   
-  virtual std::string get_class() const override { return "circleplatform"; }
-  virtual std::string get_display_name() const override { return _("Circular Platform"); }
+  static std::string class_name() { return "circleplatform"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Circular Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   virtual void initialize();

--- a/src/object/cloud_particle_system.hpp
+++ b/src/object/cloud_particle_system.hpp
@@ -37,8 +37,10 @@ public:
 
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "particles-clouds"; }
-  virtual std::string get_display_name() const override { return _("Cloud Particles"); }
+  static std::string class_name() { return "particles-clouds"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Cloud Particles"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -39,8 +39,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual void update(float dt_sec) override;
-  virtual std::string get_class() const override { return "coin"; }
-  virtual std::string get_display_name() const override { return _("Coin"); }
+  static std::string class_name() { return "coin"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Coin"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
@@ -75,8 +77,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void collision_solid(const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "heavycoin"; }
-  virtual std::string get_display_name() const override { return _("Heavy Coin"); }
+  static std::string class_name() { return "heavycoin"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Heavy Coin"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -41,8 +41,10 @@ public:
   void reinit_textures();
   virtual void update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "particles-custom"; }
-  virtual std::string get_display_name() const override { return _("Custom Particles"); }
+  static std::string class_name() { return "particles-custom"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Custom Particles"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual void save(Writer& writer) override;
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/custom_particle_system_file.hpp
+++ b/src/object/custom_particle_system_file.hpp
@@ -35,8 +35,10 @@ public:
   CustomParticleSystemFile(const ReaderMapping& reader);
   ~CustomParticleSystemFile() override;
 
-  virtual std::string get_class() const override { return "particles-custom-file"; }
-  virtual std::string get_display_name() const override { return _("Custom Particles from file"); }
+  static std::string class_name() { return "particles-custom-file"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Custom Particles from file"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -36,8 +36,10 @@ public:
 
   virtual HitResponse collision(GameObject& , const CollisionHit& ) override { return FORCE_MOVE; }
 
-  virtual std::string get_class() const override { return "decal"; }
-  virtual std::string get_display_name() const override { return _("Decal"); }
+  static std::string class_name() { return "decal"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Decal"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -30,6 +30,9 @@ public:
   Explosion(const Vector& pos, float push_strength, int num_particles=100);
   Explosion(const ReaderMapping& reader);
 
+  static std::string display_name() { return _("Explosion"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;

--- a/src/object/fallblock.hpp
+++ b/src/object/fallblock.hpp
@@ -35,8 +35,10 @@ public:
 
   virtual void draw(DrawingContext& context) override;
   
-  virtual std::string get_class() const override { return "fallblock"; }
-  virtual std::string get_display_name() const override { return _("Falling Platform"); }
+  static std::string class_name() { return "fallblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Falling Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
   

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -32,8 +32,10 @@ public:
   virtual void draw(DrawingContext& context) override;
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "firefly"; }
-  virtual std::string get_display_name() const override { return _("Checkpoint"); }
+  static std::string class_name() { return "firefly"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Checkpoint"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;

--- a/src/object/ghost_particle_system.hpp
+++ b/src/object/ghost_particle_system.hpp
@@ -32,8 +32,10 @@ public:
   void init();
   virtual void update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "particles-ghosts"; }
-  virtual std::string get_display_name() const override { return _("Ghost Particles"); }
+  static std::string class_name() { return "particles-ghosts"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ghost Particles"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/ghostparticles.png";

--- a/src/object/gradient.hpp
+++ b/src/object/gradient.hpp
@@ -38,8 +38,10 @@ public:
 
   virtual bool is_saveable() const override;
 
-  virtual std::string get_class() const override { return "gradient"; }
-  virtual std::string get_display_name() const override { return _("Gradient"); }
+  static std::string class_name() { return "gradient"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Gradient"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/gradient.png";

--- a/src/object/hurting_platform.hpp
+++ b/src/object/hurting_platform.hpp
@@ -26,8 +26,10 @@ public:
   HurtingPlatform(const ReaderMapping& reader);
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "hurting_platform"; }
-  virtual std::string get_display_name() const override { return _("Hurting Platform"); }
+  static std::string class_name() { return "hurting_platform"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Hurting Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   HurtingPlatform(const HurtingPlatform&) = delete;

--- a/src/object/infoblock.hpp
+++ b/src/object/infoblock.hpp
@@ -32,8 +32,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "infoblock"; }
-  virtual std::string get_display_name() const override { return _("Info Block"); }
+  static std::string class_name() { return "infoblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Info Block"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/invisible_block.hpp
+++ b/src/object/invisible_block.hpp
@@ -27,8 +27,10 @@ public:
   InvisibleBlock(const Vector& pos);
   InvisibleBlock(const ReaderMapping& mapping);
 
-  virtual std::string get_class() const override { return "invisible_block"; }
-  virtual std::string get_display_name() const override { return _("Invisible Block"); }
+  static std::string class_name() { return "invisible_block"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Invisible Block"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void draw(DrawingContext& context) override;
   virtual bool collides(GameObject& other, const CollisionHit& hit) const override;

--- a/src/object/invisible_wall.hpp
+++ b/src/object/invisible_wall.hpp
@@ -32,8 +32,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "invisible_wall"; }
-  virtual std::string get_display_name() const override { return _("Invisible Wall"); }
+  static std::string class_name() { return "invisible_wall"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Invisible Wall"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual bool has_variable_size() const override { return true; }
 

--- a/src/object/ispy.hpp
+++ b/src/object/ispy.hpp
@@ -30,8 +30,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual void update(float dt_sec) override;
-  virtual std::string get_class() const override { return "ispy"; }
-  virtual std::string get_display_name() const override { return _("Ispy"); }
+  static std::string class_name() { return "ispy"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Ispy"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/lantern.hpp
+++ b/src/object/lantern.hpp
@@ -33,8 +33,10 @@ public:
   virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
   virtual void ungrab(MovingObject& object, Direction dir) override;
 
-  virtual std::string get_class() const override { return "lantern"; }
-  virtual std::string get_display_name() const override { return _("Lantern"); }
+  static std::string class_name() { return "lantern"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Lantern"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/level_time.hpp
+++ b/src/object/level_time.hpp
@@ -51,8 +51,10 @@ public:
   void set_time(float time_left);
 
   /** @} */
-  virtual std::string get_class() const override { return "leveltime"; }
-  virtual std::string get_display_name() const override { return _("Time Limit"); }
+  static std::string class_name() { return "leveltime"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Time Limit"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/lit_object.hpp
+++ b/src/object/lit_object.hpp
@@ -38,8 +38,10 @@ public:
   virtual HitResponse collision(GameObject&, const CollisionHit&) override
     { return ABORT_MOVE; }
 
-  virtual std::string get_class() const override { return "lit-object"; }
-  virtual std::string get_display_name() const override { return _("Lit object"); }
+  static std::string class_name() { return "lit-object"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Lit object"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/magicblock.hpp
+++ b/src/object/magicblock.hpp
@@ -37,8 +37,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
-  virtual std::string get_class() const override { return "magicblock"; }
-  virtual std::string get_display_name() const override { return _("Magic Tile"); }
+  static std::string class_name() { return "magicblock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Magic Tile"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -48,7 +48,8 @@ public:
 
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;
-  virtual std::string get_class() const override { return "moving-sprite"; }
+  static std::string class_name() { return "moving-sprite"; }
+  virtual std::string get_class_name() const override { return class_name(); }
   virtual std::string get_default_sprite_name() const { return m_default_sprite_name; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/music_object.hpp
+++ b/src/object/music_object.hpp
@@ -37,8 +37,10 @@ public:
 
   virtual bool is_singleton() const override { return true; }
 
-  virtual std::string get_class() const override { return "music"; }
-  virtual std::string get_display_name() const override { return _("Music"); }
+  static std::string class_name() { return "music"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Music"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/music.png"; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/particle_zone.hpp
+++ b/src/object/particle_zone.hpp
@@ -36,8 +36,10 @@ public:
   virtual void draw(DrawingContext& context) override;
 
   virtual bool has_variable_size() const override { return true; }
-  virtual std::string get_class() const override { return "particle-zone"; }
-  virtual std::string get_display_name() const override { return _("Particle zone");}
+  static std::string class_name() { return "particle-zone"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Particle zone"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/particlesystem.hpp
+++ b/src/object/particlesystem.hpp
@@ -53,8 +53,10 @@ public:
 
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "particle-system"; }
-  virtual std::string get_display_name() const override { return _("Particle system"); }
+  static std::string class_name() { return "particle-system"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Particle system"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   void set_enabled(bool enabled_);

--- a/src/object/path_gameobject.hpp
+++ b/src/object/path_gameobject.hpp
@@ -40,8 +40,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "path"; }
-  virtual std::string get_display_name() const override { return _("Path"); }
+  static std::string class_name() { return "path"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Path"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/path.png";

--- a/src/object/platform.hpp
+++ b/src/object/platform.hpp
@@ -41,8 +41,10 @@ public:
 
   virtual void move_to(const Vector& pos) override;
 
-  virtual std::string get_class() const override { return "platform"; }
-  virtual std::string get_display_name() const override { return _("Platform"); }
+  static std::string class_name() { return "platform"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void editor_update() override;
 

--- a/src/object/pneumatic_platform.hpp
+++ b/src/object/pneumatic_platform.hpp
@@ -60,8 +60,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void on_flip(float height) override;
 
-  virtual std::string get_class() const override { return "pneumatic-platform"; }
-  virtual std::string get_display_name() const override { return _("Pneumatic Platform"); }
+  static std::string class_name() { return "pneumatic-platform"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Pneumatic Platform"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -32,8 +32,10 @@ public:
   virtual void on_flip(float height) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "powerup"; }
-  virtual std::string get_display_name() const override { return _("Powerup"); }
+  static std::string class_name() { return "powerup"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Powerup"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/pushbutton.hpp
+++ b/src/object/pushbutton.hpp
@@ -27,8 +27,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
-  virtual std::string get_class() const override { return "pushbutton"; }
-  virtual std::string get_display_name() const override { return _("Button"); }
+  static std::string class_name() { return "pushbutton"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Button"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/rain_particle_system.hpp
+++ b/src/object/rain_particle_system.hpp
@@ -36,8 +36,10 @@ public:
   void init();
   virtual void update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "particles-rain"; }
-  virtual std::string get_display_name() const override { return _("Rain Particles"); }
+  static std::string class_name() { return "particles-rain"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Rain Particles"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   void fade_speed(float new_speed, float fade_time);

--- a/src/object/rock.hpp
+++ b/src/object/rock.hpp
@@ -38,8 +38,10 @@ public:
 
   virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
   virtual void ungrab(MovingObject& object, Direction dir) override;
-  virtual std::string get_class() const override { return "rock"; }
-  virtual std::string get_display_name() const override { return _("Rock"); }
+  static std::string class_name() { return "rock"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Rock"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   /** Adds velocity from wind */

--- a/src/object/rublight.hpp
+++ b/src/object/rublight.hpp
@@ -29,8 +29,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
-  virtual std::string get_class() const override { return "rublight"; }
-  virtual std::string get_display_name() const override { return _("Rublight"); }
+  static std::string class_name() { return "rublight"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Rublight"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;

--- a/src/object/rusty_trampoline.hpp
+++ b/src/object/rusty_trampoline.hpp
@@ -35,8 +35,10 @@ public:
   virtual void grab(MovingObject&, const Vector& pos, Direction) override;
   virtual void ungrab(MovingObject&, Direction) override;
   virtual bool is_portable() const override;
-  virtual std::string get_class() const override { return "rustytrampoline"; }
-  virtual std::string get_display_name() const override { return _("Rusty Trampoline"); }
+  static std::string class_name() { return "rustytrampoline"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Rusty Trampoline"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
 private:

--- a/src/object/scripted_object.hpp
+++ b/src/object/scripted_object.hpp
@@ -35,8 +35,10 @@ public:
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
-  virtual std::string get_class() const override { return "scriptedobject"; }
-  virtual std::string get_display_name() const override { return _("Scripted Object"); }
+  static std::string class_name() { return "scriptedobject"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Scripted Object"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/shard.hpp
+++ b/src/object/shard.hpp
@@ -30,8 +30,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  virtual std::string get_class() const override { return "shard"; }
-  virtual std::string get_display_name() const override { return _("Shard"); }
+  static std::string class_name() { return "shard"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Shard"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 protected:
   Physic m_physic;

--- a/src/object/skull_tile.hpp
+++ b/src/object/skull_tile.hpp
@@ -28,8 +28,10 @@ class SkullTile final : public MovingSprite
 public:
   SkullTile(const ReaderMapping& mapping);
 
-  virtual std::string get_class() const override { return "skull_tile"; }
-  virtual std::string get_display_name() const override { return _("Skull Tile"); }
+  static std::string class_name() { return "skull_tile"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Skull Tile"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;

--- a/src/object/snow_particle_system.hpp
+++ b/src/object/snow_particle_system.hpp
@@ -31,8 +31,10 @@ public:
 
   virtual void update(float dt_sec) override;
 
-  virtual std::string get_class() const override { return "particles-snow"; }
-  virtual std::string get_display_name() const override { return _("Snow Particles"); }
+  static std::string class_name() { return "particles-snow"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Snow Particles"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/snow.png";

--- a/src/object/spawnpoint.hpp
+++ b/src/object/spawnpoint.hpp
@@ -43,8 +43,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override { return FORCE_MOVE; }
 
-  virtual std::string get_class() const override { return "spawnpoint"; }
-  virtual std::string get_display_name() const override { return _("Spawnpoint"); }
+  static std::string class_name() { return "spawnpoint"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spawnpoint"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual int get_layer() const override { return LAYER_FOREGROUND1; }

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -47,8 +47,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit_) override;
 
-  virtual std::string get_class() const override { return "spotlight"; }
-  virtual std::string get_display_name() const override { return _("Spotlight"); }
+  static std::string class_name() { return "spotlight"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Spotlight"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/text_array_object.hpp
+++ b/src/object/text_array_object.hpp
@@ -46,8 +46,10 @@ public:
   virtual bool is_singleton() const override { return true; }
   virtual bool is_saveable() const override { return false; }
 
-  virtual std::string get_class() const override { return "text-array"; }
-  virtual std::string get_display_name() const override { return _("Text array"); }
+  static std::string class_name() { return "text-array"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Text array"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/textarray.png";

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -39,8 +39,10 @@ public:
   TextObject(const std::string& name = std::string());
   ~TextObject() override;
 
-  virtual std::string get_class() const override { return "textobject"; }
-  virtual std::string get_display_name() const override { return _("Text"); }
+  static std::string class_name() { return "textobject"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Text"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual const std::string get_icon_path() const override { return "images/engine/editor/textarray.png"; }
 

--- a/src/object/textscroller.hpp
+++ b/src/object/textscroller.hpp
@@ -40,8 +40,10 @@ public:
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "textscroller"; }
-  virtual std::string get_display_name() const override { return _("Text Scroller"); }
+  static std::string class_name() { return "textscroller"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Text Scroller"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/textscroller.png"; }
 
   void set_default_speed(float default_speed);

--- a/src/object/thunderstorm.hpp
+++ b/src/object/thunderstorm.hpp
@@ -36,8 +36,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 
-  virtual std::string get_class() const override { return "thunderstorm"; }
-  virtual std::string get_display_name() const override { return _("Thunderstorm"); }
+  static std::string class_name() { return "thunderstorm"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Thunderstorm"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -52,9 +52,11 @@ public:
 
   virtual void finish_construction() override;
 
-  virtual std::string get_class() const override { return "tilemap"; }
+  static std::string class_name() { return "tilemap"; }
+  virtual std::string get_class_name() const override { return class_name(); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/tilemap.png"; }
-  virtual std::string get_display_name() const override { return _("Tilemap"); }
+  static std::string display_name() { return _("Tilemap"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -38,8 +38,10 @@ public:
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& ) override;
 
-  virtual std::string get_class() const override { return "torch"; }
-  virtual std::string get_display_name() const override { return _("Torch"); }
+  static std::string class_name() { return "torch"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Torch"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/trampoline.hpp
+++ b/src/object/trampoline.hpp
@@ -31,8 +31,10 @@ public:
 
   virtual void grab(MovingObject&, const Vector& pos, Direction) override;
   virtual bool is_portable() const override;
-  virtual std::string get_class() const override { return "trampoline"; }
-  virtual std::string get_display_name() const override { return _("Trampoline"); }
+  static std::string class_name() { return "trampoline"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Trampoline"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/unstable_tile.hpp
+++ b/src/object/unstable_tile.hpp
@@ -34,8 +34,10 @@ public:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual void on_flip(float height) override;
-  virtual std::string get_class() const override { return "unstable_tile"; }
-  virtual std::string get_display_name() const override { return _("Unstable Tile"); }
+  static std::string class_name() { return "unstable_tile"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Unstable Tile"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
 private:
   enum State {

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -31,8 +31,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
-  virtual std::string get_class() const override { return "weak_block"; }
-  virtual std::string get_display_name() const override { return _("Weak Tile"); }
+  static std::string class_name() { return "weak_block"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Weak Tile"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -38,8 +38,10 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual bool has_variable_size() const override { return true; }
-  virtual std::string get_class() const override { return "wind"; }
-  virtual std::string get_display_name() const override { return _("Wind");}
+  static std::string class_name() { return "wind"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Wind"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/squirrel/exposed_object.hpp
+++ b/src/squirrel/exposed_object.hpp
@@ -73,7 +73,7 @@ public:
       return;
     }
 
-    log_debug << "Exposing " << m_parent->get_class() << " object " << name << std::endl;
+    log_debug << "Exposing " << m_parent->get_class_name() << " object " << name << std::endl;
 
     auto object = std::make_unique<T>(m_parent->get_uid());
     expose_object(vm, table_idx, std::move(object), name);

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -74,7 +74,7 @@ public:
 
   /** This function saves the object. Editor will use that. */
   virtual void save(Writer& writer);
-  virtual std::string get_class() const { return "game-object"; }
+  virtual std::string get_class_name() const { return "game-object"; }
   virtual std::string get_display_name() const { return _("Unknown object"); }
 
   /** If true only a single object of this type is allowed in a

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -250,6 +250,7 @@ GameObjectFactory::init_factories()
   add_factory<LevelTime>("leveltime");
   add_factory<LitObject>("lit-object");
   add_factory<MagicBlock>("magicblock");
+  add_custom_name_factory("#node", "Path Node");
   add_factory<ParticleZone>("particle-zone");
   add_factory<Platform>("platform");
   add_factory<PneumaticPlatform>("pneumatic-platform");
@@ -313,6 +314,12 @@ GameObjectFactory::create(const std::string& name, const Vector& pos, const Dire
 
   auto doc = ReaderDocument::from_stream(lisptext);
   return create(name, doc.get_root().get_mapping());
+}
+
+std::string
+GameObjectFactory::get_display_name(const std::string& name) const
+{
+  return get_factory_display_name(name);
 }
 
 /* EOF */

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -139,6 +139,7 @@
 #include "trigger/text_area.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
+#include "util/gettext.hpp"
 
 GameObjectFactory&
 GameObjectFactory::instance()
@@ -250,7 +251,7 @@ GameObjectFactory::init_factories()
   add_factory<LevelTime>("leveltime");
   add_factory<LitObject>("lit-object");
   add_factory<MagicBlock>("magicblock");
-  add_custom_name_factory("#node", "Path Node");
+  add_custom_name_factory("#node", _("Path Node"));
   add_factory<ParticleZone>("particle-zone");
   add_factory<Platform>("platform");
   add_factory<PneumaticPlatform>("pneumatic-platform");
@@ -297,6 +298,7 @@ GameObjectFactory::init_factories()
       auto tileset = TileManager::current()->get_tileset(Level::current()->get_tileset());
       return std::make_unique<TileMap>(tileset, reader);
     });
+  add_custom_name_factory("tilemap", TileMap::display_name());
 }
 
 std::unique_ptr<GameObject>

--- a/src/supertux/game_object_factory.hpp
+++ b/src/supertux/game_object_factory.hpp
@@ -31,6 +31,7 @@ public:
   std::unique_ptr<GameObject> create(const std::string& name,
                                      const Vector& pos, const Direction& dir = Direction::AUTO,
                                      const std::string& data = {}) const;
+  std::string get_display_name(const std::string& name) const;
 
 private:
   GameObjectFactory();

--- a/src/supertux/moving_object.hpp
+++ b/src/supertux/moving_object.hpp
@@ -92,7 +92,8 @@ public:
     return &m_col;
   }
 
-  virtual std::string get_class() const override { return "moving-object"; }
+  static std::string class_name() { return "moving-object"; }
+  virtual std::string get_class_name() const override { return class_name(); }
   virtual ObjectSettings get_settings() override;
 
   virtual void editor_select() override;

--- a/src/supertux/object_factory.cpp
+++ b/src/supertux/object_factory.cpp
@@ -22,7 +22,8 @@
 #include "supertux/game_object.hpp"
 
 ObjectFactory::ObjectFactory() :
-  factories()
+  factories(),
+  name_factories()
 {
 }
 
@@ -40,6 +41,23 @@ ObjectFactory::create(const std::string& name, const ReaderMapping& reader) cons
   else
   {
     return it->second(reader);
+  }
+}
+
+std::string
+ObjectFactory::get_factory_display_name(const std::string& name) const
+{
+  auto it = name_factories.find(name);
+
+  if (it == name_factories.end())
+  {
+    std::stringstream msg;
+    msg << "No name factory for object '" << name << "' found.";
+    throw std::runtime_error(msg.str());
+  }
+  else
+  {
+    return it->second();
   }
 }
 

--- a/src/supertux/object_factory.hpp
+++ b/src/supertux/object_factory.hpp
@@ -59,7 +59,7 @@ protected:
     name_factories[class_name] = func;
   }
 
-  void add_custom_name_factory(const char* class_name, const char* display_name)
+  void add_custom_name_factory(const char* class_name, const std::string display_name)
   {
     add_name_factory(class_name, [display_name]() {
         return display_name;

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -697,14 +697,14 @@ Sector::save(Writer &writer)
 
   std::stable_sort(objects.begin(), objects.end(),
                    [](const GameObject* lhs, GameObject* rhs) {
-                     return lhs->get_class() < rhs->get_class();
+                     return lhs->get_class_name() < rhs->get_class_name();
                    });
 
   for (auto& obj : objects) {
     if (obj->is_saveable()) {
-      writer.start_list(obj->get_class());
+      writer.start_list(obj->get_class_name());
       obj->save(writer);
-      writer.end_list(obj->get_class());
+      writer.end_list(obj->get_class_name());
     }
   }
 

--- a/src/trigger/climbable.hpp
+++ b/src/trigger/climbable.hpp
@@ -45,8 +45,10 @@ public:
   Climbable(const Rectf& area);
   ~Climbable() override;
 
-  virtual std::string get_class() const override { return "climbable"; }
-  virtual std::string get_display_name() const override { return _("Climbable"); }
+  static std::string class_name() { return "climbable"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Climbable"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -31,8 +31,10 @@ public:
   Door(int x, int y, const std::string& sector, const std::string& spawnpoint);
   ~Door() override;
 
-  virtual std::string get_class() const override { return "door"; }
-  virtual std::string get_display_name() const override { return _("Door"); }
+  static std::string class_name() { return "door"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Door"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -28,8 +28,10 @@ public:
   ScriptTrigger(const ReaderMapping& reader);
   ScriptTrigger(const Vector& pos, const std::string& script);
 
-  virtual std::string get_class() const override { return "scripttrigger"; }
-  std::string get_display_name() const override { return _("Script Trigger"); }
+  static std::string class_name() { return "scripttrigger"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Script Trigger"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/trigger/secretarea_trigger.hpp
+++ b/src/trigger/secretarea_trigger.hpp
@@ -32,8 +32,10 @@ public:
   SecretAreaTrigger(const ReaderMapping& reader);
   SecretAreaTrigger(const Rectf& area, const std::string& fade_tilemap = "");
 
-  virtual std::string get_class() const override { return "secretarea"; }
-  virtual std::string get_display_name() const override { return _("Secret Area"); }
+  static std::string class_name() { return "secretarea"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Secret Area"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/trigger/sequence_trigger.hpp
+++ b/src/trigger/sequence_trigger.hpp
@@ -29,8 +29,10 @@ public:
   SequenceTrigger(const ReaderMapping& reader);
   SequenceTrigger(const Vector& pos, const std::string& sequence_name);
 
-  virtual std::string get_class() const override { return "sequencetrigger"; }
-  virtual std::string get_display_name() const override { return _("Sequence Trigger"); }
+  static std::string class_name() { return "sequencetrigger"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Sequence Trigger"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/trigger/switch.hpp
+++ b/src/trigger/switch.hpp
@@ -30,8 +30,10 @@ public:
   Switch(const ReaderMapping& reader);
   ~Switch() override;
 
-  virtual std::string get_class() const override { return "switch"; }
-  virtual std::string get_display_name() const override { return _("Switch"); }
+  static std::string class_name() { return "switch"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Switch"); }
+  virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/trigger/text_area.hpp
+++ b/src/trigger/text_area.hpp
@@ -42,8 +42,10 @@ public:
   virtual void update(float dt_sec) override;
 
   virtual ObjectSettings get_settings() override;
-  virtual std::string get_class() const override { return "text-area"; }
-  virtual std::string get_display_name() const override { return _("Text Area"); }
+  static std::string class_name() { return "text-area"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Text Area"); }
+  virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
 
 private:


### PR DESCRIPTION
Adds the ability for an object's name to be shown in the editor toolbox, when the mouse cursor hovers over it.

![image](https://user-images.githubusercontent.com/78196474/174139923-a7888664-732c-4253-afb8-7c9709d23f97.png)

**Potential issue:** Currently, the toolbox gets an object's name by using a new temporary instance of it, via `GameObjectFactory`. That may not be a good solution, because creating an object just to get its name is not optimal (additional messages from the new object can also be seen in the log, because of that). **[FIXED]**