### PR TITLE
Various TextObject and TextArray additions and fixes

### DIFF
--- a/src/object/text_object.cpp
+++ b/src/object/text_object.cpp
@@ -147,8 +147,14 @@ TextObject::fade_out(float fadetime)
 void
 TextObject::set_visible(bool visible)
 {
-  m_visible = visible;
-  m_fade_progress = 1;
+  if (visible)
+  {
+    fade_in(0);
+  }
+  else
+  {
+    fade_out(0);
+  }
 }
 
 void

--- a/src/scripting/text_array.cpp
+++ b/src/scripting/text_array.cpp
@@ -108,6 +108,9 @@ TextArray::set_text(const std::string& text)
   if (auto* textItem = object.get_current_text_item()) {
     textItem->text_object.set_text(text);
   }
+  else {
+    object.add_text(text);
+  }
 }
 
 void
@@ -215,6 +218,42 @@ TextArray::get_anchor_point() const
     return textItem->text_object.get_anchor_point();
   } else {
     return -1;
+  }
+}
+
+void
+TextArray::set_front_fill_color(float red, float green, float blue, float alpha)
+{
+  SCRIPT_GUARD_VOID;
+  if (auto* textItem = object.get_current_text_item()) {
+    textItem->text_object.set_front_fill_color(Color(red, green, blue, alpha));
+  }
+}
+
+void
+TextArray::set_back_fill_color(float red, float green, float blue, float alpha)
+{
+  SCRIPT_GUARD_VOID;
+  if (auto* textItem = object.get_current_text_item()) {
+    textItem->text_object.set_back_fill_color(Color(red, green, blue, alpha));
+  }
+}
+
+void
+TextArray::set_text_color(float red, float green, float blue, float alpha)
+{
+  SCRIPT_GUARD_VOID;
+  if (auto* textItem = object.get_current_text_item()) {
+    textItem->text_object.set_text_color(Color(red, green, blue, alpha));
+  }
+}
+
+void
+TextArray::set_roundness(float roundness)
+{
+  SCRIPT_GUARD_VOID;
+  if (auto* textItem = object.get_current_text_item()) {
+    textItem->text_object.set_roundness(roundness);
   }
 }
 

--- a/src/scripting/text_array.hpp
+++ b/src/scripting/text_array.hpp
@@ -77,6 +77,10 @@ public:
   float get_pos_y() const;
   void set_anchor_point(int anchor);
   int get_anchor_point() const;
+  void set_front_fill_color(float red, float green, float blue, float alpha);
+  void set_back_fill_color(float red, float green, float blue, float alpha);
+  void set_text_color(float red, float green, float blue, float alpha);
+  void set_roundness(float roundness);
 };
 
 } // namespace scripting

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -10563,6 +10563,187 @@ static SQInteger TextArray_get_anchor_point_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger TextArray_set_front_fill_color_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_front_fill_color' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TextArray*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_front_fill_color(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_front_fill_color'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger TextArray_set_back_fill_color_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_back_fill_color' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TextArray*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_back_fill_color(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_back_fill_color'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger TextArray_set_text_color_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_text_color' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TextArray*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg2;
+  if(SQ_FAILED(sq_getfloat(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg3;
+  if(SQ_FAILED(sq_getfloat(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_text_color(static_cast<float> (arg0), static_cast<float> (arg1), static_cast<float> (arg2), static_cast<float> (arg3));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_text_color'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger TextArray_set_roundness_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_roundness' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TextArray*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_roundness(static_cast<float> (arg0));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_roundness'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Thunderstorm_release_hook(SQUserPointer ptr, SQInteger )
 {
   auto _this = reinterpret_cast<scripting::Thunderstorm*> (ptr);
@@ -16262,6 +16443,34 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'get_anchor_point'");
+  }
+
+  sq_pushstring(v, "set_front_fill_color", -1);
+  sq_newclosure(v, &TextArray_set_front_fill_color_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_front_fill_color'");
+  }
+
+  sq_pushstring(v, "set_back_fill_color", -1);
+  sq_newclosure(v, &TextArray_set_back_fill_color_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_back_fill_color'");
+  }
+
+  sq_pushstring(v, "set_text_color", -1);
+  sq_newclosure(v, &TextArray_set_text_color_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_text_color'");
+  }
+
+  sq_pushstring(v, "set_roundness", -1);
+  sq_newclosure(v, &TextArray_set_roundness_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_roundness'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {


### PR DESCRIPTION
Fixes various issues, regarding TextObject and TextArray:

* Fixes #2256: Adds the missing `set_front_fill_color()`, `set_back_fill_color()`,  `set_text_color()` and `set_roundness()` functions to TextArray, which only modify the current TextObject.
* Closes #2257: The `set_text()` function of TextArray now adds a new TextObject with default duration set, if the TextArray has no current TextObject.
* Closes #2258: Toggling the visibility of a TextObject now checks if the desired visibility state is `true` or `false`. If `true`, `fade_in(0)` is executed, if `false` - `fade_out(0)`. This would allow not just the frame to be toggled, but the text as well.