### PR TITLE
Option to disable sound positioning

### DIFF
--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -17,6 +17,8 @@
 #include "audio/openal_sound_source.hpp"
 
 #include "audio/sound_manager.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "util/log.hpp"
 
 OpenALSoundSource::OpenALSoundSource() :
@@ -131,13 +133,23 @@ OpenALSoundSource::set_looping(bool looping)
 void
 OpenALSoundSource::set_relative(bool relative)
 {
+  if (g_config->disable_sound_positioning)
+    relative = true;
+
   alSourcei(m_source, AL_SOURCE_RELATIVE, relative ? AL_TRUE : AL_FALSE);
 }
 
 void
 OpenALSoundSource::set_position(const Vector& position)
 {
-  alSource3f(m_source, AL_POSITION, position.x, position.y, 0);
+  if (g_config->disable_sound_positioning)
+  {
+    set_relative(true);
+  }
+  else
+  {
+    alSource3f(m_source, AL_POSITION, position.x, position.y, 0);
+  }
 }
 
 void

--- a/src/audio/sound_manager.cpp
+++ b/src/audio/sound_manager.cpp
@@ -26,6 +26,8 @@
 #include "audio/dummy_sound_source.hpp"
 #include "audio/sound_file.hpp"
 #include "audio/stream_sound_source.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "util/log.hpp"
 
 SoundManager::SoundManager() :
@@ -199,7 +201,7 @@ SoundManager::play(const std::string& filename, const Vector& pos,
     std::unique_ptr<OpenALSoundSource> source(intern_create_sound_source(filename));
     source->set_gain(gain);
 
-    if (pos.x < 0 || pos.y < 0) {
+    if (g_config->disable_sound_positioning || pos.x < 0 || pos.y < 0) {
       source->set_relative(true);
     } else {
       source->set_position(pos);

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -108,7 +108,8 @@ Config::Config() :
   // and those with an older SDL; they won't have to check the setting each time
   multiplayer_buzz_controllers(false),
 #endif
-  repository_url()
+  repository_url(),
+  disable_sound_positioning(false)
 {
 }
 
@@ -204,6 +205,8 @@ Config::load()
   config_mapping.get("locale", locale);
   config_mapping.get("random_seed", random_seed);
   config_mapping.get("repository_url", repository_url);
+
+  config_mapping.get("disable_sound_positioning", disable_sound_positioning);
 
   config_mapping.get("multiplayer_auto_manage_players", multiplayer_auto_manage_players);
   config_mapping.get("multiplayer_multibind", multiplayer_multibind);
@@ -332,6 +335,7 @@ Config::save()
   writer.write("transitions_enabled", transitions_enabled);
   writer.write("locale", locale);
   writer.write("repository_url", repository_url);
+  writer.write("disable_sound_positioning", disable_sound_positioning);
   writer.write("multiplayer_auto_manage_players", multiplayer_auto_manage_players);
   writer.write("multiplayer_multibind", multiplayer_multibind);
   writer.write("multiplayer_buzz_controllers", multiplayer_buzz_controllers);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -138,6 +138,8 @@ public:
 
   std::string repository_url;
 
+  bool disable_sound_positioning;
+
   bool is_christmas() const {
     try
     {

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -66,6 +66,7 @@ enum OptionsMenuIDs {
   MNID_VSYNC,
   MNID_SOUND,
   MNID_MUSIC,
+  MNID_SOUND_POSITIONING,
   MNID_SOUND_VOLUME,
   MNID_MUSIC_VOLUME,
   MNID_RUMBLING,
@@ -397,6 +398,9 @@ OptionsMenu::OptionsMenu(bool complete) :
 
     MenuItem& music_volume_select = add_string_select(MNID_MUSIC_VOLUME, _("Music Volume"), &next_music_volume, music_volumes);
     music_volume_select.set_help(_("Adjust music volume"));
+
+    add_toggle(MNID_SOUND_POSITIONING, _("Disable sound positioning"), &g_config->disable_sound_positioning)
+      .set_help(_("Play all sounds as if they come from the middle of the screen"));
   }
   else
   {


### PR DESCRIPTION
This allows users to disable sound positioning entirely from a config entry.

Observations, remarks, caveats:
- Sounds that are played far away from the screen are very audible when the option is activated. This may give players a hint about activity far away from the screen, as well as when certain things are disabled because they are too far away to be worth updating every frame.
- If the option is changed from the pause menu while in-game, the sounds that are already playing won't be updated.
- The 'sssssssssss' of the bomb is excessively loud. This may need a fix.