### PR TITLE
Improvements to text field item and script menu

### DIFF
--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -240,6 +240,42 @@ StringObjectOption::add_to_menu(Menu& menu) const
   menu.add_textfield(get_text(), m_pointer);
 }
 
+StringMultilineObjectOption::StringMultilineObjectOption(const std::string& text, std::string* pointer, const std::string& key,
+                                       boost::optional<std::string> default_value,
+                                       unsigned int flags) :
+  ObjectOption(text, key, flags),
+  m_pointer(pointer),
+  m_default_value(std::move(default_value))
+{
+}
+
+void
+StringMultilineObjectOption::save(Writer& writer) const
+{
+  if (!get_key().empty()) {
+    if ((m_default_value && *m_default_value == *m_pointer) || m_pointer->empty()) {
+      // skip
+    } else {
+      writer.write(get_key(), *m_pointer, (get_flags() & OPTION_TRANSLATABLE));
+    }
+  }
+}
+
+std::string
+StringMultilineObjectOption::to_string() const
+{
+  if (!m_pointer->empty()) {
+    return "...";
+  }
+  return "";
+}
+
+void
+StringMultilineObjectOption::add_to_menu(Menu& menu) const
+{
+  menu.add_script(get_text(), m_pointer);
+}
+
 StringSelectObjectOption::StringSelectObjectOption(const std::string& text, int* pointer,
                                                    const std::vector<std::string>& select,
                                                    boost::optional<int> default_value,

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -186,6 +186,26 @@ private:
   StringObjectOption& operator=(const StringObjectOption&) = delete;
 };
 
+class StringMultilineObjectOption : public ObjectOption
+{
+public:
+  StringMultilineObjectOption(const std::string& text, std::string* pointer, const std::string& key,
+                     boost::optional<std::string> default_value,
+                     unsigned int flags);
+
+  virtual void save(Writer& write) const override;
+  virtual std::string to_string() const override;
+  virtual void add_to_menu(Menu& menu) const override;
+
+private:
+  std::string* const m_pointer;
+  boost::optional<std::string> m_default_value;
+
+private:
+  StringMultilineObjectOption(const StringMultilineObjectOption&) = delete;
+  StringMultilineObjectOption& operator=(const StringMultilineObjectOption&) = delete;
+};
+
 class StringSelectObjectOption : public ObjectOption
 {
 public:

--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -178,6 +178,25 @@ ObjectSettings::add_translatable_text(const std::string& text, std::string* valu
 }
 
 void
+ObjectSettings::add_multiline_text(const std::string& text, std::string* value_ptr,
+                         const std::string& key,
+                         const boost::optional<std::string>& default_value,
+                         unsigned int flags)
+{
+  add_option(std::make_unique<StringMultilineObjectOption>(text, value_ptr, key, default_value, flags));
+}
+
+void
+ObjectSettings::add_multiline_translatable_text(const std::string& text, std::string* value_ptr,
+                                      const std::string& key,
+                                      const boost::optional<std::string>& default_value,
+                                      unsigned int flags)
+{
+  add_option(std::make_unique<StringMultilineObjectOption>(text, value_ptr, key, default_value,
+                                                  flags | OPTION_TRANSLATABLE));
+}
+
+void
 ObjectSettings::add_string_select(const std::string& text, int* value_ptr, const std::vector<std::string>& select,
                                   const boost::optional<int>& default_value,
                                   const std::string& key, unsigned int flags)

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -94,6 +94,14 @@ public:
                              const std::string& key = {},
                              const boost::optional<std::string>& default_value = {},
                              unsigned int flags = 0);
+  void add_multiline_text(const std::string& text, std::string* value_ptr,
+                          const std::string& key = {},
+                          const boost::optional<std::string>& default_value = {},
+                          unsigned int flags = 0);
+  void add_multiline_translatable_text(const std::string& text, std::string* value_ptr,
+                                       const std::string& key = {},
+                                       const boost::optional<std::string>& default_value = {},
+                                       unsigned int flags = 0);
   void add_string_select(const std::string& text, int* value_ptr, const std::vector<std::string>& select,
                          const boost::optional<int>& default_value = {},
                          const std::string& key = {}, unsigned int flags = 0);

--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -113,6 +113,13 @@ ItemFloatField::insert_at(const std::string& text, const int index)
 }
 
 void
