### PR TITLE
Fix lanterns with white color not being lit

### DIFF
--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -36,7 +36,7 @@ Lantern::Lantern(const ReaderMapping& reader) :
     lightcolor = Color(vColor);
   } else {
     if (!Editor::is_active()) {
-      lightcolor = Color(0, 0, 0);
+      lightcolor = Color(1, 1, 1);
     }
   }
   lightsprite->set_blend(Blend::ADD);


### PR DESCRIPTION
Fixes issue with lantern with white color (default value) not being lit. The reason for this is that default values are not written to level file, which caused setting color to black when loading lantern data from level file.