### PR TITLE
Remove hardcoded tile IDs for electrocution

### DIFF
--- a/src/object/thunderstorm.cpp
+++ b/src/object/thunderstorm.cpp
@@ -19,7 +19,10 @@
 #include "audio/sound_manager.hpp"
 #include "editor/editor.hpp"
 #include "object/electrifier.hpp"
+#include "supertux/level.hpp"
 #include "supertux/sector.hpp"
+#include "supertux/tile_manager.hpp"
+#include "supertux/tile_set.hpp"
 #include "util/reader.hpp"
 #include "util/reader_mapping.hpp"
 #include "video/drawing_context.hpp"
@@ -41,7 +44,8 @@ Thunderstorm::Thunderstorm(const ReaderMapping& reader) :
   m_strike_script(),
   time_to_thunder(),
   time_to_lightning(),
-  flash_display_timer()
+  flash_display_timer(),
+  changing_tiles(TileManager::current()->get_tileset(Level::current()->get_tileset())->m_thunderstorm_tiles)
 {
   reader.get("running", running);
   reader.get("interval", interval);
@@ -152,20 +156,6 @@ Thunderstorm::flash()
 void
 Thunderstorm::electrify()
 {
-  auto changing_tiles = Electrifier::TileChangeMap({
-    {200, 1421}, {201, 1422},
-    {3419, 3523}, {3420, 3524},
-    {3421, 3525}, {3422, 3526},
-    {3423, 3527}, {3424, 3528},
-    {3425, 3529}, {3426, 3530},
-    {3427, 3523}, {3428, 3524},
-    {3429, 3525}, {3430, 3526},
-    {3431, 3527}, {3432, 3528},
-    {3433, 3529}, {3434, 3530},
-	{2019, 3873}, {2140, 3874},
-	{2141, 3875}, {2142, 3876},
-	{2020, 3877}
-  });
   Sector::get().add<Electrifier>(changing_tiles, ELECTRIFY_TIME);
 }
 

--- a/src/object/thunderstorm.hpp
+++ b/src/object/thunderstorm.hpp
@@ -17,6 +17,8 @@
 #ifndef HEADER_SUPERTUX_OBJECT_THUNDERSTORM_HPP
 #define HEADER_SUPERTUX_OBJECT_THUNDERSTORM_HPP
 
+#include <map>
+
 #include "squirrel/exposed_object.hpp"
 #include "scripting/thunderstorm.hpp"
 #include "supertux/game_object.hpp"
@@ -76,6 +78,8 @@ private:
   Timer time_to_thunder; /**< counts down until next thunder */
   Timer time_to_lightning; /**< counts down until next lightning */
   Timer flash_display_timer; /**< counts down while flash is displayed */
+
+  std::map<uint32_t, uint32_t> changing_tiles; /**< preserves the tiles which an electrocution should change */
 
 private:
   Thunderstorm(const Thunderstorm&) = delete;

--- a/src/supertux/tile_set.cpp
+++ b/src/supertux/tile_set.cpp
@@ -48,6 +48,7 @@ TileSet::from_file(const std::string& filename)
 
 TileSet::TileSet() :
   m_autotilesets(),
+  m_thunderstorm_tiles(),
   m_tiles(1),
   m_tilegroups()
 {

--- a/src/supertux/tile_set.hpp
+++ b/src/supertux/tile_set.hpp
@@ -17,6 +17,7 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_TILE_SET_HPP
 #define HEADER_SUPERTUX_SUPERTUX_TILE_SET_HPP
 
+#include <map>
 #include <memory>
 #include <stdint.h>
 #include <string>
@@ -74,6 +75,11 @@ public:
 public:
   // Must be public because of tile_set_parser.cpp
   std::vector<AutotileSet*>* m_autotilesets;
+
+  // Additional attributes
+
+  // Must be public because of tile_set_parser.cpp and thunderstorm.cpp
+  std::map<uint32_t, uint32_t> m_thunderstorm_tiles;
 
 private:
   std::vector<std::unique_ptr<Tile> > m_tiles;

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -138,22 +138,26 @@ TileSetParser::parse(int32_t start, int32_t end, int32_t offset, bool imported)
       {
         if (additional_iter.get_key() == "thunderstorm") // Additional attributes for thunderstorms.
         {
-           auto info_mapping = additional_iter.as_mapping();
-           // Additional attributes for changing tiles for thunderstorms.
-           std::vector<uint32_t> tiles;
-           if (info_mapping.get("changing-tiles", tiles))
-           {
-             if (tiles.size() < 2)
-             {
-               log_warning << "Less than 2 tile IDs given for thunderstorm changing tiles." << std::endl;
-               continue;
-             }
-             if (tiles.size() % 2 != 0) tiles.pop_back(); // If the number of tiles isn't even, remove last tile.
-             for (int i = 0; i < static_cast<int>(tiles.size()); i += 2)
-             {
-               m_tileset.m_thunderstorm_tiles.insert({tiles[i], tiles[i + 1]});
-             }
-           }
+          auto info_mapping = additional_iter.as_mapping();
+          // Additional attributes for changing tiles for thunderstorms.
+          std::vector<uint32_t> tiles;
+          if (info_mapping.get("changing-tiles", tiles))
+          {
+            if (tiles.size() < 2)
+            {
+              log_warning << "Less than 2 tile IDs given for thunderstorm changing tiles." << std::endl;
+              continue;
+            }
+            if (tiles.size() % 2 != 0) tiles.pop_back(); // If the number of tiles isn't even, remove last tile.
+            for (int i = 0; i < static_cast<int>(tiles.size()); i += 2)
+            {
+              m_tileset.m_thunderstorm_tiles.insert({tiles[i], tiles[i + 1]});
+            }
+          }
+        }
+        else
+        {
+          log_warning << "Unknown symbol '" << additional_iter.get_key() << "' in \"additional\" section of tileset file" << std::endl;
         }
       }
     }

--- a/src/supertux/tile_set_parser.cpp
+++ b/src/supertux/tile_set_parser.cpp
@@ -130,6 +130,33 @@ TileSetParser::parse(int32_t start, int32_t end, int32_t offset, bool imported)
       TileSetParser import_parser(m_tileset, import_filename);
       import_parser.parse(import_start, import_end, import_offset, true);
     }
