### PR TITLE
Sliding + crawling

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -475,7 +475,7 @@ HitResponse
 BadGuy::collision_player(Player& player, const CollisionHit& hit)
 {
   if (player.is_invincible() ||
-    (is_snipable() && ((player.is_sliding() && glm::length(player.get_velocity()) > 320.f) || player.is_swimboosting()))) {
+    (is_snipable() && player.is_sliding())) {
     kill_fall();
     return ABORT_MOVE;
   }

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -395,7 +395,7 @@ BadGuy::collision(GameObject& other, const CollisionHit& hit)
     /* Badguys don't let badguys squish other badguys. It's bad. */
 #if 0
     // hit from above?
-    if (badguy->get_bbox().get_bottom() < (bbox.get_top() + 16)) {
+    if (badguy->get_bbox().get_bottom() < (bbox.get_top() + (player->is_sliding() ? 8.f : 16.f))) {
       if (collision_squished(*badguy)) {
         return ABORT_MOVE;
       }
@@ -474,7 +474,8 @@ BadGuy::on_flip(float height)
 HitResponse
 BadGuy::collision_player(Player& player, const CollisionHit& hit)
 {
-  if (player.is_invincible()) {
+  if (player.is_invincible() ||
+    (is_snipable() && ((player.is_sliding() && glm::length(player.get_velocity()) > 320.f) || player.is_swimboosting()))) {
     kill_fall();
     return ABORT_MOVE;
   }

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -115,6 +115,10 @@ public:
       with the attribute "hurts" */
   virtual bool is_hurtable() const { return true; }
 
+  /** Can enemy be sniped by sliding or swimboosting Tux?
+    Returns false if enemy is spiky or too large */
+  virtual bool is_snipable() const { return false; }
+
   bool is_frozen() const;
 
   bool is_in_water() const;

--- a/src/badguy/bomb.hpp
+++ b/src/badguy/bomb.hpp
@@ -41,6 +41,7 @@ public:
   virtual bool is_portable() const override;
   virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
   virtual void ungrab(MovingObject& object, Direction dir) override;
+  virtual bool is_snipable() const override { return true; }
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/bouncing_snowball.hpp
+++ b/src/badguy/bouncing_snowball.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void after_editor_set() override;
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/captainsnowball.hpp
+++ b/src/badguy/captainsnowball.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Captain Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
   bool might_climb(int width, int height) const;
 

--- a/src/badguy/crystallo.hpp
+++ b/src/badguy/crystallo.hpp
@@ -33,6 +33,7 @@ public:
 
   virtual void active_update(float dt_sec) override;
   virtual bool is_flammable() const override;
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/flyingsnowball.hpp
+++ b/src/badguy/flyingsnowball.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Flying Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/ghoul.hpp
+++ b/src/badguy/ghoul.hpp
@@ -32,6 +32,7 @@ public:
   std::string get_display_name() const override { return display_name(); }
   bool is_freezable() const override;
   bool is_flammable() const override;
+  virtual bool is_snipable() const override { return true; }
 
   void finish_construction() override;
 

--- a/src/badguy/goldbomb.hpp
+++ b/src/badguy/goldbomb.hpp
@@ -48,6 +48,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Gold Bomb"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -45,6 +45,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Haywire"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Snowshot"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;
@@ -56,10 +57,14 @@ public:
   virtual void kill_collision() override;
 
   virtual std::string get_overlay_size() const override { return "2x1"; }
+<<<<<<< HEAD
   static std::string class_name() { return "leafshot"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Leafshot"); }
   virtual std::string get_display_name() const override { return display_name(); }
+=======
+  virtual bool is_snipable() const override { return true; }
+>>>>>>> 83df5c4a7 (Tux can slide on the ground)
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -57,14 +57,11 @@ public:
   virtual void kill_collision() override;
 
   virtual std::string get_overlay_size() const override { return "2x1"; }
-<<<<<<< HEAD
   static std::string class_name() { return "leafshot"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Leafshot"); }
   virtual std::string get_display_name() const override { return display_name(); }
-=======
   virtual bool is_snipable() const override { return true; }
->>>>>>> 83df5c4a7 (Tux can slide on the ground)
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/mrbomb.hpp
+++ b/src/badguy/mrbomb.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bomb"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -44,7 +44,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Iceblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
-  virtual bool is_snipable() const override { return true; }
+  virtual bool is_snipable() const override { return ice_state != ICESTATE_KICKED; }
 
   bool can_break();
 

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -44,6 +44,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Iceblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
   bool can_break();
 

--- a/src/badguy/owl.hpp
+++ b/src/badguy/owl.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_display_name() const override { return display_name(); }
 
   virtual ObjectSettings get_settings() override;
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   bool is_above_player() const;

--- a/src/badguy/poisonivy.hpp
+++ b/src/badguy/poisonivy.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Spring Leaf"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/scrystallo.hpp
+++ b/src/badguy/scrystallo.hpp
@@ -36,6 +36,7 @@ public:
 
   virtual void active_update(float dt_sec) override;
   virtual bool is_flammable() const override;
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/short_fuse.hpp
+++ b/src/badguy/short_fuse.hpp
@@ -37,6 +37,7 @@ protected:
   virtual void freeze() override;
   virtual void kill_fall() override;
   virtual void ignite() override;
+  virtual bool is_snipable() const override { return true; }
 
   void explode();
 

--- a/src/badguy/skullyhop.hpp
+++ b/src/badguy/skullyhop.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Skullyhop"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 private:
   enum SkullyHopState {

--- a/src/badguy/skydive.hpp
+++ b/src/badguy/skydive.hpp
@@ -41,6 +41,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Skydive"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 private:
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;

--- a/src/badguy/smartball.hpp
+++ b/src/badguy/smartball.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Smartball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/smartblock.hpp
+++ b/src/badguy/smartblock.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Smartblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 private:
   SmartBlock(const SmartBlock&) = delete;

--- a/src/badguy/smartblock.hpp
+++ b/src/badguy/smartblock.hpp
@@ -29,7 +29,6 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Smartblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
-  virtual bool is_snipable() const override { return true; }
 
 private:
   SmartBlock(const SmartBlock&) = delete;

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -44,6 +44,7 @@ public:
   virtual bool is_portable() const override;
   virtual void ungrab(MovingObject& , Direction dir_) override;
   virtual void grab(MovingObject&, const Vector& pos, Direction dir_) override;
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -44,7 +44,7 @@ public:
   virtual bool is_portable() const override;
   virtual void ungrab(MovingObject& , Direction dir_) override;
   virtual void grab(MovingObject&, const Vector& pos, Direction dir_) override;
-  virtual bool is_snipable() const override { return true; }
+  virtual bool is_snipable() const override { return state != STATE_KICKED; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/snowball.hpp
+++ b/src/badguy/snowball.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/spidermite.hpp
+++ b/src/badguy/spidermite.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Spider"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   enum SpiderMiteMode {

--- a/src/badguy/stumpy.hpp
+++ b/src/badguy/stumpy.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Walking Stump"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   enum MyState {

--- a/src/badguy/stumpy.hpp
+++ b/src/badguy/stumpy.hpp
@@ -37,7 +37,6 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Walking Stump"); }
   virtual std::string get_display_name() const override { return display_name(); }
-  virtual bool is_snipable() const override { return true; }
 
 protected:
   enum MyState {

--- a/src/badguy/toad.hpp
+++ b/src/badguy/toad.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Toad"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   enum ToadState {

--- a/src/badguy/totem.hpp
+++ b/src/badguy/totem.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Totem"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/walkingleaf.hpp
+++ b/src/badguy/walkingleaf.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Autumn Leaf"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 protected:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/badguy/zeekling.hpp
+++ b/src/badguy/zeekling.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Zeekling"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_snipable() const override { return true; }
 
 private:
   virtual bool collision_squished(GameObject& object) override;

--- a/src/object/block.cpp
+++ b/src/object/block.cpp
@@ -90,7 +90,7 @@ Block::collision(GameObject& other, const CollisionHit& )
   auto player = dynamic_cast<Player*> (&other);
   if (player)
   {
-    if(player->is_swimboosting())
+    if(player->is_swimboosting() || (player->is_sliding() && glm::length(player->get_velocity()) > 320.f))
     {
       hit(*player);
     }

--- a/src/object/block.cpp
+++ b/src/object/block.cpp
@@ -90,7 +90,12 @@ Block::collision(GameObject& other, const CollisionHit& )
   auto player = dynamic_cast<Player*> (&other);
   if (player)
   {
-    if(player->is_swimboosting() || (player->is_sliding() && glm::length(player->get_velocity()) > 320.f))
+    bool in_line_with_player = ((player->get_physic().get_velocity_x() > 0.f &&
+      player->get_bbox().get_right() < get_bbox().get_left()) ||
+      (player->get_physic().get_velocity_x() < 0.f &&
+      player->get_bbox().get_left() > get_bbox().get_right()));
+
+    if(player->is_swimboosting() || (player->is_sliding() && in_line_with_player))
     {
       hit(*player);
     }

--- a/src/object/brick.cpp
+++ b/src/object/brick.cpp
@@ -102,10 +102,14 @@ Brick::collision(GameObject& other, const CollisionHit& hit)
 }
 
 void
-Brick::try_break(Player* player)
+Brick::try_break(Player* player, bool slider)
 {
   if (m_sprite->get_action() == "empty")
     return;
+
+  //takes too long for sliding tux to barrel through crates and ends up stopping him otherwise
+  if (slider && m_breakable && m_coin_counter <= 0)
+    break_me();
 
   SoundManager::current()->play("sounds/brick.wav", get_pos());
   Player& player_one = *Sector::get().get_players()[0];

--- a/src/object/brick.hpp
+++ b/src/object/brick.hpp
@@ -33,7 +33,7 @@ public:
   static std::string display_name() { return _("Brick"); }
   virtual std::string get_display_name() const override { return display_name(); }
 
-  void try_break(Player* player);
+  void try_break(Player* player, bool slider = false);
   void break_for_crusher(IceCrusher* icecrusher);
 
 protected:

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -736,7 +736,7 @@ Player::slide()
   Rectf pre_slide_box = get_bbox();
   float fast_fall_speed = m_physic.get_velocity_y() <= 400.f ? 0.f : m_physic.get_velocity_y()*0.03f;
   pre_slide_box.set_bottom(m_col.m_bbox.get_bottom() + fast_fall_speed + 16.f);
-  bool pre_slide = !Sector::get().is_free_of_statics(pre_slide_box, false);
+  bool pre_slide = !Sector::get().is_free_of_statics(pre_slide_box);
 
   if (std::abs(m_physic.get_velocity_x()) > MAX_SLIDE_SPEED) {
     m_physic.set_acceleration_x(-m_physic.get_velocity_x());

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -709,7 +709,7 @@ Player::update(float dt_sec)
       m_slidejumping = false;
     }
 
-    if (m_jumping) {
+    if (m_jumping && !m_dying) {
       m_sprite->set_angle(m_sprite->get_angle() + (m_dir == Direction::LEFT ? -1.f : 1.f) * dt_sec * (360.0f / 0.5f));
     }
     else {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -693,6 +693,12 @@ Player::update(float dt_sec)
     }
   }
 
+  if (m_floor_normal.y != 0.f && m_crawl)
+  {
+    m_crawl = false;
+    m_sliding = true;
+  }
+
   //sliding
 
   if (m_sliding)
@@ -1024,7 +1030,11 @@ Player::handle_horizontal_input()
     }
   }
 
-  if (m_crawl)
+  if (m_duck && (m_controller->hold(Control::LEFT) || m_controller->hold(Control::RIGHT))) {
+    m_crawl = true;
+  }
+
+  if (m_crawl && on_ground() && std::abs(m_physic.get_velocity_x()) < WALK_SPEED)
   {
     if (m_controller->hold(Control::LEFT) && !m_controller->hold(Control::RIGHT))
     {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -708,7 +708,11 @@ Player::update(float dt_sec)
     if (!m_controller->hold(Control::DOWN) ||
       (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f))
     {
-      if (!adjust_height(is_big() ? BIG_TUX_HEIGHT : SMALL_TUX_HEIGHT)) {
+      if (is_big())
+      {
+        if (m_controller->hold(Control::LEFT) || m_controller->hold(Control::RIGHT)) {
+          m_crawl = true;
+        }
         m_duck = true;
       }
       m_sliding = false;
@@ -1953,13 +1957,19 @@ Player::draw(DrawingContext& context)
   }
   else if (m_crawl)
   {
-    if (m_physic.get_velocity_x() != 0.f) {
-      //placeholder action
-      m_sprite->set_action(sa_prefix + "-swimming" + sa_postfix);
+    if (on_ground())
+    {
+      if (m_physic.get_velocity_x() != 0.f) {
+        //placeholder action
+        m_sprite->set_action(sa_prefix + "-swimming" + sa_postfix);
+      }
+      else {
+        //placeholder action
+        m_sprite->set_action(sa_prefix + "-swimjump" + sa_postfix);
+      }
     }
     else {
-      //placeholder action
-      m_sprite->set_action(sa_prefix + "-swimjump" + sa_postfix);
+      m_sprite->set_action(sa_prefix + "-duck" + sa_postfix);
     }
   }
   else if (m_kick_timer.started() && !m_kick_timer.check() && !m_swimming && !m_water_jump) {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1150,7 +1150,10 @@ Player::do_duck() {
 void
 Player::do_standup(bool force_standup) {
   if (!m_duck || !is_big() || m_backflipping || m_stone)
+  {
+    m_crawl = false;
     return;
+  }
 
   Rectf new_bbox = m_col.m_bbox;
   float new_height = m_swimming ? TUX_WIDTH : BIG_TUX_HEIGHT;

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -277,6 +277,7 @@ private:
   std::unique_ptr<CodeController> m_scripting_controller; /**< This controller is used when the Player is controlled via scripting */
   PlayerStatus& m_player_status;
   bool m_duck;
+  bool m_crawl;
   bool m_dead;
   bool m_dying;
   bool m_winning;

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -163,6 +163,7 @@ public:
   bool is_dead() const { return m_dead; }
   bool is_big() const;
   bool is_stone() const { return m_stone; }
+  bool is_sliding() const { return m_sliding; }
   bool is_swimming() const { return m_swimming; }
   bool is_swimboosting() const { return m_swimboosting; }
   bool is_water_jumping() const { return m_water_jump; }
@@ -246,6 +247,7 @@ private:
   void do_jump_apex();
   void early_jump_apex();
 
+  void slide();
   void swim(float pointx, float pointy, bool boost);
 
   BonusType string_to_bonus(const std::string& bonus) const;
@@ -284,6 +286,8 @@ private:
   Direction m_peekingY;
   float m_ability_time;
   bool m_stone;
+  bool m_sliding;
+  bool m_slidejumping;
   bool m_swimming;
   bool m_swimboosting;
   bool m_no_water;


### PR DESCRIPTION
Tux can now slide on slopes and on the ground.  He is a penguin AND a clone of Super Mario, both of which have this ability, so he should have it as well.  He gains the most speed from going down slopes, but can also gain some speed from falling onto normal terrain; this gives sliding more usage since slopes can't be used everywhere. Also, his acceleration depends on the intensity of the slope.  He can also slide up off of inclines, with the angle of slide-jumping also based off of the intensity of the slope.  Also added is "sniping" for when Tux hits certain enemies while sliding at a high speed.

Fixes #1081 