### PR TITLE
Add notification GUI item + check for new releases

### DIFF
--- a/src/gui/menu_manager.cpp
+++ b/src/gui/menu_manager.cpp
@@ -20,6 +20,7 @@
 #include "gui/dialog.hpp"
 #include "gui/menu.hpp"
 #include "gui/mousecursor.hpp"
+#include "gui/notification.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -141,6 +142,9 @@ MenuManager::MenuManager() :
   m_dialog(),
   m_has_next_dialog(false),
   m_next_dialog(),
+  m_notification(),
+  m_has_next_notification(false),
+  m_next_notification(),
   m_menu_stack(),
   m_transition(new MenuTransition)
 {
@@ -189,6 +193,11 @@ MenuManager::event(const SDL_Event& ev)
       // transition animation
       current_menu()->event(ev);
     }
+
+    if (m_notification)
+    {
+      m_notification->event(ev);
+    }
   }
 }
 
@@ -199,6 +208,12 @@ MenuManager::draw(DrawingContext& context)
   {
     m_dialog = std::move(m_next_dialog);
     m_has_next_dialog = false;
+  }
+
+  if (m_has_next_notification)
+  {
+    m_notification = std::move(m_next_notification);
+    m_has_next_notification = false;
   }
 
   if (m_transition->is_active())
@@ -224,6 +239,11 @@ MenuManager::draw(DrawingContext& context)
     }
   }
 
+  if (m_notification)
+  {
+    m_notification->draw(context);
+  }
+
   if ((m_dialog || current_menu()) && MouseCursor::current())
   {
     MouseCursor::current()->draw(context);
@@ -237,6 +257,15 @@ MenuManager::set_dialog(std::unique_ptr<Dialog> dialog)
   // can't unset itself without ending up with "delete this" problems
   m_next_dialog = std::move(dialog);
   m_has_next_dialog = true;
+}
+
+void
+MenuManager::set_notification(std::unique_ptr<Notification> notification)
+{
+  // delay reseting m_notification to a later point, as otherwise the Notification
+  // can't unset itself without ending up with "delete this" problems
+  m_next_notification = std::move(notification);
+  m_has_next_notification = true;
 }
 
 void

--- a/src/gui/menu_manager.hpp
+++ b/src/gui/menu_manager.hpp
@@ -25,6 +25,7 @@ class Dialog;
 class DrawingContext;
 class Menu;
 class MenuTransition;
+class Notification;
 union SDL_Event;
 
 class MenuManager final
@@ -38,6 +39,10 @@ private:
   std::unique_ptr<Dialog> m_dialog;
   bool m_has_next_dialog;
   std::unique_ptr<Dialog> m_next_dialog;
+
+  std::unique_ptr<Notification> m_notification;
+  bool m_has_next_notification;
+  std::unique_ptr<Notification> m_next_notification;
 
   std::vector<std::unique_ptr<Menu> > m_menu_stack;
   std::unique_ptr<MenuTransition> m_transition;
@@ -53,6 +58,7 @@ public:
   void draw(DrawingContext& context);
 
   void set_dialog(std::unique_ptr<Dialog> dialog);
+  void set_notification(std::unique_ptr<Notification> notification);
 
   void set_menu(int id);
   void set_menu(std::unique_ptr<Menu> menu);

