### PR TITLE
On damage, deduct stacked powerups first and go to GROWUP_BONUS only if there is 1 powerup left

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2035,18 +2035,43 @@ Player::kill(bool completely)
 
   if (!completely && is_big()) {
     SoundManager::current()->play("sounds/hurt.wav", get_pos());
+    m_safe_timer.start(TUX_SAFE_TIME);
 
-    if (m_player_status.bonus[get_id()] == FIRE_BONUS
-      || m_player_status.bonus[get_id()] == ICE_BONUS
-      || m_player_status.bonus[get_id()] == AIR_BONUS
-      || m_player_status.bonus[get_id()] == EARTH_BONUS) {
-      m_safe_timer.start(TUX_SAFE_TIME);
-      set_bonus(GROWUP_BONUS, true);
-    } else if (m_player_status.bonus[get_id()] == GROWUP_BONUS) {
-      m_safe_timer.start(TUX_SAFE_TIME /* + GROWING_TIME */);
-      m_duck = false;
-      stop_backflipping();
-      set_bonus(NO_BONUS, true);
+    switch (m_player_status.bonus[get_id()]) {
+      case FIRE_BONUS:
+        if (m_player_status.max_fire_bullets[get_id()] <= 1) {
+          set_bonus(GROWUP_BONUS, true);
+        } else {
+          m_player_status.max_fire_bullets[get_id()]--;
+        }
+        break;
+      case ICE_BONUS:
+        if (m_player_status.max_ice_bullets[get_id()] <= 1) {
+          set_bonus(GROWUP_BONUS, true);
+        } else {
+          m_player_status.max_ice_bullets[get_id()]--;
+        }
+        break;
+      case AIR_BONUS:
+        if (m_player_status.max_air_time[get_id()] <= 1) {
+          set_bonus(GROWUP_BONUS, true);
+        } else {
+          m_player_status.max_air_time[get_id()]--;
+        }
+        break;
+      case EARTH_BONUS:
+        if (m_player_status.max_earth_time[get_id()] <= 1) {
+          set_bonus(GROWUP_BONUS, true);
+        } else {
+          m_player_status.max_earth_time[get_id()]--;
+        }
+        break;
+      case GROWUP_BONUS:
+        m_safe_timer.start(TUX_SAFE_TIME);
+        m_duck = false;
+        stop_backflipping();
+        set_bonus(NO_BONUS, true);
+        break;
     }
   } else {
     SoundManager::current()->play("sounds/kill.wav", get_pos());


### PR DESCRIPTION
**Why?**
I think this makes the game more enjoyable. Specifically, it's because players that don't care about stacking (like me) will simply leave powerups behind to collect them later when they lose their existing powerup, especially on the early levels. Also, those players who do care about stacking lose all their stacked powerups from one bad thing hitting them.

**Example of how this will affect the game if merged**
_Before pull request_
You collect four fire-flowers, they are stacked. You then get damaged by a badguy and you are now left without any fire-flowers.
_After pull request_
You collect four fire-flowers, they are stacked. You then get damaged by a badguy and you are now left with three stacked fire-flowers.