### PR TITLE
Make bonus blocks able to dispense more than 1 of coin rain and coin explosion

### DIFF
--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -351,14 +351,12 @@ BonusBlock::try_open(Player* player)
     }
     case Content::RAIN:
     {
-      m_hit_counter = 1; // multiple hits of coin rain is not allowed
       Sector::get().add<CoinRain>(get_pos(), true);
       play_upgrade_sound = true;
       break;
     }
     case Content::EXPLODE:
     {
-      m_hit_counter = 1; // multiple hits of coin explode is not allowed
       Sector::get().add<CoinExplode>(get_pos() + Vector (0, -40));
       play_upgrade_sound = true;
       break;
@@ -485,7 +483,6 @@ BonusBlock::try_drop(Player *player)
     }
     case Content::EXPLODE:
     {
-      m_hit_counter = 1; // multiple hits of coin explode is not allowed
       Sector::get().add<CoinExplode>(get_pos() + Vector (0, 40));
       play_upgrade_sound = true;
       countdown = true;

--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -218,7 +218,7 @@ Level::get_total_coins() const
         } else if (block->get_contents() == BonusBlock::Content::RAIN ||
                    block->get_contents() == BonusBlock::Content::EXPLODE)
         {
-          total_coins += 10;
+          total_coins += 10 * block->get_hit_counter();
           continue;
         }
       }


### PR DESCRIPTION
Fixes #2268 