### PR TITLE
Package addons as "Community Contrib Levels"

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -943,6 +943,8 @@ Editor::pack_addon()
 {
   auto id = FileSystem::basename(get_world()->get_basedir());
 
+  get_world()->save(false, true); //Save with "contrib-type" set to "community".
+
   int version = 0;
   try
   {
@@ -985,6 +987,8 @@ Editor::pack_addon()
   info.end_list("supertux-addoninfo");
 
   *zip.Add_File(id + ".nfo") << ss.rdbuf();
+
+  get_world()->save(); //Revert saving with "contrib-type" set to "community".
 }
 
 /* EOF */

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -943,7 +943,7 @@ Editor::pack_addon()
 {
   auto id = FileSystem::basename(get_world()->get_basedir());
 
-  get_world()->save(false, true); //Save with "contrib-type" set to "community".
+  get_world()->save(false, true); //Replace the levelset info file with a new one, made for an addon.
 
   int version = 0;
   try
@@ -988,7 +988,7 @@ Editor::pack_addon()
 
   *zip.Add_File(id + ".nfo") << ss.rdbuf();
 
-  get_world()->save(); //Revert saving with "contrib-type" set to "community".
+  get_world()->save(); //Revert back to a regular levelset info file.
 }
 
 /* EOF */

--- a/src/supertux/world.cpp
+++ b/src/supertux/world.cpp
@@ -109,7 +109,7 @@ World::World(const std::string& directory) :
 }
 
 void
-World::save(bool retry)
+World::save(bool retry, const bool addon)
 {
   std::string filepath = FileSystem::join(m_basedir, "/info");
 
@@ -142,20 +142,20 @@ World::save(bool retry)
     writer.write("title", m_title, true);
     writer.write("description", m_description, true);
     writer.write("levelset", m_is_levelset);
-    writer.write("contrib-type", "user");
+    writer.write("contrib-type", addon ? "community" : "user");
     writer.write("hide-from-contribs", m_hide_from_contribs);
 
     writer.end_list("supertux-level-subset");
-    log_warning << "Levelset info saved as " << filepath << "." << std::endl;
+    log_warning << "Levelset" << (addon ? " addon " : " ") << "info saved as " << filepath << "." << std::endl;
   }
   catch(std::exception& e)
   {
     if (retry) {
       std::stringstream msg;
-      msg << "Problem when saving levelset info '" << filepath << "': " << e.what();
+      msg << "Problem when saving" << (addon ? " addon " : " ") << "levelset info '" << filepath << "': " << e.what();
       throw std::runtime_error(msg.str());
     } else {
-      log_warning << "Failed to save the levelset info, retrying..." << std::endl;
+      log_warning << "Failed to save the" << (addon ? " addon " : " ") << "levelset info, retrying..." << std::endl;
       { // create the levelset directory again
         std::string dirname = FileSystem::dirname(filepath);
         if (!PHYSFS_mkdir(dirname.c_str()))

--- a/src/supertux/world.hpp
+++ b/src/supertux/world.hpp
@@ -46,7 +46,7 @@ public:
   std::string get_worldmap_filename() const;
   std::string get_savegame_filename() const;
 
-  void save(bool retry = false);
+  void save(bool retry = false, const bool addon = false);
 
 public:
   std::string m_title;


### PR DESCRIPTION
Changes the `contrib-type` property of levelsets, packaged using the in-game level editor option "Package Add-on", to `community`, so new add-ons, packaged from there, show up in the "Community Contrib Levels" section in "Contrib Levels". Achieved by replacing the `info` file of the levelset with one where the property is set to `community`, before the add-on is archived, and afterwards reverting it back to `user`.