### PR TITLE
Find tiles/objects from tilemap in toolbox

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -987,4 +987,16 @@ Editor::pack_addon()
   *zip.Add_File(id + ".nfo") << ss.rdbuf();
 }
 
+void
+Editor::show_tile_in_toolbox(uint32_t tile)
+{
+  m_toolbox_widget->show_tile_in_toolbox(tile);
+}
+
+void
+Editor::show_object_in_toolbox(const std::string& classname)
+{
+  m_toolbox_widget->show_object_in_toolbox(classname);
+}
+
 /* EOF */

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -157,6 +157,9 @@ public:
 
   void pack_addon();
 
+  void show_tile_in_toolbox(uint32_t tile);
+  void show_object_in_toolbox(const std::string& classname);
+
 private:
   void set_sector(Sector* sector);
   void set_level(std::unique_ptr<Level> level, bool reset = true);

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -866,6 +866,35 @@ EditorOverlayWidget::process_middle_click()
 {
   m_previous_mouse_pos = m_mouse_pos;
   m_scrolling = true;
+
+  switch (m_editor.get_tileselect_input_type())
+  {
+    case EditorToolboxWidget::InputType::TILE:
+      {
+        auto tilemap = m_editor.get_selected_tilemap();
+        if (!tilemap) {
+          return;
+        }
+
+        auto tile = tilemap->get_tile_id(static_cast<int>(m_hovered_tile.x),
+                                         static_cast<int>(m_hovered_tile.y));
+        m_editor.show_tile_in_toolbox(tile);
+      }
+      break;
+
+    case EditorToolboxWidget::InputType::NONE:
+    case EditorToolboxWidget::InputType::OBJECT:
+      {
+        if (m_hovered_object && m_hovered_object->is_valid())
+        {
+          m_editor.show_object_in_toolbox(m_hovered_object->get_class_name());
+        }
+      }
+      break;
+
+    default:
+      break;
+  }
 }
 
 Rectf

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -622,4 +622,49 @@ EditorToolboxWidget::has_mouse_focus() const
   return m_has_mouse_focus;
 }
 
+void
+EditorToolboxWidget::show_tile_in_toolbox(uint32_t tile)
+{
+  for (const auto& tilegroup : m_editor.get_tileset()->get_tilegroups())
+  {
+    const auto& tiles = tilegroup.tiles;
+
+    for (int id = 0; id < tiles.size(); id++)
+    {
+      if (tiles[id] == tile)
+      {
+        m_active_tilegroup.reset(new Tilegroup(tilegroup));
+        m_input_type = EditorToolboxWidget::InputType::TILE;
+        m_starting_tile = (id / 4) * 4;
+        return;
+      }
+    }
+  }
+}
+
+void
+EditorToolboxWidget::show_object_in_toolbox(const std::string& classname)
+{
+  m_active_objectgroup = 0;
+  m_input_type = EditorToolboxWidget::InputType::OBJECT;
+
+  for (int i = 0; i < m_object_info->m_groups.size(); i++)
+  {
+    const auto& objs = m_object_info->m_groups.at(i).get_icons();
+
+    for (int id = 0; id < objs.size(); id++)
+    {
+      const auto& obj = objs[id];
+
+      if (obj.get_object_class() == classname)
+      {
+        m_active_objectgroup = i;
+        m_input_type = EditorToolboxWidget::InputType::OBJECT;
+        m_starting_tile = (id / 4) * 4;
+        return;
+      }
+    }
+  }
+}
+
 /* EOF */

--- a/src/editor/toolbox_widget.hpp
+++ b/src/editor/toolbox_widget.hpp
@@ -83,6 +83,9 @@ public:
   bool has_mouse_focus() const;
   bool has_active_object_tip() const { return m_object_tip != nullptr; }
 
+  void show_tile_in_toolbox(uint32_t tile);
+  void show_object_in_toolbox(const std::string& classname);
+
 private:
   Vector get_tile_coords(const int pos) const;
   int get_tile_pos(const Vector& coords) const;


### PR DESCRIPTION
When using the editor, using the middle mouse button to click on a tile or an object (depending on which mode the toolbox is in) will show that object or tile in the toolbox by switching the toolbox to the appropriate category and scrolling to the icon for that object/tile.