### PR TITLE
Fix ItemIntField inserting 0, when "-" inserted in empty field

### DIFF
--- a/src/gui/item_floatfield.cpp
+++ b/src/gui/item_floatfield.cpp
@@ -59,7 +59,6 @@ ItemFloatField::add_char(char c, const int left_offset_pos)
   {
     if (!input->empty() && *input != "0")
     {
-      *number *= -1;
       if (*input->begin() == '-')
       {
         if (m_cursor_left_offset == static_cast<int>(input->size())) m_cursor_left_offset--;

--- a/src/gui/item_intfield.cpp
+++ b/src/gui/item_intfield.cpp
@@ -46,7 +46,6 @@ ItemIntField::add_char(char c, const int left_offset_pos)
   {
     if (!input->empty() && *input != "0")
     {
-      *number *= -1;
       if (*input->begin() == '-')
       {
         if (m_cursor_left_offset == static_cast<int>(input->size())) m_cursor_left_offset--;
@@ -73,7 +72,7 @@ ItemIntField::add_char(char c, const int left_offset_pos)
 void
 ItemIntField::on_input_update()
 {
-  if (input->empty())
+  if (input->empty() || *input == "-")
   {
     *number = 0;
     return;


### PR DESCRIPTION
Fixes an issue, where ItemIntField items insert "0", when a "-" is inserted, often for the creation of a negative number. Also removes one unneeded multiplication operation from both ItemIntField and ItemFloatField.

Related to #2246.