--- a/src/gui/notification.cpp
+++ b/src/gui/notification.cpp
@@ -1,0 +1,257 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gui/notification.hpp"
+
+#include "control/controller.hpp"
+#include "gui/menu_manager.hpp"
+#include "gui/mousecursor.hpp"
+#include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/resources.hpp"
+#include "video/color.hpp"
+#include "video/renderer.hpp"
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
+#include "util/gettext.hpp"
+#include "util/log.hpp"
+
+Notification::Notification(std::string id, bool no_auto_hide, bool no_auto_disable) :
+  m_id(id),
+  m_auto_hide(!no_auto_hide),
+  m_auto_disable(!no_auto_disable),
+  m_text(),
+  m_mini_text(),
+  m_text_size(),
+  m_mini_text_size(),
+  m_pos(),
+  m_size(),
+  m_mouse_pos(),
+  m_mouse_over(false),
+  m_mouse_over_sym1(false),
+  m_mouse_over_sym2(false),
+  m_quit(false),
+  m_callback([](){})
+{
+  if (is_disabled(id)) // The notification exists in the config as disabled.
+  {
+    log_warning << "Requested launch of disabled dialog with ID \"" << m_id << "\". Closing." << std::endl;
+    m_quit = true;
+    return;
+  }
+
+  set_mini_text(_("Click for more details.")); // Set default mini text.
+}
+
+Notification::~Notification()
+{
+}
+
+void
+Notification::set_text(const std::string& text)
+{
+  m_text = text;
+
+  m_text_size = Sizef(Resources::normal_font->get_text_width(m_text),
+                      Resources::normal_font->get_text_height(m_text));
+  calculate_size();
+}
+
+void
+Notification::set_mini_text(const std::string& text)
+{
+  m_mini_text = text;
+
+  m_mini_text_size = Sizef(Resources::small_font->get_text_width(m_mini_text),
+                           Resources::small_font->get_text_height(m_mini_text));
+  calculate_size();
+}
+
+void
+Notification::calculate_size()
+{
+  m_size = Sizef(std::max(m_text_size.width, m_mini_text_size.width) + 60,
+                 m_text_size.height + m_mini_text_size.height + 40);
+}
+
+void
+Notification::draw(DrawingContext& context)
+{
+  if (m_quit || !MenuManager::instance().is_active()) // Close notification, if a quit has been requested, or the MenuManager isn't active.
+  {
+    close();
+    return;
+  }
+
+  m_pos = Vector(static_cast<float>(context.get_width()) - std::max(m_text_size.width, m_mini_text_size.width) - 90.0f,
+                 static_cast<float>(context.get_height() / 12) - m_text_size.height - m_mini_text_size.height + 10.0f);
+  Rectf bg_rect(m_pos, m_size);
+
+  // Draw background rect
+  context.color().draw_filled_rect(bg_rect.grown(12.0f),
+                                     Color(g_config->menubackcolor.red, g_config->menubackcolor.green,
+                                       g_config->menubackcolor.blue, std::max(0.f, g_config->menubackcolor.alpha - 0.5f)),
+                                       g_config->menuroundness + 4.f,
+                                     LAYER_GUI - 10);
+
+  context.color().draw_filled_rect(bg_rect.grown(8.0f),
+                                     Color(g_config->menufrontcolor.red, g_config->menufrontcolor.green,
+                                       g_config->menufrontcolor.blue, std::max(0.f, g_config->menufrontcolor.alpha - 0.3f)),
+                                       g_config->menuroundness,
+                                     LAYER_GUI - 10);
+
+  // Draw normal and mini texts.
+  context.color().draw_text(Resources::normal_font, m_text,
+                              Vector(bg_rect.get_left() + bg_rect.get_width() / 2.0f,
+                                     bg_rect.get_top() + (bg_rect.get_height() / 2 - bg_rect.get_height() / 3)),
+                              ALIGN_CENTER, LAYER_GUI);
+
+  context.color().draw_text(Resources::small_font, m_mini_text,
+                              Vector(bg_rect.get_left() + bg_rect.get_width() / 2.0f,
+                                     bg_rect.get_top() + (bg_rect.get_height() / 2 + bg_rect.get_height() / 8)),
+                              ALIGN_CENTER, LAYER_GUI);
+
+  // Draw "do not show again" symbol ("!") and "close" ("X"), if the mouse is hovering over the notification.
+  if (!m_mouse_over) return;
+  std::string sym1 = "-";
+  std::string sym2 = "X";
+  Vector sym1_pos = Vector(bg_rect.get_left() + 5.0f, bg_rect.get_top());
+  Vector sym2_pos = Vector(bg_rect.get_right() - 15.0f, bg_rect.get_top());
+
+  context.color().draw_text(Resources::normal_font, sym1, sym1_pos,
+                              ALIGN_LEFT, LAYER_GUI, Color::YELLOW);
+
+  context.color().draw_text(Resources::normal_font, sym2, sym2_pos,
+                              ALIGN_LEFT, LAYER_GUI, Color::RED);
+
+  // Draw description of a symbol, when the mouse hovers over it.
+  Rectf sym1_rect(sym1_pos, Sizef(Resources::normal_font->get_text_width(sym1), Resources::normal_font->get_text_height(sym1)));
+  Rectf sym2_rect(sym2_pos, Sizef(Resources::normal_font->get_text_width(sym2), Resources::normal_font->get_text_height(sym2)));
+
+  m_mouse_over_sym1 = sym1_rect.contains(m_mouse_pos);
+  m_mouse_over_sym2 = sym2_rect.contains(m_mouse_pos);
+
+  if (m_mouse_over_sym1)
+  {
+    context.color().draw_text(Resources::normal_font, _("Do not show again"),
+                                Vector(m_mouse_pos.x,
+                                       m_mouse_pos.y + 20.0f),
+                                ALIGN_RIGHT, LAYER_GUI + 1, Color::CYAN);
+  }
+  else if (m_mouse_over_sym2)
+  {
+    context.color().draw_text(Resources::normal_font, _("Close"),
+                                Vector(m_mouse_pos.x,
+                                       m_mouse_pos.y + 20.0f),
+                                ALIGN_RIGHT, LAYER_GUI + 1, Color::CYAN);
+  }
+}
+
+void
+Notification::event(const SDL_Event& ev)
+{
+  Rectf bg_rect(m_pos, m_size);
+  bg_rect = bg_rect.grown(12.0f);
+
+  switch (ev.type)
+  {
+    case SDL_MOUSEBUTTONDOWN:
+    if (ev.button.button == SDL_BUTTON_LEFT)
+    {
+      if (m_mouse_over)
+      {
+        if (m_mouse_over_sym1) // "Do not show again" action
+        {
+          disable();
+          close();
+        }
+        else if (m_mouse_over_sym2) // "Close" action
+        {
+          close();
+        }
+        else // Dialog clicked (execute callback)
+        {
+          m_callback();
+          if (m_auto_disable) disable();
+          if (m_auto_hide) close();
+        }
+      }
+    }
+    break;
+
+    case SDL_MOUSEMOTION:
+    {
+      m_mouse_pos = VideoSystem::current()->get_viewport().to_logical(ev.motion.x, ev.motion.y);
+      m_mouse_over = bg_rect.contains(m_mouse_pos);
+      if (MouseCursor::current() && m_mouse_over) MouseCursor::current()->set_state(MouseCursorState::LINK);
+    }
+    break;
+
+    default:
+      break;
+  }
+}
+
+void
+Notification::process_input(const Controller& controller)
+{
+  if (controller.pressed(Control::MENU_BACK) && !MenuManager::instance().previous_menu())
+  {
+    // If the user tries to go back on the last menu, close the notification instead.
+    close();
+  }
+}
+
+// Notification actions
+
+void
+Notification::disable()
+{
+  // Save the notification as disabled in the config.
+  bool defined = false;
+  for (auto& notif : g_config->notifications)
+  {
+    if (notif.id == m_id)
+    {
+      // If the notification is already defined in the config, only set "disabled" to "true".
+      defined = true;
+      notif.disabled = true;
+    }
+  }
+  if (!defined) g_config->notifications.push_back({m_id, true}); 
+}
+
+void
+Notification::close()
+{
+  if (MouseCursor::current() && m_mouse_over) MouseCursor::current()->set_state(MouseCursorState::NORMAL);
+  MenuManager::instance().set_notification({});
+}
+
+// Static functions, serving as utilities
+
+bool
+Notification::is_disabled(std::string id) // Check if a notification is disabled by its ID.
+{
+  return std::any_of(g_config->notifications.begin(), g_config->notifications.end(),
+                     [id](const auto& notif)
+                     {
+                       return notif.id == id && notif.disabled;
+                     });
+}
+
+/* EOF */