+ItemFloatField::clear()
+{
+  input->clear();
+  *number = 0;
+}
+
+void
 ItemFloatField::delete_front()
 {
   if (!input->empty() && m_cursor_left_offset < static_cast<int>(input->size()))

--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -19,8 +19,8 @@
 
 ItemFloatField::ItemFloatField(const std::string& text_, float* input_, int id_) :
   ItemTextField(text_, new std::string, id_),
-  m_input(std::to_string(*input_)),
   number(input_),
+  m_input(std::to_string(*input_)),
   m_has_comma(true)
 {
   change_input(m_input);

--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -101,7 +101,7 @@ ItemFloatField::on_input_update()
     return;
   }
 
-  m_has_comma = input->find(".") != std::string::npos || input->find(",") != std::string::npos;
+  m_has_comma = input->find(".") != std::string::npos;
 
   try
   {

--- a/src/gui/item_floatfield.hpp
+++ b/src/gui/item_floatfield.hpp
@@ -28,17 +28,19 @@ public:
 
   float* number;
 
-  /** Processes the given custom event cases. */
-  virtual bool custom_event(const SDL_Event& ev) override;
+  // Text manipulation and navigation functions
 
-  /** Processes the menu action. */
-  virtual void process_action(const MenuAction& action) override;
+  virtual void insert_at(const std::string& text, const int index) override;
+  virtual void delete_front() override;
+  virtual void delete_back() override;
+  virtual void undo() override;
+  virtual void redo() override;
 
 private:
   std::string m_input;
   bool m_has_comma;
 
-  void add_char(char c);
+  void add_char(char c, const int index);
 
 private:
   ItemFloatField(const ItemFloatField&) = delete;

--- a/src/gui/item_floatfield.hpp
+++ b/src/gui/item_floatfield.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,40 +18,25 @@
 #ifndef HEADER_SUPERTUX_GUI_ITEM_FLOATFIELD_HPP
 #define HEADER_SUPERTUX_GUI_ITEM_FLOATFIELD_HPP
 
-#include "gui/menu_item.hpp"
+#include "gui/item_textfield.hpp"
 
-class ItemFloatField final : public MenuItem
+class ItemFloatField final : public ItemTextField
 {
 public:
   ItemFloatField(const std::string& text_, float* input_, int id_ = -1);
+  ~ItemFloatField() override;
 
-  /** Draws the menu item. */
-  virtual void draw(DrawingContext&, const Vector& pos, int menu_width, bool active) override;
+  float* number;
 
-  /** Returns the minimum width of the menu item. */
-  virtual int get_width() const override;
+  /** Processes the given custom event cases. */
+  virtual bool custom_event(const SDL_Event& ev) override;
 
   /** Processes the menu action. */
   virtual void process_action(const MenuAction& action) override;
 
-  float* number;
-
-  void change_input(const std::string& input_) {
-    input = input_;
-  }
-
-  /** Processes the given event. */
-  virtual void event(const SDL_Event& ev) override;
-
-  virtual bool changes_width() const override {
-    return true;
-  }
-
 private:
-
-  std::string input;
-  int flickw;
-  bool has_comma;
+  std::string m_input;
+  bool m_has_comma;
 
   void add_char(char c);
 

--- a/src/gui/item_floatfield.hpp
+++ b/src/gui/item_floatfield.hpp
@@ -28,14 +28,12 @@ public:
 
   float* number;
 
+  /** Calls when the input gets updated. */
+  virtual void on_input_update() override;
+
   // Text manipulation and navigation functions
 
   virtual void insert_at(const std::string& text, const int index) override;
-  virtual void clear() override;
-  virtual void delete_front() override;
-  virtual void delete_back() override;
-  virtual void undo() override;
-  virtual void redo() override;
 
 private:
   std::string m_input;

--- a/src/gui/item_floatfield.hpp
+++ b/src/gui/item_floatfield.hpp
@@ -23,7 +23,7 @@
 class ItemFloatField final : public ItemTextField
 {
 public:
-  ItemFloatField(const std::string& text_, float* input_, int id_ = -1);
+  ItemFloatField(const std::string& text_, float* input_, int id_ = -1, bool positive = false);
   ~ItemFloatField() override;
 
   float* number;
@@ -33,13 +33,14 @@ public:
 
   // Text manipulation and navigation functions
 
-  virtual void insert_at(const std::string& text, const int index) override;
+  virtual void insert_text(const std::string& text, const int left_offset_pos) override;
 
 private:
   std::string m_input;
   bool m_has_comma;
+  const bool m_positive;
 
-  void add_char(char c, const int index);
+  void add_char(char c, const int left_offset_pos);
 
 private:
   ItemFloatField(const ItemFloatField&) = delete;

--- a/src/gui/item_floatfield.hpp
+++ b/src/gui/item_floatfield.hpp
@@ -31,6 +31,7 @@ public:
   // Text manipulation and navigation functions
 
   virtual void insert_at(const std::string& text, const int index) override;
+  virtual void clear() override;
   virtual void delete_front() override;
   virtual void delete_back() override;
   virtual void undo() override;

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -19,8 +19,8 @@
 
 ItemIntField::ItemIntField(const std::string& text_, int* input_, int id_) :
   ItemTextField(text_, new std::string, id_),
-  m_input(std::to_string(*input_)),
-  number(input_)
+  number(input_),
+  m_input(std::to_string(*input_))
 {
   change_input(m_input);
 }

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -35,11 +35,19 @@ ItemIntField::add_char(char c, const int index)
 {
   if (c == '-')
   {
+    update_undo();
     if (!input->empty() && *input != "0")
     {
-      update_undo();
       *number *= -1;
-      *input = std::to_string(*number);
+      if (*input->begin() == '-')
+      {
+        if (m_cursor_left_offset == static_cast<int>(input->size())) m_cursor_left_offset--;
+        input->erase(input->begin());
+      }
+      else
+      {
+        input->insert(input->begin(), '-');
+      }
     }
     else
     {
@@ -53,6 +61,18 @@ ItemIntField::add_char(char c, const int index)
   update_undo();
   *input = input->substr(0, input->size() - index) + c +
     input->substr(input->size() - index);
+  on_input_update();
+}
+
+void
+ItemIntField::on_input_update()
+{
+  if (input->empty())
+  {
+    *number = 0;
+    return;
+  }
+
   try
   {
     int new_number = std::stoi(*input);
@@ -72,116 +92,6 @@ ItemIntField::insert_at(const std::string& text, const int index)
   for (auto& c : text)
   {
     add_char(c, index);
-  }
-}
-
-void
-ItemIntField::clear()
-{
-  input->clear();
-  *number = 0;
-}
-
-void
-ItemIntField::delete_front()
-{
-  if (!input->empty() && m_cursor_left_offset < static_cast<int>(input->size()))
-  {
-    update_undo();
-    *input = input->substr(0, static_cast<int>(input->size()) - m_cursor_left_offset - 1) +
-      input->substr(input->size() - m_cursor_left_offset);
-
-    if (!input->empty())
-    {
-      try
-      {
-        int new_number = std::stoi(*input);
-        *number = new_number;
-      }
-      catch (...)
-      {
-        *input = std::to_string(*number);
-      }
-    }
-    else
-    {
-      *number = 0;
-    }
-  }
-  else
-  {
-    invalid_remove();
-  }
-}
-
-void
-ItemIntField::delete_back()
-{
-  if (!input->empty() && m_cursor_left_offset > 0)
-  {
-    update_undo();
-    *input = input->substr(0, input->size() - m_cursor_left_offset) +
-      input->substr(input->size() - m_cursor_left_offset + 1);
-    m_cursor_left_offset--;
-
-    if (!input->empty())
-    {
-      try
-      {
-        int new_number = std::stoi(*input);
-        *number = new_number;
-      }
-      catch (...)
-      {
-        *input = std::to_string(*number);
-      }
-    }
-    else
-    {
-      *number = 0;
-    }
-  }
-  else
-  {
-    invalid_remove();
-  }
-}
-
-void
-ItemIntField::undo()
-{
-  if (m_input_undo.empty()) return;
-  m_input_redo = *input;
-  *input = m_input_undo;
-  m_input_undo.clear();
-
-  try
-  {
-    int new_number = std::stoi(*input);
-    *number = new_number;
-  }
-  catch (...)
-  {
-    *input = std::to_string(*number);
-  }
-}
-
-void
-ItemIntField::redo()
-{
-  if (m_input_redo.empty()) return;
-  m_input_undo = *input;
-  *input = m_input_redo;
-  m_input_redo.clear();
-
-  try
-  {
-    int new_number = std::stoi(*input);
-    *number = new_number;
-  }
-  catch (...)
-  {
-    *input = std::to_string(*number);
   }
 }
 

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -16,92 +17,128 @@
 
 #include "gui/item_intfield.hpp"
 
-#include "supertux/colorscheme.hpp"
-#include "supertux/gameconfig.hpp"
-#include "supertux/globals.hpp"
-#include "supertux/resources.hpp"
-#include "video/drawing_context.hpp"
-
 ItemIntField::ItemIntField(const std::string& text_, int* input_, int id_) :
-  MenuItem(text_, id_),
-  number(input_),
-  input(std::to_string(*input_)),
-  flickw(static_cast<int>(Resources::normal_font->get_text_width("_")))
+  ItemTextField(text_, new std::string, id_),
+  m_input(std::to_string(*input_)),
+  number(input_)
 {
+  change_input(m_input);
 }
 
-void
-ItemIntField::draw(DrawingContext& context, const Vector& pos, int menu_width, bool active) {
-  std::string r_input = input;
-  bool fl = active && (int(g_real_time*2)%2);
-  if ( fl ) {
-    r_input += "_";
-  }
-  context.color().draw_text(Resources::normal_font, r_input,
-                            Vector(pos.x + static_cast<float>(menu_width) - 16 - static_cast<float>(fl ? 0 : flickw),
-                                   pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_RIGHT, LAYER_GUI, ColorScheme::Menu::field_color);
-  context.color().draw_text(Resources::normal_font, get_text(),
-                            Vector(pos.x + 16.0f,
-                                   pos.y - Resources::normal_font->get_height() / 2.0f),
-                            ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
+ItemIntField::~ItemIntField()
+{
+  delete input;
 }
 
-int
-ItemIntField::get_width() const {
-  return static_cast<int>(Resources::normal_font->get_text_width(get_text()) + Resources::normal_font->get_text_width(input)) + 16 + flickw;
-}
-
-void
-ItemIntField::event(const SDL_Event& ev) {
+bool
+ItemIntField::custom_event(const SDL_Event& ev)
+{
   if (ev.type == SDL_TEXTINPUT) {
     std::string txt = ev.text.text;
-    for (auto& c : txt) {
+    for (auto& c : txt)
+    {
       add_char(c);
     }
   }
-}
+  else if (ev.type == SDL_KEYDOWN)
+  {
+    if (ev.key.keysym.sym == SDLK_DELETE) // Delete back
+    {
+      if (!input->empty() && m_cursor_left_offset > 0)
+      {
+        *input = input->substr(0, input->size() - m_cursor_left_offset) +
+          input->substr(input->size() - m_cursor_left_offset + 1);
+        m_cursor_left_offset--;
 
-void
-ItemIntField::add_char(char c) {
-  if (c == '-') {
-    if (input.length() && input != "0") {
-      *number *= -1;
-      input = std::to_string(*number);
-    } else {
-      input = "-";
-    }
-  }
-
-  if (c < '0' || c > '9') {
-    return;
-  }
-
-  input.push_back(c);
-  try {
-    int new_number = std::stoi(input);
-    *number = new_number;
-  } catch (...) {
-    input = std::to_string(*number);
-  }
-}
-
-void
-ItemIntField::process_action(const MenuAction& action) {
-  if (action == MenuAction::REMOVE && input.length()) {
-    unsigned char last_char;
-    do {
-      last_char = *(--input.end());
-      input.resize(input.length() - 1);
-      if (input.length() == 0) {
-        break;
+        if (!input->empty())
+        {
+          int new_number = std::stoi(*input);
+          *number = new_number;
+        }
+        else
+        {
+          *number = 0;
+        }
       }
-    } while ( (last_char & 128) && !(last_char & 64) );
-    if (input.length() && input != "-") {
-      *number = std::stoi(input);
-    } else {
-      *number = 0;
+      else
+      {
+        invalid_remove();
+      }
     }
+  }
+  return false;
+}
+
+void
+ItemIntField::process_action(const MenuAction& action)
+{
+  if (action == MenuAction::REMOVE) // Delete front (backspace)
+  {
+    if (!input->empty() && m_cursor_left_offset < static_cast<int>(input->size()))
+    {
+      *input = input->substr(0, static_cast<int>(input->size()) - m_cursor_left_offset - 1) +
+        input->substr(input->size() - m_cursor_left_offset);
+
+      if (!input->empty())
+      {
+        int new_number = std::stoi(*input);
+        *number = new_number;
+      }
+      else
+      {
+        *number = 0;
+      }
+    }
+    else
+    {
+      invalid_remove();
+    }
+  }
+  else if (action == MenuAction::LEFT) // Left
+  {
+    if (m_cursor_left_offset >= static_cast<int>(input->size()))
+      return;
+
+    m_cursor_left_offset++;
+  }
+  else if (action == MenuAction::RIGHT) // Right
+  {
+    if (m_cursor_left_offset <= 0)
+      return;
+
+    m_cursor_left_offset--;
+  }
+}
+
+void
+ItemIntField::add_char(char c)
+{
+  if (c == '-')
+  {
+    if (!input->empty() && *input != "0")
+    {
+      *number *= -1;
+      *input = std::to_string(*number);
+    }
+    else
+    {
+      *input = "-";
+    }
+  }
+
+  if (c < '0' || c > '9')
+    return;
+
+  *input = input->substr(0, input->size() - m_cursor_left_offset) + c +
+    input->substr(input->size() - m_cursor_left_offset);
+  try
+  {
+    int new_number = std::stoi(*input);
+    *number = new_number;
+  }
+  catch (...)
+  {
+    *input = std::to_string(*number);
   }
 }
 

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -76,6 +76,13 @@ ItemIntField::insert_at(const std::string& text, const int index)
 }
 
 void
+ItemIntField::clear()
+{
+  input->clear();
+  *number = 0;
+}
+
+void
 ItemIntField::delete_front()
 {
   if (!input->empty() && m_cursor_left_offset < static_cast<int>(input->size()))

--- a/src/gui/item_intfield.hpp
+++ b/src/gui/item_intfield.hpp
@@ -28,14 +28,12 @@ public:
 
   int* number;
 
+  /** Calls when the input gets updated. */
+  virtual void on_input_update() override;
+
   // Text manipulation and navigation functions
 
   virtual void insert_at(const std::string& text, const int index) override;
-  virtual void clear() override;
-  virtual void delete_front() override;
-  virtual void delete_back() override;
-  virtual void undo() override;
-  virtual void redo() override;
 
 private:
   std::string m_input;

--- a/src/gui/item_intfield.hpp
+++ b/src/gui/item_intfield.hpp
@@ -28,16 +28,18 @@ public:
 
   int* number;
 
-  /** Processes the given custom event cases. */
-  virtual bool custom_event(const SDL_Event& ev) override;
+  // Text manipulation and navigation functions
 
-  /** Processes the menu action. */
-  virtual void process_action(const MenuAction& action) override;
+  virtual void insert_at(const std::string& text, const int index) override;
+  virtual void delete_front() override;
+  virtual void delete_back() override;
+  virtual void undo() override;
+  virtual void redo() override;
 
 private:
   std::string m_input;
 
-  void add_char(char c);
+  void add_char(char c, const int index);
 
 private:
   ItemIntField(const ItemIntField&) = delete;

--- a/src/gui/item_intfield.hpp
+++ b/src/gui/item_intfield.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,39 +18,24 @@
 #ifndef HEADER_SUPERTUX_GUI_ITEM_INTFIELD_HPP
 #define HEADER_SUPERTUX_GUI_ITEM_INTFIELD_HPP
 
-#include "gui/menu_item.hpp"
+#include "gui/item_textfield.hpp"
 
-class ItemIntField final : public MenuItem
+class ItemIntField final : public ItemTextField
 {
 public:
   ItemIntField(const std::string& text_, int* input_, int id_ = -1);
+  ~ItemIntField() override;
 
-  /** Draws the menu item. */
-  virtual void draw(DrawingContext&, const Vector& pos, int menu_width, bool active) override;
+  int* number;
 
-  /** Returns the minimum width of the menu item. */
-  virtual int get_width() const override;
+  /** Processes the given custom event cases. */
+  virtual bool custom_event(const SDL_Event& ev) override;
 
   /** Processes the menu action. */
   virtual void process_action(const MenuAction& action) override;
 
-  int* number;
-
-  void change_input(const std::string& input_) {
-    input = input_;
-  }
-
-  /** Processes the given event. */
-  virtual void event(const SDL_Event& ev) override;
-
-  virtual bool changes_width() const override {
-    return true;
-  }
-
 private:
-
-  std::string input;
-  int flickw;
+  std::string m_input;
 
   void add_char(char c);
 

--- a/src/gui/item_intfield.hpp
+++ b/src/gui/item_intfield.hpp
@@ -23,7 +23,7 @@
 class ItemIntField final : public ItemTextField
 {
 public:
-  ItemIntField(const std::string& text_, int* input_, int id_ = -1);
+  ItemIntField(const std::string& text_, int* input_, int id_ = -1, bool positive = false);
   ~ItemIntField() override;
 
   int* number;
@@ -33,12 +33,13 @@ public:
 
   // Text manipulation and navigation functions
 
-  virtual void insert_at(const std::string& text, const int index) override;
+  virtual void insert_text(const std::string& text, const int left_offset_pos) override;
 
 private:
   std::string m_input;
+  const bool m_positive;
 
-  void add_char(char c, const int index);
+  void add_char(char c, const int left_offset_pos);
 
 private:
   ItemIntField(const ItemIntField&) = delete;

--- a/src/gui/item_intfield.hpp
+++ b/src/gui/item_intfield.hpp
@@ -31,6 +31,7 @@ public:
   // Text manipulation and navigation functions
 
   virtual void insert_at(const std::string& text, const int index) override;
+  virtual void clear() override;
   virtual void delete_front() override;
   virtual void delete_back() override;
   virtual void undo() override;

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -31,7 +31,7 @@
 ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
   ItemTextField("", input_, id_)
 {
-  m_cursor_char_width = Resources::console_font->get_text_width(m_cursor_char_str);
+  m_cursor_width = Resources::console_font->get_text_width(m_cursor);
 }
 
 void
@@ -48,13 +48,13 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
   if (active && ((int(g_real_time * 2) % 2) || (m_cursor_left_offset != 0 && m_cursor_left_offset != static_cast<int>(input->size()))))
   {
     // Draw text cursor.
-    context.color().draw_text(Resources::console_font, m_cursor_char_str,
+    context.color().draw_text(Resources::console_font, m_cursor,
                               Vector(pos.x + 15.0f + input_part_1_width,
                                      pos.y - Resources::console_font->get_height() / 2.0f),
                               ALIGN_LEFT, LAYER_GUI, Color::CYAN);
   }
   context.color().draw_text(Resources::console_font, input_part_2,
-                            Vector(pos.x + 14.0f + input_part_1_width + m_cursor_char_width,
+                            Vector(pos.x + 14.0f + input_part_1_width + m_cursor_width,
                                    pos.y - Resources::console_font->get_height() / 2.0f),
                             ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
 }
@@ -62,7 +62,7 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
 int
 ItemScriptLine::get_width() const
 {
-  return static_cast<int>(Resources::console_font->get_text_width(*input) + 16.0f + m_cursor_char_width);
+  return static_cast<int>(Resources::console_font->get_text_width(*input) + 16.0f + m_cursor_width);
 }
 
 void
@@ -115,7 +115,7 @@ ItemScriptLine::paste() // Paste with mutli-line support
   SDL_free(clipboard_content);
 
   if (paste_lines.empty()) return;
-  insert_at(paste_lines[0], m_cursor_left_offset);
+  insert_text(paste_lines[0], m_cursor_left_offset);
   for (std::size_t i = 1; i < paste_lines.size(); i++)
   {
     auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -31,6 +31,7 @@
 ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
   ItemTextField("", input_, id_)
 {
+  m_cursor_char_width = Resources::console_font->get_text_width(m_cursor_char_str);
 }
 
 void
@@ -53,7 +54,7 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
                               ALIGN_LEFT, LAYER_GUI, Color::CYAN);
   }
   context.color().draw_text(Resources::console_font, input_part_2,
-                            Vector(pos.x + 9.5f + input_part_1_width + m_cursor_char_width,
+                            Vector(pos.x + 14.0f + input_part_1_width + m_cursor_char_width,
                                    pos.y - Resources::console_font->get_height() / 2.0f),
                             ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
 }

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -61,7 +61,7 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
 int
 ItemScriptLine::get_width() const
 {
-  return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16.0f + static_cast<float>(m_cursor_char_width);
+  return static_cast<int>(Resources::console_font->get_text_width(*input) + 16.0f + m_cursor_char_width);
 }
 
 bool

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -33,22 +33,41 @@ ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
 void
 ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width, bool active)
 {
-  std::string r_input = *input;
-  if (active)
-  {
-    r_input = r_input.substr(0, r_input.size() - m_cursor_left_offset) + m_cursor_char +
-      r_input.substr(r_input.size() - m_cursor_left_offset);
-  }
-  context.color().draw_text(Resources::console_font, r_input,
+  context.color().draw_text(Resources::console_font, *input,
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::console_font->get_height() / 2.0f),
                             ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
+  if (active && (int(g_real_time * 2) % 2))
+  {
+    // Draw text cursor.
+    context.color().draw_text(Resources::console_font, m_cursor_char_str,
+                              Vector(pos.x + 13.5f +
+                                       Resources::console_font->get_text_width(input->substr(m_cursor_left_offset)),
+                                     pos.y - Resources::console_font->get_height() / 2.0f),
+                              ALIGN_LEFT, LAYER_GUI, Color::CYAN);
+  }
 }
 
 int
 ItemScriptLine::get_width() const
 {
   return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16 + m_cursor_char_width;
+}
+
+bool
+ItemScriptLine::custom_event(const SDL_Event& ev)
+{
+  if (ev.type == SDL_KEYDOWN)
+  {
+    if (ev.key.keysym.sym == SDLK_d && SDL_GetModState() & KMOD_CTRL) // Duplicate line
+    {
+      auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());
+      if (!menu) return true;
+      menu->add_line()->set_input_text(*input);
+      return false;
+    }
+  }
+  return true;
 }
 
 void

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -89,7 +89,7 @@ ItemScriptLine::custom_event(const SDL_Event& ev)
         {
           auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());
           if (!menu) break;
-          menu->add_line()->set_input_text(paste_lines[i]);
+          menu->add_line()->change_input(paste_lines[i]);
         }
         return false;
       }
@@ -97,7 +97,7 @@ ItemScriptLine::custom_event(const SDL_Event& ev)
       {
         auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());
         if (!menu) return true;
-        menu->add_line()->set_input_text(*input);
+        menu->add_line()->change_input(*input);
         return false;
       }
     }

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -69,7 +70,10 @@ ItemScriptLine::custom_event(const SDL_Event& ev)
         m_input_redo.clear();
 
         std::vector<std::string> paste_lines;
-        boost::split(paste_lines, SDL_GetClipboardText(), boost::is_any_of("\n")); // Split any newlines for use on seperate lines.
+        char* clipboard_content = SDL_GetClipboardText();
+        boost::split(paste_lines, std::string(clipboard_content), boost::is_any_of("\n")); // Split any newlines for use on seperate lines.
+        SDL_free(clipboard_content);
+
         if (paste_lines.empty()) return true;
         *input = input->substr(0, input->size() - m_cursor_left_offset) + paste_lines[0] +
           input->substr(input->size() - m_cursor_left_offset);

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -40,7 +40,7 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::console_font->get_height() / 2.0f),
                             ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
-  if (active && (int(g_real_time * 2) % 2))
+  if (active && ((int(g_real_time * 2) % 2) || (m_cursor_left_offset != 0 && m_cursor_left_offset != static_cast<int>(input->size()))))
   {
     // Draw text cursor.
     context.color().draw_text(Resources::console_font, m_cursor_char_str,
@@ -71,7 +71,8 @@ ItemScriptLine::custom_event(const SDL_Event& ev)
 
         std::vector<std::string> paste_lines;
         char* clipboard_content = SDL_GetClipboardText();
-        boost::split(paste_lines, std::string(clipboard_content), boost::is_any_of("\n")); // Split any newlines for use on seperate lines.
+        std::string clipboard_content_str(clipboard_content);
+        boost::split(paste_lines, clipboard_content_str, boost::is_any_of("\n"));
         SDL_free(clipboard_content);
 
         if (paste_lines.empty()) return true;

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -115,8 +115,7 @@ ItemScriptLine::paste() // Paste with mutli-line support
   SDL_free(clipboard_content);
 
   if (paste_lines.empty()) return;
-  *input = input->substr(0, input->size() - m_cursor_left_offset) + paste_lines[0] +
-    input->substr(input->size() - m_cursor_left_offset);
+  insert_at(paste_lines[0], m_cursor_left_offset);
   for (std::size_t i = 1; i < paste_lines.size(); i++)
   {
     auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -66,7 +66,7 @@ ItemScriptLine::get_width() const
 }
 
 void
-ItemScriptLine::custom_event(const SDL_Event& ev)
+ItemScriptLine::event(const SDL_Event& ev)
 {
   if (ev.type == SDL_KEYDOWN)
   {
@@ -78,6 +78,8 @@ ItemScriptLine::custom_event(const SDL_Event& ev)
       }
     }
   }
+
+  ItemTextField::event(ev);
 }
 
 void
@@ -121,6 +123,8 @@ ItemScriptLine::paste() // Paste with mutli-line support
     if (!menu) break;
     menu->add_line()->change_input(paste_lines[i]);
   }
+
+  on_input_update();
 }
 
 void

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -36,7 +36,11 @@ ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
 void
 ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width, bool active)
 {
-  context.color().draw_text(Resources::console_font, *input,
+  const int index = active ? static_cast<int>(input->size()) - m_cursor_left_offset : -1;
+  const std::string input_part_1 = active ? input->substr(0, index) : *input;
+  const std::string input_part_2 = active ? input->substr(index) : "";
+  const float input_part_1_width = Resources::console_font->get_text_width(input_part_1);
+  context.color().draw_text(Resources::console_font, input_part_1,
                             Vector(pos.x + 16.0f,
                                    pos.y - Resources::console_font->get_height() / 2.0f),
                             ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
@@ -44,17 +48,20 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
   {
     // Draw text cursor.
     context.color().draw_text(Resources::console_font, m_cursor_char_str,
-                              Vector(pos.x + 13.5f +
-                                       Resources::console_font->get_text_width(input->substr(m_cursor_left_offset)),
+                              Vector(pos.x + 15.0f + input_part_1_width,
                                      pos.y - Resources::console_font->get_height() / 2.0f),
                               ALIGN_LEFT, LAYER_GUI, Color::CYAN);
   }
+  context.color().draw_text(Resources::console_font, input_part_2,
+                            Vector(pos.x + 9.5f + input_part_1_width + m_cursor_char_width,
+                                   pos.y - Resources::console_font->get_height() / 2.0f),
+                            ALIGN_LEFT, LAYER_GUI, ColorScheme::Menu::field_color);
 }
 
 int
 ItemScriptLine::get_width() const
 {
-  return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16 + m_cursor_char_width;
+  return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16.0f + static_cast<float>(m_cursor_char_width);
 }
 
 bool

--- a/src/gui/item_script_line.cpp
+++ b/src/gui/item_script_line.cpp
@@ -31,11 +31,13 @@ ItemScriptLine::ItemScriptLine(std::string* input_, int id_) :
 }
 
 void
-ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width, bool active) {
+ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width, bool active)
+{
   std::string r_input = *input;
-  bool fl = active && (int(g_real_time*2)%2);
-  if ( fl ) {
-    r_input += "_";
+  if (active)
+  {
+    r_input = r_input.substr(0, r_input.size() - m_cursor_left_offset) + m_cursor_char +
+      r_input.substr(r_input.size() - m_cursor_left_offset);
   }
   context.color().draw_text(Resources::console_font, r_input,
                             Vector(pos.x + 16.0f,
@@ -44,29 +46,29 @@ ItemScriptLine::draw(DrawingContext& context, const Vector& pos, int menu_width,
 }
 
 int
-ItemScriptLine::get_width() const {
-  return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16 + flickw;
+ItemScriptLine::get_width() const
+{
+  return static_cast<int>(Resources::console_font->get_text_width(*input)) + 16 + m_cursor_char_width;
 }
 
 void
-ItemScriptLine::process_action(const MenuAction& action) {
+ItemScriptLine::process_action(const MenuAction& action)
+{
   ItemTextField::process_action(action);
   const Controller& controller = InputManager::current()->get_controller();
-  if (action == MenuAction::HIT && controller.pressed(Control::MENU_SELECT)) {
+  if (action == MenuAction::HIT && controller.pressed(Control::MENU_SELECT))
+  {
     auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());
-    if (!menu) {
-      return;
-    }
+    if (!menu) return;
     menu->add_line();
   }
 }
 
 void
-ItemScriptLine::invalid_remove() {
+ItemScriptLine::invalid_remove()
+{
   auto menu = dynamic_cast<ScriptMenu*>(MenuManager::instance().current_menu());
-  if (!menu) {
-    return;
-  }
+  if (!menu) return;
   menu->remove_line();
 }
 

--- a/src/gui/item_script_line.hpp
+++ b/src/gui/item_script_line.hpp
@@ -34,8 +34,8 @@ public:
   /** Processes the menu action. */
   virtual void process_action(const MenuAction& action) override;
 
-  /** Processes the given custom event cases. */
-  virtual void custom_event(const SDL_Event& ev) override;
+  /** Processes the given event. */
+  virtual void event(const SDL_Event& ev) override;
 
   /** Calls when the user wants to remove an invalid char. */
   virtual void invalid_remove() override;

--- a/src/gui/item_script_line.hpp
+++ b/src/gui/item_script_line.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2016 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/src/gui/item_script_line.hpp
+++ b/src/gui/item_script_line.hpp
@@ -35,10 +35,16 @@ public:
   virtual void process_action(const MenuAction& action) override;
 
   /** Processes the given custom event cases. */
-  virtual bool custom_event(const SDL_Event& ev) override;
+  virtual void custom_event(const SDL_Event& ev) override;
 
   /** Calls when the user wants to remove an invalid char. */
   virtual void invalid_remove() override;
+
+  // Text manipulation and navigation functions
+
+  virtual void paste() override;
+  virtual void new_line();
+  virtual void duplicate_line();
 
 private:
   ItemScriptLine(const ItemScriptLine&) = delete;

--- a/src/gui/item_script_line.hpp
+++ b/src/gui/item_script_line.hpp
@@ -33,6 +33,9 @@ public:
   /** Processes the menu action. */
   virtual void process_action(const MenuAction& action) override;
 
+  /** Processes the given custom event cases. */
+  virtual bool custom_event(const SDL_Event& ev) override;
+
   /** Calls when the user wants to remove an invalid char. */
   virtual void invalid_remove() override;
 

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -76,8 +76,6 @@ ItemTextField::get_width() const
 void
 ItemTextField::event(const SDL_Event& ev)
 {
-  custom_event(ev); // Execute any available custom events.
-
   if (ev.type == SDL_TEXTINPUT) // Text input
   {
     insert_at(ev.text.text, m_cursor_left_offset);
@@ -154,12 +152,15 @@ ItemTextField::insert_at(const std::string& text, const int index)
   update_undo();
   *input = input->substr(0, input->size() - index) + text +
     input->substr(input->size() - index);
+  on_input_update();
 }
 
 void
 ItemTextField::clear()
 {
+  m_cursor_left_offset = 0;
   input->clear();
+  on_input_update();
 }
 
 void
@@ -219,6 +220,7 @@ ItemTextField::delete_front()
         input->substr(input->size() - m_cursor_left_offset);
       if (input->empty() || m_cursor_left_offset >= static_cast<int>(input->size())) break;
     } while ((last_char & 128) && !(last_char & 64));
+    on_input_update();
   }
   else
   {
@@ -241,6 +243,7 @@ ItemTextField::delete_back()
       m_cursor_left_offset--;
       if (input->empty() || m_cursor_left_offset <= 0) break;
     } while ((next_char & 128) && !(next_char & 64));
+    on_input_update();
   }
   else
   {
@@ -274,6 +277,8 @@ ItemTextField::paste()
 
   if (clipboard_text.empty()) return;
   insert_at(clipboard_text, m_cursor_left_offset);
+
+  on_input_update();
 }
 
 void
@@ -283,6 +288,8 @@ ItemTextField::undo()
   m_input_redo = *input;
   *input = m_input_undo;
   m_input_undo.clear();
+
+  on_input_update();
 }
 
 void
@@ -292,6 +299,8 @@ ItemTextField::redo()
   m_input_undo = *input;
   *input = m_input_redo;
   m_input_redo.clear();
+
+  on_input_update();
 }
 
 /* EOF */

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -31,9 +31,8 @@ ItemTextField::ItemTextField(const std::string& text_, std::string* input_, int 
   input(input_),
   m_input_undo(),
   m_input_redo(),
-  m_cursor_char('|'),
-  m_cursor_char_str(std::string(1, m_cursor_char)),
-  m_cursor_char_width(Resources::normal_font->get_text_width(m_cursor_char_str)),
+  m_cursor("|"),
+  m_cursor_width(Resources::normal_font->get_text_width(m_cursor)),
   m_cursor_left_offset(0)
 {
 }
@@ -46,13 +45,13 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
   const std::string input_part_2 = active ? input->substr(index) : "";
   const float input_part_2_width = Resources::normal_font->get_text_width(input_part_2);
   context.color().draw_text(Resources::normal_font, input_part_1,
-                            Vector(pos.x + static_cast<float>(menu_width) - 9.0f - input_part_2_width - m_cursor_char_width,
+                            Vector(pos.x + static_cast<float>(menu_width) - 9.0f - input_part_2_width - m_cursor_width,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
                             ALIGN_RIGHT, LAYER_GUI, ColorScheme::Menu::field_color);
   if (active && ((int(g_real_time * 2) % 2) || (m_cursor_left_offset != 0 && m_cursor_left_offset != static_cast<int>(input->size()))))
   {
     // Draw text cursor.
-    context.color().draw_text(Resources::normal_font, m_cursor_char_str,
+    context.color().draw_text(Resources::normal_font, m_cursor,
                               Vector(pos.x + static_cast<float>(menu_width) - 12.0f - input_part_2_width,
                                      pos.y - Resources::normal_font->get_height() / 2.0f),
                               ALIGN_RIGHT, LAYER_GUI, Color::CYAN);
@@ -70,7 +69,7 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
 int
 ItemTextField::get_width() const
 {
-  return static_cast<int>(Resources::normal_font->get_text_width(get_text()) + Resources::normal_font->get_text_width(*input) + 16.0f + m_cursor_char_width);
+  return static_cast<int>(Resources::normal_font->get_text_width(get_text()) + Resources::normal_font->get_text_width(*input) + 16.0f + m_cursor_width);
 }
 
 void
@@ -78,7 +77,7 @@ ItemTextField::event(const SDL_Event& ev)
 {
   if (ev.type == SDL_TEXTINPUT) // Text input
   {
-    insert_at(ev.text.text, m_cursor_left_offset);
+    insert_text(ev.text.text, m_cursor_left_offset);
   }
   else if (ev.type == SDL_KEYDOWN)
   {
@@ -147,11 +146,11 @@ ItemTextField::update_undo()
 // Text manipulation and navigation functions
 
 void
-ItemTextField::insert_at(const std::string& text, const int index)
+ItemTextField::insert_text(const std::string& text, const int left_offset_pos)
 {
   update_undo();
-  *input = input->substr(0, input->size() - index) + text +
-    input->substr(input->size() - index);
+  *input = input->substr(0, input->size() - left_offset_pos) + text +
+    input->substr(input->size() - left_offset_pos);
   on_input_update();
 }
 
@@ -276,7 +275,7 @@ ItemTextField::paste()
   boost::replace_all(clipboard_text, "\n", " "); // Replace any newlines with spaces.
 
   if (clipboard_text.empty()) return;
-  insert_at(clipboard_text, m_cursor_left_offset);
+  insert_text(clipboard_text, m_cursor_left_offset);
 
   on_input_update();
 }

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -67,14 +67,6 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
                             ALIGN_LEFT, LAYER_GUI, active ? g_config->activetextcolor : get_color());
 }
 
-void
-ItemTextField::set_input_text(const std::string& text)
-{
-  *input = text;
-  m_input_undo.clear();
-  m_input_redo.clear();
-}
-
 int
 ItemTextField::get_width() const
 {
@@ -170,10 +162,12 @@ ItemTextField::event(const SDL_Event& ev)
 void
 ItemTextField::process_action(const MenuAction& action)
 {
-  if (action == MenuAction::REMOVE)
+  if (action == MenuAction::REMOVE) // Delete front (backspace)
   {
     if (!input->empty() && m_cursor_left_offset < static_cast<int>(input->size()))
     {
+      m_input_undo = *input;
+      m_input_redo.clear();
       unsigned char last_char;
       do
       {
@@ -189,7 +183,7 @@ ItemTextField::process_action(const MenuAction& action)
       invalid_remove();
     }
   }
-  else if (action == MenuAction::LEFT)
+  else if (action == MenuAction::LEFT) // Left
   {
     if (m_cursor_left_offset >= static_cast<int>(input->size()))
       return;
@@ -202,7 +196,7 @@ ItemTextField::process_action(const MenuAction& action)
       if (m_cursor_left_offset >= static_cast<int>(input->size())) break;
     } while ((last_char & 128) && !(last_char & 64));
   }
-  else if (action == MenuAction::RIGHT)
+  else if (action == MenuAction::RIGHT) // Right
   {
     if (m_cursor_left_offset <= 0)
       return;

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -157,6 +157,12 @@ ItemTextField::insert_at(const std::string& text, const int index)
 }
 
 void
+ItemTextField::clear()
+{
+  input->clear();
+}
+
+void
 ItemTextField::go_left()
 {
   if (m_cursor_left_offset >= static_cast<int>(input->size()))
@@ -247,7 +253,7 @@ ItemTextField::cut()
 {
   update_undo();
   SDL_SetClipboardText(input->c_str());
-  input->clear();
+  clear();
 }
 
 void

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -124,8 +124,11 @@ ItemTextField::event(const SDL_Event& ev)
         m_input_undo = *input;
         m_input_redo.clear();
 
-        std::string clipboard_text = SDL_GetClipboardText();
+        char* clipboard_content = SDL_GetClipboardText();
+        std::string clipboard_text = std::string(clipboard_content);
+        SDL_free(clipboard_content);
         boost::replace_all(clipboard_text, "\n", " "); // Replace any newlines with spaces.
+
         if (clipboard_text.empty()) return;
         *input = input->substr(0, input->size() - m_cursor_left_offset) + clipboard_text +
           input->substr(input->size() - m_cursor_left_offset);

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -45,7 +45,7 @@ ItemTextField::draw(DrawingContext& context, const Vector& pos, int menu_width, 
                             Vector(pos.x + static_cast<float>(menu_width) - 16.0f,
                                    pos.y - Resources::normal_font->get_height() / 2.0f),
                             ALIGN_RIGHT, LAYER_GUI, ColorScheme::Menu::field_color);
-  if (active && (int(g_real_time * 2) % 2))
+  if (active && ((int(g_real_time * 2) % 2) || (m_cursor_left_offset != 0 && m_cursor_left_offset != static_cast<int>(input->size()))))
   {
     // Draw text cursor.
     context.color().draw_text(Resources::normal_font, m_cursor_char_str,
@@ -111,7 +111,7 @@ ItemTextField::event(const SDL_Event& ev)
     }
     else if (ev.key.keysym.sym == SDLK_HOME) // Home: go to beginning of text
     {
-      m_cursor_left_offset = input->size();
+      m_cursor_left_offset = static_cast<int>(input->size());
     }
     else if (ev.key.keysym.sym == SDLK_END) // End: go to end of text
     {
@@ -161,7 +161,7 @@ ItemTextField::process_action(const MenuAction& action)
       unsigned char last_char;
       do
       {
-        const int index = input->size() - m_cursor_left_offset - 1;
+        const int index = static_cast<int>(input->size()) - m_cursor_left_offset - 1;
         last_char = input->at(index);
         *input = input->substr(0, index) +
           input->substr(input->size() - m_cursor_left_offset);

--- a/src/gui/item_textfield.cpp
+++ b/src/gui/item_textfield.cpp
@@ -78,7 +78,7 @@ ItemTextField::set_input_text(const std::string& text)
 int
 ItemTextField::get_width() const
 {
-  return static_cast<int>(Resources::normal_font->get_text_width(get_text()) + Resources::normal_font->get_text_width(*input) + 16.0f + static_cast<float>(m_cursor_char_width));
+  return static_cast<int>(Resources::normal_font->get_text_width(get_text()) + Resources::normal_font->get_text_width(*input) + 16.0f + m_cursor_char_width);
 }
 
 void

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -57,7 +57,7 @@ public:
   virtual void update_undo();
 
   /** Calls when the input gets updated. */
-  virtual void on_input_update() {};
+  virtual void on_input_update() {}
 
   // Text manipulation and navigation functions
 

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -56,11 +56,12 @@ public:
     return true;
   }
 
-  void update_undo();
+  virtual void update_undo();
 
   // Text manipulation and navigation functions
 
   virtual void insert_at(const std::string& text, const int index);
+  virtual void clear();
   virtual void go_left();
   virtual void go_right();
   virtual void go_to_beginning();

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Hume2 <teratux.mail@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -27,6 +28,9 @@ public:
   /** Draws the menu item. */
   virtual void draw(DrawingContext&, const Vector& pos, int menu_width, bool active) override;
 
+  /** Set the text of the item to the given string. */
+  void set_input_text(const std::string& text);
+
   /** Returns the minimum width of the menu item. */
   virtual int get_width() const override;
 
@@ -45,13 +49,21 @@ public:
   /** Processes the given event. */
   virtual void event(const SDL_Event& ev) override;
 
+  /** Processes the given custom event cases. Check for the other base events of TextField, based on return value. */
+  virtual bool custom_event(const SDL_Event& ev) { return true; }
+
+  /** Indicates that this item changes its width. */
   virtual bool changes_width() const override {
     return true;
   }
 
 protected:
-  char m_cursor_char;
-  int m_cursor_char_width;
+  std::string m_input_undo;
+  std::string m_input_redo;
+
+  const char m_cursor_char;
+  const std::string m_cursor_char_str;
+  const int m_cursor_char_width;
   int m_cursor_left_offset;
 
 private:

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -61,7 +61,7 @@ public:
 
   // Text manipulation and navigation functions
 
-  virtual void insert_at(const std::string& text, const int index);
+  virtual void insert_text(const std::string& text, const int left_offset_pos);
   virtual void clear();
   virtual void go_left();
   virtual void go_right();
@@ -79,9 +79,8 @@ protected:
   std::string m_input_undo;
   std::string m_input_redo;
 
-  const char m_cursor_char;
-  const std::string m_cursor_char_str;
-  float m_cursor_char_width;
+  const std::string m_cursor;
+  float m_cursor_width;
   int m_cursor_left_offset;
 
 private:

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -62,7 +62,7 @@ protected:
 
   const char m_cursor_char;
   const std::string m_cursor_char_str;
-  const float m_cursor_char_width;
+  float m_cursor_char_width;
   int m_cursor_left_offset;
 
 private:

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -50,7 +50,9 @@ public:
   }
 
 protected:
-  int flickw;
+  char m_cursor_char;
+  int m_cursor_char_width;
+  int m_cursor_left_offset;
 
 private:
   ItemTextField(const ItemTextField&) = delete;

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -63,7 +63,7 @@ protected:
 
   const char m_cursor_char;
   const std::string m_cursor_char_str;
-  const int m_cursor_char_width;
+  const float m_cursor_char_width;
   int m_cursor_left_offset;
 
 private:

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -28,9 +28,6 @@ public:
   /** Draws the menu item. */
   virtual void draw(DrawingContext&, const Vector& pos, int menu_width, bool active) override;
 
-  /** Set the text of the item to the given string. */
-  void set_input_text(const std::string& text);
-
   /** Returns the minimum width of the menu item. */
   virtual int get_width() const override;
 
@@ -41,6 +38,8 @@ public:
 
   void change_input(const std::string& input_) {
     *input = input_;
+    m_input_undo.clear();
+    m_input_redo.clear();
   }
 
   /** Calls when the user wants to remove an invalid char. */

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -48,15 +48,16 @@ public:
   /** Processes the given event. */
   virtual void event(const SDL_Event& ev) override;
 
-  /** Processes the given custom event cases. */
-  virtual void custom_event(const SDL_Event& ev) {}
-
   /** Indicates that this item changes its width. */
   virtual bool changes_width() const override {
     return true;
   }
 
+  /** Updates undo and redo status. */
   virtual void update_undo();
+
+  /** Calls when the input gets updated. */
+  virtual void on_input_update() {};
 
   // Text manipulation and navigation functions
 

--- a/src/gui/item_textfield.hpp
+++ b/src/gui/item_textfield.hpp
@@ -48,13 +48,30 @@ public:
   /** Processes the given event. */
   virtual void event(const SDL_Event& ev) override;
 
-  /** Processes the given custom event cases. Check for the other base events of TextField, based on return value. */
-  virtual bool custom_event(const SDL_Event& ev) { return true; }
+  /** Processes the given custom event cases. */
+  virtual void custom_event(const SDL_Event& ev) {}
 
   /** Indicates that this item changes its width. */
   virtual bool changes_width() const override {
     return true;
   }
+
+  void update_undo();
+
+  // Text manipulation and navigation functions
+
+  virtual void insert_at(const std::string& text, const int index);
+  virtual void go_left();
+  virtual void go_right();
+  virtual void go_to_beginning();
+  virtual void go_to_end();
+  virtual void delete_front();
+  virtual void delete_back();
+  virtual void cut();
+  virtual void copy();
+  virtual void paste();
+  virtual void undo();
+  virtual void redo();
 
 protected:
   std::string m_input_undo;

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -199,18 +199,18 @@ Menu::add_script_line(std::string* input, int id)
 }
 
 ItemIntField&
-Menu::add_intfield(const std::string& text, int* input, int id)
+Menu::add_intfield(const std::string& text, int* input, int id, bool positive)
 {
-  auto item = std::make_unique<ItemIntField>(text, input, id);
+  auto item = std::make_unique<ItemIntField>(text, input, id, positive);
   auto item_ptr = item.get();
   add_item(std::move(item));
   return *item_ptr;
 }
 
 ItemFloatField&
-Menu::add_floatfield(const std::string& text, float* input, int id)
+Menu::add_floatfield(const std::string& text, float* input, int id, bool positive)
 {
-  auto item = std::make_unique<ItemFloatField>(text, input, id);
+  auto item = std::make_unique<ItemFloatField>(text, input, id, positive);
   auto item_ptr = item.get();
   add_item(std::move(item));
   return *item_ptr;

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -87,8 +87,8 @@ public:
   ItemTextField& add_textfield(const std::string& text, std::string* input, int id = -1);
   ItemScript& add_script(const std::string& text, std::string* script, int id = -1);
   ItemScriptLine& add_script_line(std::string* input, int id = -1);
-  ItemIntField& add_intfield(const std::string& text, int* input, int id = -1);
-  ItemFloatField& add_floatfield(const std::string& text, float* input, int id = -1);
+  ItemIntField& add_intfield(const std::string& text, int* input, int id = -1, bool positive = false);
+  ItemFloatField& add_floatfield(const std::string& text, float* input, int id = -1, bool positive = false);
   ItemBadguySelect& add_badguy_select(const std::string& text, std::vector<std::string>* badguys, int id = -1);
   ItemFile& add_file(const std::string& text, std::string* input, const std::vector<std::string>& extensions,
                      const std::string& basedir, bool path_relative_to_basedir, int id = -1);

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -125,11 +125,6 @@ public:
   float get_width() const;
   float get_height() const;
 
-  /** Recalculates the width for this menu */
-  void calculate_width();
-  /** Recalculates the height for this menu */
-  void calculate_height();
-
 protected:
   /** returns true when the text is more important than action */
   virtual bool is_sensitive() const;
@@ -137,6 +132,11 @@ protected:
   MenuItem& add_item(std::unique_ptr<MenuItem> menu_item);
   MenuItem& add_item(std::unique_ptr<MenuItem> menu_item, int pos_);
   void delete_item(int pos_);
+
+  /** Recalculates the width for this menu */
+  void calculate_width();
+  /** Recalculates the height for this menu */
+  void calculate_height();
 
 private:
   void process_action(const MenuAction& menuaction);

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -125,6 +125,11 @@ public:
   float get_width() const;
   float get_height() const;
 
+  /** Recalculates the width for this menu */
+  void calculate_width();
+  /** Recalculates the height for this menu */
+  void calculate_height();
+
 protected:
   /** returns true when the text is more important than action */
   virtual bool is_sensitive() const;
@@ -137,10 +142,6 @@ private:
   void process_action(const MenuAction& menuaction);
   void check_controlfield_change_event(const SDL_Event& event);
   void draw_item(DrawingContext& context, int index, float y_pos);
-  /** Recalculates the width for this menu */
-  void calculate_width();
-  /** Recalculates the height for this menu */
-  void calculate_height();
 
 private:
   /** position of the menu (ie. center of the menu, not top/left) */

--- a/src/gui/menu_script.cpp
+++ b/src/gui/menu_script.cpp
@@ -71,6 +71,7 @@ ScriptMenu::remove_line() {
 
   script_strings.erase(script_strings.begin() + (m_active_item - 2));
   delete_item(m_active_item);
+  calculate_height();
 }
 
 void

--- a/src/gui/menu_script.cpp
+++ b/src/gui/menu_script.cpp
@@ -74,7 +74,7 @@ ScriptMenu::remove_line() {
   calculate_height();
 }
 
-void
+ItemScriptLine*
 ScriptMenu::add_line() {
   auto new_line = std::make_unique<std::string>();
   script_strings.insert(script_strings.begin() + (m_active_item - 1), move(new_line));
@@ -83,12 +83,13 @@ ScriptMenu::add_line() {
         new ItemScriptLine( (script_strings.begin()+(m_active_item-1))->get() ));
   add_item(std::move(line_item), m_active_item+1);
   m_active_item++;
+
+  return dynamic_cast<ItemScriptLine*>(m_items[m_active_item].get());
 }
 
 void
 ScriptMenu::menu_action(MenuItem& item)
 {
-
 }
 
 bool

--- a/src/gui/menu_script.hpp
+++ b/src/gui/menu_script.hpp
@@ -28,7 +28,7 @@ public:
   void menu_action(MenuItem& item) override;
 
   void remove_line();
-  void add_line();
+  ItemScriptLine* add_line();
 
 protected:
   bool is_sensitive() const override;

--- a/src/object/infoblock.cpp
+++ b/src/object/infoblock.cpp
@@ -73,7 +73,7 @@ InfoBlock::get_settings()
 {
   ObjectSettings result = Block::get_settings();
 
-  result.add_translatable_text(_("Message"), &m_message, "message");
+  result.add_multiline_translatable_text(_("Message"), &m_message, "message");
 
   result.add_color(_("Front Color"), &m_frontcolor, "frontcolor", Color(0.6f, 0.7f, 0.8f, 0.5f));
 

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -173,7 +173,7 @@ EditorMenu::menu_action(MenuItem& item)
 	case MNID_HELP:
     {
       auto dialog = std::make_unique<Dialog>();
-      dialog->set_text(_("Keyboard Shortcuts:\n---------------------\nEsc = Open Menu\nCtrl+S = Save\nCtrl+T = Test\nCtrl+Z = Undo\nCtrl+Y = Redo\nF6 = Render Light\nF7 = Grid Snapping\nF8 = Show Grid"));
+      dialog->set_text(_("Keyboard Shortcuts:\n---------------------\nEsc = Open Menu\nCtrl+S = Save\nCtrl+T = Test\nCtrl+Z = Undo\nCtrl+Y = Redo\nF6 = Render Light\nF7 = Grid Snapping\nF8 = Show Grid\n \nScripting Shortcuts:\n    -------------    \nHome = Go to beginning of line\nEnd = Go to end of line\nLeft arrow = Go back in text\nRight arrow = Go forward in text\nBackspace = Delete in front of the text cursor\nDelete = Delete behind the text cursor\nCtrl+V = Paste\nCtrl+D = Duplicate line\nCtrl+Z = Undo\nCtrl+Y = Redo"));
       dialog->add_cancel_button(_("Got it!"));
       MenuManager::instance().set_dialog(std::move(dialog));
     }

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -173,7 +173,7 @@ EditorMenu::menu_action(MenuItem& item)
 	case MNID_HELP:
     {
       auto dialog = std::make_unique<Dialog>();
-      dialog->set_text(_("Keyboard Shortcuts:\n---------------------\nEsc = Open Menu\nCtrl+S = Save\nCtrl+T = Test\nCtrl+Z = Undo\nCtrl+Y = Redo\nF6 = Render Light\nF7 = Grid Snapping\nF8 = Show Grid\n \nScripting Shortcuts:\n    -------------    \nHome = Go to beginning of line\nEnd = Go to end of line\nLeft arrow = Go back in text\nRight arrow = Go forward in text\nBackspace = Delete in front of the text cursor\nDelete = Delete behind the text cursor\nCtrl+V = Paste\nCtrl+D = Duplicate line\nCtrl+Z = Undo\nCtrl+Y = Redo"));
+      dialog->set_text(_("Keyboard Shortcuts:\n---------------------\nEsc = Open Menu\nCtrl+S = Save\nCtrl+T = Test\nCtrl+Z = Undo\nCtrl+Y = Redo\nF6 = Render Light\nF7 = Grid Snapping\nF8 = Show Grid\n \nScripting Shortcuts:\n    -------------    \nHome = Go to beginning of line\nEnd = Go to end of line\nLeft arrow = Go back in text\nRight arrow = Go forward in text\nBackspace = Delete in front of text cursor\nDelete = Delete behind text cursor\nCtrl+X = Cut whole line\nCtrl+C = Copy whole line\nCtrl+V = Paste\nCtrl+D = Duplicate line\nCtrl+Z = Undo\nCtrl+Y = Redo"));
       dialog->add_cancel_button(_("Got it!"));
       MenuManager::instance().set_dialog(std::move(dialog));
     }


### PR DESCRIPTION
Improves the text field and script line menu items:

* Support for going back in text and inserting/deleting characters from the current position. ("Backspace" for deleting characters in front of the cursor, "Delete" for deleting behind it.)
* Cut and copy support for whole lines. [Ctrl+X, Ctrl+C]
* Paste support (new-line characters are converted to spaces). [Ctrl+V]
* Undo/redo support (restricted to 1 step for both). [Ctrl+Z, Ctrl+Y]

Some tiny improvements take place in the script menu as well:

* Ability to duplicate lines. [Ctrl+D]
* Fix for a bug, where the menu doesn't change its size when a script line is deleted.

Other improvements included:

* The int field and float field items were refactored. They now inherit the text field item. A way to restrict them to only having positive values was also added.
* Objects can now have options, which support multi-line text editing. An example where this is applied is the info block's "Message" option.

This PR aims to provide a partial fix to #936. Partial cut/copy, and paste support are added, but not selecting text.