### PR TITLE
Add "loop-frame" property for sprite actions

### DIFF
--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -125,7 +125,7 @@ Sprite::update()
 
   while (m_frameidx >= get_frames() && !animation_done()) {
     // Loop animation.
-    m_frameidx -= get_frames() - (m_action->loop_frame > 1 ? m_action->loop_frame - 1 : 0);
+    m_frameidx -= get_frames() - (m_action->loop_frame - 1);
     m_animation_loops--;
   }
 

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -124,7 +124,8 @@ Sprite::update()
   }
 
   while (m_frameidx >= get_frames() && !animation_done()) {
-    m_frameidx -= get_frames();
+    // Loop animation.
+    m_frameidx -= get_frames() - (m_action->loop_frame > 1 ? m_action->loop_frame - 1 : 0);
     m_animation_loops--;
   }
 

--- a/src/sprite/sprite_data.cpp
+++ b/src/sprite/sprite_data.cpp
@@ -36,6 +36,7 @@ SpriteData::Action::Action() :
   hitbox_h(0),
   fps(10),
   loops(-1),
+  loop_frame(1),
   has_custom_loops(false),
   family_name(),
   surfaces()
@@ -92,6 +93,14 @@ SpriteData::parse_action(const ReaderMapping& mapping)
   if (mapping.get("loops", action->loops))
   {
     action->has_custom_loops = true;
+  }
+  if (mapping.get("loop-frame", action->loop_frame))
+  {
+    if (action->loop_frame < 1)
+    {
+      log_warning << "'loop-frame' of action '" << action->name << "' in sprite '" << name << "' set to a value below 1." << std::endl;
+      action->loop_frame = 1;
+    }
   }
 
   if (!mapping.get("family_name", action->family_name))
@@ -211,6 +220,15 @@ SpriteData::parse_action(const ReaderMapping& mapping)
       throw std::runtime_error(msg.str());
     }
   }
+
+  // Reset loop-frame, if it's specified in current action, but not-in-range of total frames.
+  const int frames = static_cast<int>(action->surfaces.size());
+  if (action->loop_frame > frames && frames > 0)
+  {
+    log_warning << "'loop-frame' of action '" << action->name << "' in sprite '" << name << "' not-in-range of total frames." << std::endl;
+    action->loop_frame = 1;
+  }
+
   actions[action->name] = std::move(action);
 }
 

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -61,6 +61,9 @@ private:
     /** Loops (-1 = looping endlessly) */
     int loops;
 
+    /** Starting frame for animation loops */
+    int loop_frame;
+
     /** Flag that gets set to true if the action
         has custom loops defined */
     bool has_custom_loops;


### PR DESCRIPTION
Adds a new `loop-frame` property for sprite actions, which allows a sprite to loop from a specific frame. It accepts values from 1 to the total amount of frames available.

Closes #1109.