--- a/src/gui/notification.cpp
+++ b/src/gui/notification.cpp
@@ -49,7 +49,7 @@ Notification::Notification(std::string id, bool no_auto_hide, bool no_auto_disab
 {
   if (is_disabled(id)) // The notification exists in the config as disabled.
   {
-    log_warning << "Requested launch of disabled dialog with ID \"" << m_id << "\". Closing." << std::endl;
+    log_warning << "Requested launch of disabled notification with ID \"" << m_id << "\". Closing." << std::endl;
     m_quit = true;
     return;
   }
@@ -125,7 +125,7 @@ Notification::draw(DrawingContext& context)
                                      bg_rect.get_top() + (bg_rect.get_height() / 2 + bg_rect.get_height() / 8)),
                               ALIGN_CENTER, LAYER_GUI);
 
-  // Draw "do not show again" symbol ("!") and "close" ("X"), if the mouse is hovering over the notification.
+  // Draw "Do not show again" and "Close" symbols, if the mouse is hovering over the notification.
   if (!m_mouse_over) return;
   const std::string sym1 = "-";
   const std::string sym2 = "X";
@@ -183,7 +183,7 @@ Notification::event(const SDL_Event& ev)
         {
           close();
         }
-        else // Dialog clicked (execute callback)
+        else // Notification clicked (execute callback)
         {
           m_callback();
           if (m_auto_disable) disable();

--- a/src/gui/notification.cpp
+++ b/src/gui/notification.cpp
@@ -84,8 +84,8 @@ Notification::set_mini_text(const std::string& text)
 void
 Notification::calculate_size()
 {
-  m_size = Sizef(std::max(m_text_size.width, m_mini_text_size.width) + 60,
-                 m_text_size.height + m_mini_text_size.height + 40);
+  m_size = Sizef(std::max(m_text_size.width, m_mini_text_size.width) + 60.0f,
+                 m_text_size.height + m_mini_text_size.height + 40.0f);
 }
 
 void
@@ -127,8 +127,8 @@ Notification::draw(DrawingContext& context)
 
   // Draw "do not show again" symbol ("!") and "close" ("X"), if the mouse is hovering over the notification.
   if (!m_mouse_over) return;
-  std::string sym1 = "-";
-  std::string sym2 = "X";
+  const std::string sym1 = "-";
+  const std::string sym2 = "X";
   Vector sym1_pos = Vector(bg_rect.get_left() + 5.0f, bg_rect.get_top());
   Vector sym2_pos = Vector(bg_rect.get_right() - 15.0f, bg_rect.get_top());
 

--- a/src/gui/notification.hpp
+++ b/src/gui/notification.hpp
@@ -1,0 +1,83 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_GUI_NOTIFICATION_HPP
+#define HEADER_SUPERTUX_GUI_NOTIFICATION_HPP
+
+#include <SDL.h>
+#include <functional>
+#include <string>
+
+#include "control/controller.hpp"
+#include "math/sizef.hpp"
+#include "video/drawing_context.hpp"
+
+class Notification
+{
+private:
+  const std::string m_id;
+  const bool m_auto_hide;
+  const bool m_auto_disable;
+
+  std::string m_text;
+  std::string m_mini_text;
+  Sizef m_text_size;
+  Sizef m_mini_text_size;
+
+  Vector m_pos;
+  Sizef m_size;
+
+  Vector m_mouse_pos;
+  bool m_mouse_over;
+  bool m_mouse_over_sym1; // Mouse is over "Do not show again".
+  bool m_mouse_over_sym2; // Mouse is over "Close".
+
+  bool m_quit; // Requested notification quit.
+
+  std::function<void ()> m_callback;
+
+public:
+  Notification(std::string id, bool no_auto_hide = false, bool no_auto_disable = false);
+  ~Notification();
+
+  void set_text(const std::string& text);
+  void set_mini_text(const std::string& text);
+  void on_press(const std::function<void ()>& callback) { m_callback = callback; }
+
+  void event(const SDL_Event& event);
+  void process_input(const Controller& controller);
+  void draw(DrawingContext& context);
+
+  // Notification actions
+
+  void disable();
+  void close();
+
+  // Static functions, serving as utilities
+
+  static bool is_disabled(std::string id);
+
+private:
+  void calculate_size();
+
+private:
+  Notification(const Notification&) = delete;
+  Notification& operator=(const Notification&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -164,7 +164,7 @@ Config::load()
         auto notification = notification_node.get_mapping();
 
         std::string id;
-        bool disabled;
+        bool disabled = false;
         if (notification.get("id", id) &&
             notification.get("disabled", disabled))
         {

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -106,11 +106,20 @@ public:
   bool confirmation_dialog;
   bool pause_on_focusloss;
   bool custom_mouse_cursor;
+  bool do_release_check;
 
 #ifdef ENABLE_DISCORD
   bool enable_discord;
 #endif
   bool hide_editor_levelnames;
+
+  struct Notification
+  {
+    std::string id;
+    bool disabled;
+  };
+  std::vector<Notification> notifications;
+
   Color menubackcolor;
   Color menufrontcolor;
   Color menuhelpbackcolor;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -750,7 +750,7 @@ Main::release_check()
     }
     auto mapping = root.get_mapping();
     std::string latest_ver;
-    if (root.get_mapping().get("latest", latest_ver))
+    if (mapping.get("latest", latest_ver))
     {
       const std::string version_full = std::string(PACKAGE_VERSION);
       const std::string version = version_full.substr(version_full.find("v") + 1, version_full.find("-") - 1);

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -732,8 +732,8 @@ Main::release_check()
 {
   // Detect a potential new release of SuperTux. If a release, other than
   // the current one is indicated on the given web file, show a notification on the main menu screen.
-  const std::string target_file = "verinfo.nfo";
-  TransferStatusPtr status = m_downloader.request_download("https://raw.githubusercontent.com/SuperTux/supertux/master/verinfo.nfo", target_file);
+  const std::string target_file = "ver_info.nfo";
+  TransferStatusPtr status = m_downloader.request_download("https://raw.githubusercontent.com/SuperTux/addons/master/ver_info.nfo", target_file);
   status->then([target_file, status](bool success)
   {
     if (!success)

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -26,6 +26,7 @@
 #include <boost/locale.hpp>
 #include <physfs.h>
 #include <tinygettext/log.hpp>
+#include <fmt/format.h>
 extern "C" {
 #include <findlocale.h>
 }
@@ -35,6 +36,7 @@ extern "C" {
 #endif
 
 #include "addon/addon_manager.hpp"
+#include "addon/downloader.hpp"
 #include "audio/sound_manager.hpp"
 #include "editor/editor.hpp"
 #include "editor/layer_icon.hpp"
@@ -44,6 +46,7 @@ extern "C" {
 #include "editor/tool_icon.hpp"
 #include "gui/dialog.hpp"
 #include "gui/menu_manager.hpp"
+#include "gui/notification.hpp"
 #include "math/random.hpp"
 #include "object/player.hpp"
 #include "object/spawnpoint.hpp"
@@ -72,8 +75,11 @@ extern "C" {
 #include "supertux/tile_manager.hpp"
 #include "supertux/title_screen.hpp"
 #include "supertux/world.hpp"
+#include "supertux/menu/download_dialog.hpp"
 #include "util/file_system.hpp"
 #include "util/gettext.hpp"
+#include "util/reader_document.hpp"
+#include "util/reader_mapping.hpp"
 #include "util/string_util.hpp"
 #include "util/timelog.hpp"
 #include "util/string_util.hpp"
@@ -133,7 +139,8 @@ Main::Main() :
   m_console(),
   m_game_manager(),
   m_screen_manager(),
-  m_savegame()
+  m_savegame(),
+  m_downloader() // Used for getting the version of the latest SuperTux release.
 {
 }
 
@@ -598,6 +605,7 @@ Main::launch_game(const CommandLineArguments& args)
     else
     {
       m_screen_manager->push_screen(std::make_unique<TitleScreen>(*m_savegame));
+      if (g_config->do_release_check) release_check();
     }
   }
 
@@ -717,6 +725,54 @@ Main::run(int argc, char** argv)
 #endif
 
   return result;
+}
+
+void
+Main::release_check()
+{
+  // Detect a potential new release of SuperTux. If a release, other than
+  // the current one is indicated on the given web file, show a notification on the main menu screen.
+  const std::string target_file = "verinfo.nfo";
+  TransferStatusPtr status = m_downloader.request_download("https://raw.githubusercontent.com/SuperTux/supertux/master/verinfo.nfo", target_file);
+  status->then([target_file, status](bool success)
+  {
+    if (!success)
+    {
+      log_warning << "Error performing new release check: Failed to download \"supertux-versioninfo\" file: " << status->error_msg << std::endl;
+      return;
+    }
+    auto doc = ReaderDocument::from_file(target_file);
+    auto root = doc.get_root();
+    if (root.get_name() != "supertux-versioninfo")
+    {
+      log_warning << "File is not a \"supertux-versioninfo\" file." << std::endl;
+      return;
+    }
+    auto mapping = root.get_mapping();
+    std::string latest_ver;
+    if (root.get_mapping().get("latest", latest_ver))
+    {
+      const std::string version_full = std::string(PACKAGE_VERSION);
+      const std::string version = version_full.substr(version_full.find("v") + 1, version_full.find("-") - 1);
+      if (version != latest_ver)
+      {
+        auto notif = std::make_unique<Notification>("new_release_" + latest_ver);
+        notif->set_text("New release: SuperTux v" + latest_ver + "!");
+        notif->on_press([latest_ver]()
+                       {
+                         Dialog::show_confirmation(fmt::format(fmt::runtime(_("A new release of SuperTux (v{}) is available!\nFor more information, you can visit the SuperTux website.\n \nDo you want to visit the website now?")), latest_ver), []()
+                                                   {
+                                                     FileSystem::open_url("https://supertux.org");
+                                                   });
+                       });
+        MenuManager::instance().set_notification(std::move(notif));
+      }
+    }
+  });
+  // Set up a download dialog to update the transfer status.
+  auto dialog = std::make_unique<DownloadDialog>(status, true, true, true);
+  dialog->set_title(_("Checking for new releases..."));
+  MenuManager::instance().set_dialog(std::move(dialog));
 }
 
 /* EOF */

--- a/src/supertux/main.hpp
+++ b/src/supertux/main.hpp
@@ -86,6 +86,7 @@ private:
 
   void launch_game(const CommandLineArguments& args);
   void resave(const std::string& input_filename, const std::string& output_filename);
+  void release_check();
 
 private:
   // Using pointers allows us to initialize them whenever we want
@@ -106,6 +107,8 @@ private:
   std::unique_ptr<GameManager> m_game_manager;
   std::unique_ptr<ScreenManager> m_screen_manager;
   std::unique_ptr<Savegame> m_savegame;
+
+  Downloader m_downloader; // Used for getting the version of the latest SuperTux release.
 
 private:
   Main(const Main&) = delete;

--- a/src/supertux/menu/download_dialog.cpp
+++ b/src/supertux/menu/download_dialog.cpp
@@ -18,11 +18,12 @@
 
 #include "addon/addon_manager.hpp"
 
-DownloadDialog::DownloadDialog(TransferStatusPtr status, bool auto_close, bool passive) :
+DownloadDialog::DownloadDialog(TransferStatusPtr status, bool auto_close, bool passive, bool no_error_msg) :
   Dialog(passive),
   m_status(std::move(status)),
   m_title(),
-  m_auto_close(auto_close)
+  m_auto_close(auto_close),
+  m_error_msg(!no_error_msg)
 {
   add_default_button(_("Abort Download"), [this]{
       on_abort();
@@ -39,7 +40,14 @@ DownloadDialog::DownloadDialog(TransferStatusPtr status, bool auto_close, bool p
       }
       else
       {
-        Dialog::show_message(_("Error:\n") + m_status->error_msg);
+        if (m_error_msg)
+        {
+          Dialog::show_message(_("Error:\n") + m_status->error_msg);
+        }
+        else
+        {
+          MenuManager::instance().set_dialog({});
+        }
       }
     });
 }

--- a/src/supertux/menu/download_dialog.hpp
+++ b/src/supertux/menu/download_dialog.hpp
@@ -28,9 +28,10 @@ private:
   TransferStatusPtr m_status;
   std::string m_title;
   bool m_auto_close;
+  bool m_error_msg;
 
 public:
-  DownloadDialog(TransferStatusPtr status, bool auto_close = false, bool passive = false);
+  DownloadDialog(TransferStatusPtr status, bool auto_close = false, bool passive = false, bool no_error_msg = false);
 
   void set_title(const std::string& title);
   void update() override;

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -75,6 +75,9 @@ enum OptionsMenuIDs {
   MNID_CONFIRMATION_DIALOG,
   MNID_PAUSE_ON_FOCUSLOSS,
   MNID_CUSTOM_CURSOR,
+#ifndef __EMSCRIPTEN__
+  MNID_RELEASE_CHECK,
+#endif
   MNID_MOBILE_CONTROLS
 };
 
@@ -444,6 +447,10 @@ OptionsMenu::OptionsMenu(bool complete) :
   add_toggle(MNID_PAUSE_ON_FOCUSLOSS, _("Pause on focus loss"), &g_config->pause_on_focusloss)
     .set_help(_("Automatically pause the game when the window loses focus"));
   add_toggle(MNID_CUSTOM_CURSOR, _("Use custom mouse cursor"), &g_config->custom_mouse_cursor).set_help(_("Whether the game renders its own cursor or uses the system's cursor"));
+#ifndef __EMSCRIPTEN__
+  add_toggle(MNID_RELEASE_CHECK, _("Check for new releases"), &g_config->do_release_check)
+    .set_help(_("Allows the game to perform checks for new SuperTux releases on startup and notify if any found."));
+#endif
 
   add_submenu(_("Integrations and presence"), MenuStorage::INTEGRATIONS_MENU)
       .set_help(_("Manage whether SuperTux should display the levels you play on your social media profiles (Discord)"));

--- a/verinfo.nfo
+++ b/verinfo.nfo
@@ -1,3 +1,0 @@
-(supertux-versioninfo
-  (latest "0.6.3")
-)

--- a/verinfo.nfo
+++ b/verinfo.nfo
@@ -1,0 +1,3 @@
+(supertux-versioninfo
+  (latest "0.6.3")
+)


### PR DESCRIPTION
Adds a new `Notification` GUI item, which shows up on the top-right of the screen with appearance, similar to the one of passive dialogs. It features "Do not show again" and "Close" buttons, which are useful if users want to ignore a notification. Clicking on a notification executes a given callback.

Other than that, this PR also adds the ability for the game to check which the latest SuperTux version is on startup, and if it's different from the current version, show a notification. Checking for new releases on game startup can be toggled from "Options". Clicking on the notification for the new release shows a dialog, indicating that the user could go to the SuperTux website and view more information about the new release there.

![Preview of the dialog for new releases](https://user-images.githubusercontent.com/78196474/181024911-e86eba41-aa07-48a6-8101-994a16387041.png)

Fixes #248.