### PR TITLE
Fix bug with swimming, walljumping and bricks

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -529,6 +529,7 @@ Player::update(float dt_sec)
     {
       adjust_height(is_big() ? BIG_TUX_HEIGHT : SMALL_TUX_HEIGHT);
       m_water_jump = false;
+      m_swimboosting = false;
     }
     m_powersprite->set_angle(0.f);
     m_lightsprite->set_angle(0.f);


### PR DESCRIPTION
There was a really annoying bug where bricks would repeat their sound forever if Tux swimjumped, walljumped, and then landed on them, so I fixed it.