+    else if (iter.get_key() == "additional")
+    {
+      ReaderMapping reader = iter.as_mapping();
+      auto additional_iter = reader.get_iter();
+      while (additional_iter.next())
+      {
+        if (additional_iter.get_key() == "thunderstorm") // Additional attributes for thunderstorms.
+        {
+           auto info_mapping = additional_iter.as_mapping();
+           // Additional attributes for changing tiles for thunderstorms.
+           std::vector<uint32_t> tiles;
+           if (info_mapping.get("changing-tiles", tiles))
+           {
+             if (tiles.size() < 2)
+             {
+               log_warning << "Less than 2 tile IDs given for thunderstorm changing tiles." << std::endl;
+               continue;
+             }
+             if (tiles.size() % 2 != 0) tiles.pop_back(); // If the number of tiles isn't even, remove last tile.
+             for (int i = 0; i < static_cast<int>(tiles.size()); i += 2)
+             {
+               m_tileset.m_thunderstorm_tiles.insert({tiles[i], tiles[i + 1]});
+             }
+           }
+        }
+      }
+    }
     else
     {
       log_warning << "Unknown symbol '" << iter.get_key() << "' in tileset file" << std::endl;


### PR DESCRIPTION
Removes hardcoded tile IDs, used for water electrocution in `thunderstorm.cpp`. They are now defined in the newly created `additional` category for additional attributes and properties in tileset files.

Importing the water electrocution tile IDs works by adding these data sections in the file, preferably at the end:

```
 ;; Additional attributes
  (additional
    (thunderstorm
      ;; Attributes for thunderstorm changing tiles
      (changing-tiles
        200  1421
        3419 3523
        3420 3524
        3421 3525
        [more pairs below...]
      )
    )
  )
```

Fixes #2261.