### PR TITLE
Fix out-of-bounds accesses in ProfileMenu::menu_action and a potential nullptr dereference in Sector::Sector

### DIFF
--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -177,9 +177,8 @@ ProfileMenu::menu_action(MenuItem& item)
   else if (id == -4)
   {
     Dialog::show_confirmation(_("This will reset your game progress on all profiles. Are you sure?"), [this]() {
-      for (std::size_t i = 0; i <= m_profiles.size(); i++)
-      {
-        savegames_util::delete_savegames(m_profiles[i], true);
+      for (const int profile : m_profiles) {
+        savegames_util::delete_savegames(profile, true);
       }
     });
   }
@@ -205,9 +204,8 @@ ProfileMenu::menu_action(MenuItem& item)
   else if (id == -6)
   {
     Dialog::show_confirmation(_("This will delete all profiles, including all game progress on them.\nAre you sure?"), [this]() {
-      for (std::size_t i = 0; i <= m_profiles.size(); i++)
-      {
-        savegames_util::delete_savegames(m_profiles[i]);
+      for (const int profile : m_profiles) {
+        savegames_util::delete_savegames(profile);
       }
       g_config->profiles.clear();
       g_config->profile = 1;

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -91,6 +91,7 @@ Sector::Sector(Level& parent) :
   {
     if (!InputManager::current()->has_corresponsing_controller(id)
         && !InputManager::current()->m_uses_keyboard[id]
+        && savegame
         && !savegame->is_title_screen()
         && id != 0)
       continue;
@@ -372,7 +373,7 @@ Sector::before_object_add(GameObject& object)
       return false;
     }
   }
-  
+
   if (auto* movingobject = dynamic_cast<MovingObject*>(&object))
   {
     m_collision_system->add(movingobject->get_collision_object());


### PR DESCRIPTION
I found these with TscanCode; they were introduced in these commits: https://github.com/SuperTux/supertux/commit/5ca4dc6e3d1a0be8cc9f57a66b0a3f03ad7988be#diff-abbbfc03a6342c2fa8924bc76f71cde054fc628a58f9fe46f3287d29d0fb8c20R94 https://github.com/SuperTux/supertux/commit/0de68b210e6d525b0edca4fa392289cef80c8882#diff-f9de83bde22e94086caae91611106a59d1284054bb5d8a156622ff6a7f419207R180

TscanCode has some additional detections; I think three of them are false positives: 
```
[[…]/object/player.cpp:1658]: (Serious) Comparing [m_target] to null at line 1656 implies that [m_target ] might be null.Dereferencing null pointer [m_target].
[[…]/object/player.cpp:377]: (Serious) Comparing [m_target] to null at line 375 implies that [m_target ] might be null.Dereferencing null pointer [m_target].
[[…]/supertux/menu/addon_preview_menu.cpp:109]: (Serious) When i==desc.size(), desc[i] is out of bounds.
[[…]/video/bitmap_font.cpp:254]: (Serious) Null - checking [surface] suggests that it may be null, but it has already been dereferenced at line 225.
```
I've ommited the fix in `addon_preview_menu.cpp` because it's already part of PR #2294: https://github.com/SuperTux/supertux/pull/2294/commits/f9765b9a947a41fa7fe0f072ffc6a486ced62808