### PR TITLE
In-game achievement system

### DIFF
--- a/src/gui/achievement_notification.cpp
+++ b/src/gui/achievement_notification.cpp
@@ -1,0 +1,62 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gui/achievement_notification.hpp"
+
+#include "audio/sound_manager.hpp"
+#include "util/gettext.hpp"
+
+const float AchievementNotification::s_fade_time = 0.5f;
+
+AchievementNotification::AchievementNotification(std::string id) :
+  Notification("achievement_" + id, false, true),
+  m_transition_timer(),
+  m_fading_out(false),
+  m_hide_timer()
+{
+  set_mini_text(_("Achievement completed!")); // Set default mini text.
+
+  m_transition_timer.start(s_fade_time);
+  m_hide_timer.start(5);
+
+  SoundManager::current()->preload("sounds/tada.ogg");
+  SoundManager::current()->play("sounds/tada.ogg");
+}
+
+void
+AchievementNotification::draw(DrawingContext& context)
+{
+  m_pos = Vector(static_cast<float>(context.get_width()) / 2 - std::max(m_text_size.width, m_mini_text_size.width) / 2,
+                 static_cast<float>(context.get_height() / 12) - m_text_size.height - m_mini_text_size.height + 10.0f);
+
+  // Show transition when showing and hiding.
+  const float timeleft = m_transition_timer.get_timeleft();
+  if (timeleft > 0 || m_fading_out)
+    m_pos.y -= m_size.height * (m_fading_out ? s_fade_time - timeleft : timeleft) * 4;
+
+  if (timeleft <= 0 && m_fading_out)
+    close();
+
+  Notification::draw(context);
+
+  if (m_hide_timer.check())
+  {
+    m_fading_out = true;
+    m_transition_timer.start(s_fade_time);
+  }
+}
+
+/* EOF */

--- a/src/gui/achievement_notification.hpp
+++ b/src/gui/achievement_notification.hpp
@@ -1,0 +1,53 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_GUI_ACHIEVEMENT_NOTIFICATION_HPP
+#define HEADER_SUPERTUX_GUI_ACHIEVEMENT_NOTIFICATION_HPP
+
+#include "gui/notification.hpp"
+
+#include "supertux/timer.hpp"
+
+class AchievementNotification final : public Notification
+{
+private:
+  static const float s_fade_time;
+
+private:
+  Timer m_transition_timer;
+  bool m_fading_out;
+
+  Timer m_hide_timer;
+
+public:
+  AchievementNotification(std::string id);
+
+  void draw(DrawingContext& context) override;
+
+protected:
+  // Overridable properties
+  bool persistent() const override { return true; }
+  bool uses_custom_pos() const override { return true; }
+  bool interactable() const override { return false; }
+
+private:
+  AchievementNotification(const AchievementNotification&) = delete;
+  AchievementNotification& operator=(const AchievementNotification&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/gui/horizontal_menu.cpp
+++ b/src/gui/horizontal_menu.cpp
@@ -1,0 +1,298 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gui/horizontal_menu.hpp"
+
+#include "gui/menu_manager.hpp"
+#include "gui/mousecursor.hpp"
+#include "math/util.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/resources.hpp"
+#include "video/drawing_context.hpp"
+#include "video/surface.hpp"
+#include "video/viewport.hpp"
+
+float HorizontalMenu::s_max_width = 0.0f; // Will be initialized later.
+const float HorizontalMenu::s_height = 100.0f;
+
+const float HorizontalMenu::s_width_offset = 20.0f;
+const float HorizontalMenu::s_item_spacing = 30.0f;
+
+const float HorizontalMenu::s_icon_y = 10.0f;
+const float HorizontalMenu::s_text_y = s_height - 30.0f;
+
+HorizontalMenu::HorizontalMenu() :
+  m_items(),
+  m_selected_item(0),
+  m_rect(),
+  m_item_range_begin(0),
+  m_item_range_end(0),
+  m_width(0.0f)
+{
+  s_max_width = static_cast<float>(SCREEN_WIDTH) - s_width_offset * 2;
+}
+
+void
+HorizontalMenu::add_item(std::string text, std::string description,
+                         std::string icon_file, int id)
+{
+  m_items.push_back({ id, text, description, Surface::from_file(icon_file) });
+}
+
+void
+HorizontalMenu::calculate_width(int begin)
+{
+  const float leftover_spacing = std::fabs(10.0f - s_item_spacing);
+
+  const int total = static_cast<int>(m_items.size());
+  int end = total - 1;
+
+  float width = 10.0f;
+  for (int i = begin; i < total; i++)
+  {
+    float item_width = Resources::normal_font->get_text_width(m_items[i].text) + s_item_spacing;
+    width += item_width;
+    if (width > s_max_width)
+    {
+      // Try removing the leftover spacing after the last item.
+      width -= leftover_spacing;
+      item_width -= leftover_spacing;
+
+      if (width > s_max_width) // The width of the item is still bigger.
+      {
+        end = i - 1;
+        width -= item_width - leftover_spacing; // Remove the leftover spacing after the last item.
+      }
+      else // The item can fit.
+      {
+        end = i;
+      }
+      break;
+    }
+  }
+
+  m_item_range_begin = begin;
+  m_item_range_end = end;
+  m_width = width;
+}
+
+void
+HorizontalMenu::draw(DrawingContext& context)
+{
+  if (m_width == 0.0f) calculate_width();
+
+  m_rect = Rectf(Vector(s_width_offset + (s_max_width - m_width) / 2, get_y()), Sizef(m_width, s_height));
+
+  // Draw background rect.
+  context.color().draw_filled_rect(m_rect.grown(12.0f),
+                                     Color(g_config->menubackcolor.red, g_config->menubackcolor.green,
+                                       g_config->menubackcolor.blue, std::max(0.f, g_config->menubackcolor.alpha - 0.5f)),
+                                       g_config->menuroundness + 4.f,
+                                     LAYER_GUI - 10);
+
+  context.color().draw_filled_rect(m_rect.grown(8.0f),
+                                     Color(g_config->menufrontcolor.red, g_config->menufrontcolor.green,
+                                       g_config->menufrontcolor.blue, std::max(0.f, g_config->menufrontcolor.alpha - 0.3f)),
+                                       g_config->menuroundness,
+                                     LAYER_GUI - 10);
+
+  // Draw items.
+  float pos_x = m_rect.get_left() + 20.0f;
+  for (int i = m_item_range_begin; i <= m_item_range_end; i++)
+  {
+    // Draw item separation line.
+    if (i > m_item_range_begin)
+      context.color().draw_line(Vector(pos_x - 20.0f, get_y() - 8.0f),
+                                Vector(pos_x - 20.0f, get_y() + s_height + 8.0f),
+                                Color::WHITE, LAYER_GUI);
+
+    const float text_width = Resources::normal_font->get_text_width(m_items[i].text);
+    draw_item(context, i, pos_x, text_width);
+
+    pos_x += text_width + s_item_spacing;
+  }
+
+  // Draw arrows.
+  if (m_item_range_begin > 0)
+    context.color().draw_text(Resources::big_font, "<",
+                              Vector(m_rect.get_left() + 5.0f, get_y() + s_height / 2.5f),
+                              ALIGN_CENTER, LAYER_GUI);
+  if (m_item_range_end < static_cast<int>(m_items.size()) - 1)
+    context.color().draw_text(Resources::big_font, ">",
+                              Vector(m_rect.get_right() - 5.0f, get_y() + s_height / 2.5f),
+                              ALIGN_CENTER, LAYER_GUI);
+}
+
+void
+HorizontalMenu::draw_item(DrawingContext& context, const int& index,
+                          const float& pos_x, const float& text_width)
+{
+  // Draw icon.
+  context.color().draw_surface_scaled(m_items[index].icon, Rectf(Vector(pos_x + text_width / 2.35f, get_y() + s_icon_y),
+                                                                 Sizef(s_height / 2, s_height / 2)), LAYER_GUI);
+
+  // Draw text.
+  context.color().draw_text(Resources::normal_font, m_items[index].text,
+                            Vector(pos_x, get_y() + s_text_y),
+                            ALIGN_LEFT, LAYER_GUI);
+
+  // Draw selection border, if selected.
+  if (index == m_selected_item)
+  {
+    const float blink = (sinf(g_real_time * math::PI * 1.0f) / 2.0f + 0.5f) * 0.5f + 0.25f;
+
+    const float text_height = Resources::normal_font->get_text_height(m_items[index].text);
+    const Rectf item_rect(Vector(pos_x - 2.0f, get_y() + s_icon_y), Sizef(text_width, s_text_y + text_height));
+
+    context.color().draw_filled_rect(item_rect,
+                                     Color(1.0f, 1.0f, 1.0f, blink),
+                                     std::max(0.f, g_config->menuroundness - 2.f),
+                                     LAYER_GUI - 10);
+    context.color().draw_filled_rect(item_rect.grown(3.0f),
+                                     Color(1.0f, 1.0f, 1.0f, 0.5f),
+                                     std::max(0.f, g_config->menuroundness - 4.f),
+                                     LAYER_GUI - 10);
+
+    // Draw description, if available.
+    if (!m_items[index].description.empty())
+    {
+      const float description_width = Resources::normal_font->get_text_width(m_items[index].description) + 45.0f;
+      const Rectf text_rect(Vector(pos_x + text_width / 2 - description_width / 2, get_y() + s_height * 1.3f),
+                            Sizef(description_width, Resources::normal_font->get_text_height(m_items[index].description) + 6.0f));
+
+      context.color().draw_filled_rect(text_rect.grown(8.0f),
+                                       g_config->menuhelpfrontcolor,
+                                       g_config->menuroundness,
+                                       LAYER_GUI);
+      context.color().draw_filled_rect(text_rect.grown(12.0f),
+                                       g_config->menuhelpbackcolor,
+                                       g_config->menuroundness + 4.f,
+                                       LAYER_GUI);
+
+      context.color().draw_text(Resources::big_font, m_items[index].description,
+                                Vector(text_rect.get_left() + text_rect.get_width() / 2, text_rect.get_top()),
+                                ALIGN_CENTER, LAYER_GUI);
+    }
+  }
+}
+
+void
+HorizontalMenu::event(const SDL_Event& ev)
+{
+  switch (ev.type)
+  {
+    case SDL_KEYDOWN:
+    {
+      switch (ev.key.keysym.sym)
+      {
+        case SDLK_LEFT:
+        {
+          go_left();
+          break;
+        }
+        case SDLK_RIGHT:
+        {
+          go_right();
+          break;
+        }
+        case SDLK_RETURN:
+        {
+          // Execute an action for the specific item.
+          if (interactable()) menu_action(m_items[m_selected_item]);
+          break;
+        }
+      }
+      break;
+    }
+    case SDL_MOUSEBUTTONDOWN:
+    {
+      if (!MenuManager::instance().is_active()) break;
+
+      if (ev.button.button == SDL_BUTTON_LEFT)
+      {
+        const Vector mouse_pos = VideoSystem::current()->get_viewport().to_logical(ev.motion.x, ev.motion.y);
+
+        if (m_rect.contains(mouse_pos))
+        {
+          // Execute an action for the specific item.
+          if (interactable()) menu_action(m_items[m_selected_item]);
+        }
+      }
+      break;
+    }
+    case SDL_MOUSEMOTION:
+    {
+      if (!MenuManager::instance().is_active()) break;
+
+      const Vector mouse_pos = VideoSystem::current()->get_viewport().to_logical(ev.motion.x, ev.motion.y);
+
+      if (m_rect.contains(mouse_pos))
+      {
+        float pos_x = m_rect.get_left() + 20.0f;
+        for (int i = m_item_range_begin; i <= m_item_range_end; i++)
+        {
+          const float text_width = Resources::normal_font->get_text_width(m_items[i].text);
+          const Rectf item_rect(Vector(pos_x - 2.0f, get_y() + s_icon_y),
+                                Sizef(text_width, s_text_y + Resources::normal_font->get_text_height(m_items[i].text)));
+
+          if (item_rect.contains(mouse_pos))
+          {
+            m_selected_item = i;
+            break;
+          }
+
+          pos_x += text_width + s_item_spacing;
+        }
+
+        if (MouseCursor::current() && interactable())
+          MouseCursor::current()->set_state(MouseCursorState::LINK);
+      }
+      else
+      {
+        if (MouseCursor::current())
+          MouseCursor::current()->set_state(MouseCursorState::NORMAL);
+      }
+      break;
+    }
+  }
+}
+
+// Navigation functions
+
+void
+HorizontalMenu::go_left()
+{
+  if (m_selected_item == 0)
+    return;
+
+  m_selected_item--;
+  if (m_selected_item < m_item_range_begin)
+    calculate_width(m_selected_item);
+}
+
+void
+HorizontalMenu::go_right()
+{
+  if (m_selected_item == static_cast<int>(m_items.size()) - 1)
+    return;
+
+  m_selected_item++;
+  if (m_selected_item > m_item_range_end)
+    calculate_width(m_item_range_begin + 1);
+}
+
+/* EOF */

--- a/src/gui/horizontal_menu.hpp
+++ b/src/gui/horizontal_menu.hpp
@@ -1,0 +1,87 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_GUI_HORIZONTAL_MENU_HPP
+#define HEADER_SUPERTUX_GUI_HORIZONTAL_MENU_HPP
+
+#include <vector>
+
+#include "video/drawing_context.hpp"
+#include "video/surface_ptr.hpp"
+
+class HorizontalMenu
+{
+protected:
+  static float s_max_width;
+  static const float s_height;
+
+  static const float s_width_offset;
+  static const float s_item_spacing;
+
+  static const float s_icon_y;
+  static const float s_text_y;
+
+protected:
+  struct Item
+  {
+    const int id;
+    const std::string text;
+    const std::string description;
+    const SurfacePtr icon;
+  };
+
+protected:
+  std::vector<Item> m_items;
+
+  Rectf m_rect;
+
+  int m_selected_item;
+  int m_item_range_begin;
+  int m_item_range_end;
+  float m_width;
+
+public:
+  HorizontalMenu();
+
+  void add_item(std::string text, std::string description,
+                std::string icon_file, int id = -1);
+
+  virtual void draw(DrawingContext& context);
+  virtual void draw_item(DrawingContext& context, const int& index,
+                         const float& pos_x, const float& text_width);
+  virtual void event(const SDL_Event& ev);
+
+  virtual void menu_action(const Item& item) {}
+
+  // Navigation functions
+  void go_left();
+  void go_right();
+
+protected:
+  void calculate_width(int begin = 0);
+
+  // Overridable properties
+  virtual bool interactable() const { return true; } // The user can interact.
+  virtual float get_y() const { return 0.0f; } // Provide the Y position of the menu.
+
+private:
+  HorizontalMenu(const HorizontalMenu&) = delete;
+  HorizontalMenu& operator=(const HorizontalMenu&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/gui/menu_manager.hpp
+++ b/src/gui/menu_manager.hpp
@@ -23,6 +23,7 @@
 class Controller;
 class Dialog;
 class DrawingContext;
+class HorizontalMenu;
 class Menu;
 class MenuTransition;
 class Notification;
@@ -44,6 +45,10 @@ private:
   bool m_has_next_notification;
   std::unique_ptr<Notification> m_next_notification;
 
+  std::unique_ptr<HorizontalMenu> m_horizontal_menu;
+  bool m_has_next_horizontal_menu;
+  std::unique_ptr<HorizontalMenu> m_next_horizontal_menu;
+
   std::vector<std::unique_ptr<Menu> > m_menu_stack;
   std::unique_ptr<MenuTransition> m_transition;
 
@@ -59,6 +64,7 @@ public:
 
   void set_dialog(std::unique_ptr<Dialog> dialog);
   void set_notification(std::unique_ptr<Notification> notification);
+  void set_horizontal_menu(std::unique_ptr<HorizontalMenu> horizontal_menu);
 
   void set_menu(int id);
   void set_menu(std::unique_ptr<Menu> menu);
@@ -70,7 +76,7 @@ public:
   void on_window_resize();
   bool is_active() const
   {
-    return !m_menu_stack.empty();
+    return !m_menu_stack.empty() || m_horizontal_menu;
   }
 
   bool has_dialog() const

--- a/src/gui/notification.hpp
+++ b/src/gui/notification.hpp
@@ -24,10 +24,17 @@
 #include "control/controller.hpp"
 #include "math/sizef.hpp"
 #include "video/drawing_context.hpp"
+#include "video/surface_ptr.hpp"
 
 class Notification
 {
-private:
+protected:
+  static const float s_icon_size;
+
+  static const std::string s_sym1;
+  static const std::string s_sym2;
+
+protected:
   const std::string m_id;
   const bool m_auto_hide;
   const bool m_auto_disable;
@@ -36,6 +43,8 @@ private:
   std::string m_mini_text;
   Sizef m_text_size;
   Sizef m_mini_text_size;
+
+  SurfacePtr m_icon;
 
   Vector m_pos;
   Sizef m_size;
@@ -55,23 +64,27 @@ public:
 
   void set_text(const std::string& text);
   void set_mini_text(const std::string& text);
+  void set_icon(const std::string& file);
   void on_press(const std::function<void ()>& callback) { m_callback = callback; }
 
-  void event(const SDL_Event& event);
-  void process_input(const Controller& controller);
-  void draw(DrawingContext& context);
+  virtual void event(const SDL_Event& event);
+  virtual void process_input(const Controller& controller);
+  virtual void draw(DrawingContext& context);
 
   // Notification actions
-
   void disable();
   void close();
 
-  // Static functions, serving as utilities
-
+  // Static utilities
   static bool is_disabled(std::string id);
 
-private:
-  void calculate_size();
+protected:
+  virtual void calculate_size();
+
+  // Overridable properties
+  virtual bool persistent() const { return false; } // Should always be visible.
+  virtual bool uses_custom_pos() const { return false; } // Uses custom position.
+  virtual bool interactable() const { return true; } // The user can interact.
 
 private:
   Notification(const Notification&) = delete;

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -22,6 +22,7 @@
 #include "object/bouncy_coin.hpp"
 #include "object/player.hpp"
 #include "object/tilemap.hpp"
+#include "supertux/achievement_system.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/level.hpp"
 #include "supertux/sector.hpp"
@@ -189,6 +190,9 @@ Coin::collect()
   Sector::get().add<BouncyCoin>(get_pos(), false, get_sprite_name());
   Sector::get().get_level().m_stats.increment_coins();
   remove_me();
+
+  AchievementSystem::current()->update("10coins", 1);
+  AchievementSystem::current()->update("20coins", 1);
 
   if (!m_collect_script.empty()) {
     Sector::get().run_script(m_collect_script, "collect-script");

--- a/src/supertux/achievement.hpp
+++ b/src/supertux/achievement.hpp
@@ -1,0 +1,55 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_HPP
+#define HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_HPP
+
+#include <string>
+
+enum AchievementType
+{
+  ACHIEVEMENT_INSTANT, // The achievement is applied instantly.
+  ACHIEVEMENT_LEVEL // The achievement is queued to be applied on level finish.
+};
+
+struct Achievement
+{
+  Achievement(std::string id_, std::string name_, std::string desc_,
+              std::string icon_, AchievementType type_, float goal_) :
+    id(id_),
+    name(name_),
+    description(desc_),
+    icon(icon_),
+    type(type_),
+    goal(goal_),
+    progress(0.0f),
+    completed(false)
+  {}
+
+  const std::string id;
+  const std::string name;
+  const std::string description;
+  const std::string icon;
+  const AchievementType type;
+  const float goal;
+
+  float progress;
+  bool completed; // Has indicated its completion to the user.
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/achievement_data.cpp
+++ b/src/supertux/achievement_data.cpp
@@ -1,0 +1,165 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/achievement_data.hpp"
+
+#include <physfs.h>
+
+#include "physfs/util.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "util/file_system.hpp"
+#include "util/log.hpp"
+#include "util/reader_collection.hpp"
+#include "util/reader_document.hpp"
+#include "util/reader_mapping.hpp"
+#include "util/writer.hpp"
+
+void
+AchievementData::load(std::vector<Achievement>& data)
+{
+  if (!apply(data)) // When reading data fails, only clear the current data.
+    clear(data);
+}
+
+bool
+AchievementData::apply(std::vector<Achievement>& data)
+{
+  // Load file according to profile.
+  const std::string file = FileSystem::join("profile" + std::to_string(g_config->profile), "achievements.stad");
+
+  if (!PHYSFS_exists(file.c_str()))
+  {
+    log_info << file << " achievement data for profile " << g_config->profile << " doesn't exist, not loading." << std::endl;
+    return false;
+  }
+  if (physfsutil::is_directory(file))
+  {
+    log_info << file << " is a directory, not loading." << std::endl;
+    return false;
+  }
+
+  auto doc = ReaderDocument::from_file(file);
+  auto root = doc.get_root();
+
+  if (root.get_name() != "supertux-achievements")
+  {
+    log_warning << "File is not a supertux-achievements file." << std::endl;
+    return false;
+  }
+
+  log_debug << "Loading achievement data from " << file << std::endl;
+
+  auto mapping = root.get_mapping();
+
+  boost::optional<ReaderCollection> achievements_mapping;
+  if (mapping.get("achievements", achievements_mapping))
+  {
+    for (const auto& achievement_node : achievements_mapping->get_objects())
+    {
+      if (achievement_node.get_name() == "achievement")
+      {
+        auto achievement_mapping = achievement_node.get_mapping();
+
+        std::string id;
+        float progress = 0.0f;
+        bool completed = false;
+        if (achievement_mapping.get("id", id) &&
+            achievement_mapping.get("progress", progress) &&
+            achievement_mapping.get("completed", completed))
+        {
+          // Set the progress to an existing achievement.
+          for (auto& achievement : data)
+          {
+            if (achievement.id == id)
+            {
+              achievement.progress = progress;
+              achievement.completed = completed;
+            }
+          }
+        }
+      }
+      else
+      {
+        log_warning << "Unknown token in achievement data file: " << achievement_node.get_name() << std::endl;
+      }
+    }
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void
+AchievementData::save(const std::vector<Achievement>& data, int profile)
+{
+  // Save to file according to profile.
+  const std::string file = FileSystem::join("profile" + std::to_string(profile < 0 ? g_config->profile : profile), "achievements.stad");
+
+  log_debug << "Saving achievement data to " << file << std::endl;
+
+  // Make sure the file directory exists.
+  std::string directory = FileSystem::dirname(file);
+  if (!PHYSFS_exists(directory.c_str()))
+  {
+    if (!PHYSFS_mkdir(directory.c_str()))
+    {
+      std::ostringstream msg;
+      msg << "Couldn't create directory for achievement data '"
+          << directory << "': " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+      throw std::runtime_error(msg.str());
+    }
+  }
+  if (!physfsutil::is_directory(directory))
+  {
+    std::ostringstream msg;
+    msg << "Achievement data path '" << directory << "' is not a directory.";
+    throw std::runtime_error(msg.str());
+  }
+
+  Writer writer(file);
+
+  writer.start_list("supertux-achievements");
+  writer.write("version", 1);
+
+  writer.start_list("achievements");
+  for (const auto& achievement : data)
+  {
+    writer.start_list("achievement");
+    writer.write("id", achievement.id);
+    writer.write("progress", achievement.progress);
+    writer.write("completed", achievement.completed);
+    writer.end_list("achievement");
+  }
+  writer.end_list("achievements");
+
+  writer.end_list("supertux-achievements");
+}
+
+void
+AchievementData::clear(std::vector<Achievement>& data)
+{
+  for (auto& achievement : data)
+  {
+    achievement.progress = 0.0f;
+    achievement.completed = false;
+  }
+}
+
+/* EOF */

--- a/src/supertux/achievement_data.cpp
+++ b/src/supertux/achievement_data.cpp
@@ -110,7 +110,8 @@ void
 AchievementData::save(const std::vector<Achievement>& data, int profile)
 {
   // Save to file according to profile.
-  const std::string file = FileSystem::join("profile" + std::to_string(profile < 0 ? g_config->profile : profile), "achievements.stad");
+  profile = profile < 0 ? g_config->profile : profile;
+  const std::string file = FileSystem::join("profile" + std::to_string(profile), "achievements.stad");
 
   log_debug << "Saving achievement data to " << file << std::endl;
 
@@ -118,13 +119,8 @@ AchievementData::save(const std::vector<Achievement>& data, int profile)
   std::string directory = FileSystem::dirname(file);
   if (!PHYSFS_exists(directory.c_str()))
   {
-    if (!PHYSFS_mkdir(directory.c_str()))
-    {
-      std::ostringstream msg;
-      msg << "Couldn't create directory for achievement data '"
-          << directory << "': " << PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
-      throw std::runtime_error(msg.str());
-    }
+    log_warning << "Directory for profile " << profile << " doesn't exist, skipping achievement data save." << std::endl;
+    return;
   }
   if (!physfsutil::is_directory(directory))
   {

--- a/src/supertux/achievement_data.hpp
+++ b/src/supertux/achievement_data.hpp
@@ -1,6 +1,5 @@
 //  SuperTux
-//  Copyright (C) 2008 Ingo Ruhnke <grumbel@gmail.com>
-//                2022 Vankata453
+//  Copyright (C) 2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -15,33 +14,26 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_PROFILE_MENU_HPP
-#define HEADER_SUPERTUX_SUPERTUX_MENU_PROFILE_MENU_HPP
+#ifndef HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_DATA_HPP
+#define HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_DATA_HPP
 
-#include "gui/menu.hpp"
+#include <vector>
 
-class ProfileMenu final : public Menu
+#include "supertux/achievement.hpp"
+
+/** Parses achievement data from a file. */
+class AchievementData
 {
-private:
-  std::vector<int> m_profiles;
-  std::vector<std::string> m_profile_names;
+public:
+  static void load(std::vector<Achievement>& data);
 
-  const int m_initial_profile;
+private:
+  static bool apply(std::vector<Achievement>& data);
 
 public:
-  ProfileMenu();
-  ~ProfileMenu();
-
-  void refresh() override;
-  void rebuild_menu();
-  void menu_action(MenuItem& item) override;
+  static void save(const std::vector<Achievement>& data, int profile = -1);
+  static void clear(std::vector<Achievement>& data);
 };
-
-namespace savegames_util
-{
-  std::vector<int> get_savegames();
-  void delete_savegames(int idx, bool reset = false);
-}
 
 #endif
 

--- a/src/supertux/achievement_system.cpp
+++ b/src/supertux/achievement_system.cpp
@@ -45,6 +45,12 @@ AchievementSystem::reload(int profile)
   AchievementData::load(m_achievements); // Load achievement progress from current profile.
 }
 
+void
+AchievementSystem::reset_progress()
+{
+  AchievementData::clear(m_achievements);
+}
+
 
 void
 AchievementSystem::show_achievements()

--- a/src/supertux/achievement_system.cpp
+++ b/src/supertux/achievement_system.cpp
@@ -1,0 +1,191 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/achievement_system.hpp"
+
+#include "gui/achievement_notification.hpp"
+#include "gui/menu_manager.hpp"
+#include "supertux/menu/achievements_menu.hpp"
+#include "util/gettext.hpp"
+
+AchievementSystem::AchievementSystem() :
+  m_achievements(),
+  m_level_progress()
+{
+  // Initialize all achievements.
+  m_achievements.push_back({ "10coins", _("Collect 10 coins in a level"), _("Collect 10 coins in a level."), "images/objects/coin/coin-0.png", ACHIEVEMENT_LEVEL, 10 });
+  m_achievements.push_back({ "20coins", _("Collect 20 coins"), _("Collect 20 coins."), "images/objects/coin/coin-0.png", ACHIEVEMENT_INSTANT, 20 });
+
+  AchievementData::load(m_achievements); // Load achievement progress from current profile.
+}
+
+AchievementSystem::~AchievementSystem()
+{
+  AchievementData::save(m_achievements); // Save achievement progress.
+}
+
+void
+AchievementSystem::reload(int profile)
+{
+  AchievementData::save(m_achievements, profile); // Save achievement progress to old profile.
+  clear_level_progress();
+  AchievementData::load(m_achievements); // Load achievement progress from current profile.
+}
+
+
+void
+AchievementSystem::show_achievements()
+{
+  MenuManager::instance().set_horizontal_menu(std::make_unique<AchievementsMenu>(m_achievements));
+}
+
+
+const Achievement&
+AchievementSystem::get(const std::string& id) const
+{
+  for (const auto& achievement : m_achievements)
+    if (achievement.id == id)
+      return achievement;
+
+  throw std::runtime_error("Achievement with ID '" + id + "' not found.");
+}
+
+Achievement&
+AchievementSystem::get_write(const std::string& id)
+{
+  for (auto& achievement : m_achievements)
+    if (achievement.id == id)
+      return achievement;
+
+  throw std::runtime_error("Achievement with ID '" + id + "' not found.");
+}
+
+void
+AchievementSystem::update(std::string id, float new_progress)
+{
+  Achievement& achievement = get_write(id);
+
+  if (achievement.progress >= achievement.goal) return;
+
+  switch (achievement.type)
+  {
+    case ACHIEVEMENT_INSTANT:
+    {
+      achievement.progress += new_progress;
+      check_progress();
+      break;
+    }
+    case ACHIEVEMENT_LEVEL:
+    {
+      if (m_level_progress.find(id) != m_level_progress.end())
+      {
+        if (achievement.progress + m_level_progress[id] < achievement.goal)
+        {
+          m_level_progress[id] += new_progress;
+        }
+      }
+      else
+      {
+        m_level_progress.insert({ id, new_progress });
+      }
+      break;
+    }
+  }
+}
+
+
+void
+AchievementSystem::clear_level_progress()
+{
+  m_level_progress.clear();
+}
+
+void
+AchievementSystem::merge_progress()
+{
+  // Merge all temporary level progress into the permanent progress.
+  for (auto& progress : m_level_progress)
+    get_write(progress.first).progress += progress.second;
+
+  m_level_progress.clear();
+  check_progress();
+}
+
+void
+AchievementSystem::check_progress()
+{
+  // Check achievement progress. Execute actions on achievement unlock.
+  for (auto& achievement : m_achievements)
+    if (achievement.progress >= achievement.goal)
+      unlock_achievement(achievement.id); // Unlock the achievement.
+}
+
+
+float
+AchievementSystem::get_progress(const std::string& id) const
+{
+  try
+  {
+    return get(id).progress;
+  }
+  catch (...)
+  {
+    return 0.0f;
+  }
+}
+
+int
+AchievementSystem::calculate_progress_percentage(const std::string& id) const
+{
+  try
+  {
+    const Achievement& achievement = get(id);
+
+    float progress = achievement.progress;
+    if (m_level_progress.find(id) != m_level_progress.end())
+      progress += m_level_progress.at(id); // Append temporary level progress.
+
+    if (progress > 100) // Just in case, make sure value is always maximum 100.
+      progress = 100;
+
+    return progress / achievement.goal * 100;
+  }
+  catch (...)
+  {
+    return 0;
+  }
+}
+
+
+void
+AchievementSystem::unlock_achievement(const std::string& id)
+{
+  Achievement& achievement = get_write(id);
+
+  if (achievement.completed)
+    return; // If the current achievement has alredy been completed before.
+
+  achievement.completed = true;
+
+  // Show a notification to indicate the unlocked achievement.
+  auto notif = std::make_unique<AchievementNotification>(id);
+  notif->set_text(achievement.name);
+  notif->set_icon(achievement.icon);
+
+  MenuManager::instance().set_notification(std::move(notif));
+}
+
+/* EOF */

--- a/src/supertux/achievement_system.hpp
+++ b/src/supertux/achievement_system.hpp
@@ -1,0 +1,66 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_SYSTEM_HPP
+#define HEADER_SUPERTUX_SUPERTUX_ACHIEVEMENT_SYSTEM_HPP
+
+#include "util/currenton.hpp"
+
+#include <map>
+
+#include "supertux/achievement_data.hpp"
+#include "video/drawing_context.hpp"
+
+/** System to track and manage achievements, according to their type. */
+class AchievementSystem final : public Currenton<AchievementSystem>
+{
+private:
+  std::vector<Achievement> m_achievements;
+
+  // Temporarily stored progress in the current level.
+  std::map<std::string, float> m_level_progress;
+
+public:
+  AchievementSystem();
+  ~AchievementSystem();
+
+  void reload(int profile = -1);
+
+  void show_achievements();
+
+  const Achievement& get(const std::string& id) const;
+  void update(std::string id, float new_progress);
+
+  void clear_level_progress();
+  void merge_progress();
+  void check_progress();
+
+  float get_progress(const std::string& id) const;
+  int calculate_progress_percentage(const std::string& id) const;
+
+private:
+  Achievement& get_write(const std::string& id);
+
+  void unlock_achievement(const std::string& id);
+
+private:
+  AchievementSystem(const AchievementSystem&) = delete;
+  AchievementSystem& operator=(const AchievementSystem&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/achievement_system.hpp
+++ b/src/supertux/achievement_system.hpp
@@ -38,6 +38,7 @@ public:
   ~AchievementSystem();
 
   void reload(int profile = -1);
+  void reset_progress();
 
   void show_achievements();
 

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -30,6 +30,7 @@
 #include "object/music_object.hpp"
 #include "object/player.hpp"
 #include "sdk/integration.hpp"
+#include "supertux/achievement_system.hpp"
 #include "supertux/fadetoblack.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/level.hpp"
@@ -148,6 +149,7 @@ GameSession::restart_level(bool after_death)
   m_endsequence_timer.stop();
 
   InputManager::current()->reset();
+  AchievementSystem::current()->clear_level_progress();
 
   m_currentsector = nullptr;
 
@@ -287,6 +289,8 @@ GameSession::abort_level()
     {
     }
   }
+
+  AchievementSystem::current()->clear_level_progress();
 
   PlayerStatus& currentStatus = m_savegame.get_player_status();
   currentStatus.coins = m_coins_at_start;
@@ -759,6 +763,8 @@ GameSession::start_sequence(Player* caller, Sequence seq, const SequenceData* da
     p->set_controller(m_end_sequence->get_controller(p->get_id()));
     p->set_speedlimit(230); // MAX_WALK_XM
   }
+
+  AchievementSystem::current()->merge_progress();
 
   // Stop all clocks.
   for (const auto& obj : m_currentsector->get_objects())

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -519,6 +519,7 @@ Main::launch_game(const CommandLineArguments& args)
 
   m_game_manager.reset(new GameManager());
   m_screen_manager.reset(new ScreenManager(*m_video_system, *m_input_manager));
+  m_achievement_system.reset(new AchievementSystem());
 
   if (!args.filenames.empty())
   {

--- a/src/supertux/main.hpp
+++ b/src/supertux/main.hpp
@@ -26,6 +26,7 @@
 #include "sprite/sprite_data.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "squirrel/squirrel_virtual_machine.hpp"
+#include "supertux/achievement_system.hpp"
 #include "supertux/command_line_arguments.hpp"
 #include "supertux/console.hpp"
 #include "supertux/game_manager.hpp"
@@ -107,6 +108,7 @@ private:
   std::unique_ptr<GameManager> m_game_manager;
   std::unique_ptr<ScreenManager> m_screen_manager;
   std::unique_ptr<Savegame> m_savegame;
+  std::unique_ptr<AchievementSystem> m_achievement_system;
 
   Downloader m_downloader; // Used for getting the version of the latest SuperTux release.
 

--- a/src/supertux/menu/achievements_menu.cpp
+++ b/src/supertux/menu/achievements_menu.cpp
@@ -1,0 +1,53 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/menu/achievements_menu.hpp"
+
+#include "supertux/achievement.hpp"
+#include "supertux/achievement_system.hpp"
+#include "supertux/resources.hpp"
+#include "video/color.hpp"
+#include "video/surface.hpp"
+
+AchievementsMenu::AchievementsMenu(const std::vector<Achievement>& achievements) :
+  m_achievement_progressions(),
+  m_completable_achievements()
+{
+  const AchievementSystem* system = AchievementSystem::current();
+
+  for (const auto& achievement : achievements)
+  {
+    add_item(achievement.name, achievement.description, achievement.icon);
+
+    m_achievement_progressions.push_back(system->calculate_progress_percentage(achievement.id));
+    m_completable_achievements.push_back({ achievement.completed });
+  }
+}
+
+void
+AchievementsMenu::draw_item(DrawingContext& context, const int& index,
+                            const float& pos_x, const float& text_width)
+{
+  HorizontalMenu::draw_item(context, index, pos_x, text_width);
+
+  // Draw progress percentage.
+  context.color().draw_text(Resources::normal_font, std::to_string(m_achievement_progressions[index]) + "%",
+                            Vector(pos_x + text_width / 2.5f + s_height / 2,
+                                   get_y() + s_icon_y + s_height / 2.8f),
+                            ALIGN_CENTER, LAYER_GUI, m_completable_achievements[index].completed ? Color::GREEN : Color::YELLOW);
+}
+
+/* EOF */

--- a/src/supertux/menu/achievements_menu.hpp
+++ b/src/supertux/menu/achievements_menu.hpp
@@ -1,0 +1,53 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_ACHIEVEMENTS_MENU_HPP
+#define HEADER_SUPERTUX_SUPERTUX_MENU_ACHIEVEMENTS_MENU_HPP
+
+#include "gui/horizontal_menu.hpp"
+
+class Achievement;
+
+class AchievementsMenu final : public HorizontalMenu
+{
+private:
+  struct CompletableAchievement
+  {
+    const bool completed;
+  };
+
+private:
+  std::vector<int> m_achievement_progressions;
+  std::vector<CompletableAchievement> m_completable_achievements;
+
+public:
+  AchievementsMenu(const std::vector<Achievement>& achievements);
+
+  void draw_item(DrawingContext& context, const int& index,
+                 const float& pos_x, const float& text_width) override;
+
+private:
+  // Overridable properties
+  bool interactable() const override { return false; }
+
+private:
+  AchievementsMenu(const AchievementsMenu&) = delete;
+  AchievementsMenu& operator=(const AchievementsMenu&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -24,6 +24,7 @@
 #include "gui/dialog.hpp"
 #include "gui/menu_manager.hpp"
 #include "gui/menu_item.hpp"
+#include "supertux/achievement_system.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/menu/profile_name_menu.hpp"
@@ -33,9 +34,19 @@
 
 ProfileMenu::ProfileMenu() :
   m_profiles(),
-  m_profile_names()
+  m_profile_names(),
+  m_initial_profile(g_config->profile)
 {
   refresh();
+}
+
+ProfileMenu::~ProfileMenu()
+{
+  if (g_config->profile != m_initial_profile)
+  {
+    // Perform actions on profile change.
+    AchievementSystem::current()->reload(m_initial_profile);
+  }
 }
 
 void

--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -256,6 +256,9 @@ namespace savegames_util {
       PHYSFS_delete(filepath.c_str());
     }
     if (!reset) PHYSFS_delete(profile_path.c_str());
+
+    // Perform actions on profile reset or deletion.
+    AchievementSystem::current()->reset_progress();
   }
 } // namespace savegames_util
 

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -27,6 +27,7 @@
 #include "object/player.hpp"
 #include "sdk/integration.hpp"
 #include "squirrel/squirrel_virtual_machine.hpp"
+#include "supertux/achievement_system.hpp"
 #include "supertux/console.hpp"
 #include "supertux/constants.hpp"
 #include "supertux/controller_hud.hpp"
@@ -477,6 +478,12 @@ ScreenManager::process_events()
         {
           g_config->developer_mode = !g_config->developer_mode;
           log_info << "developer mode: " << g_config->developer_mode << std::endl;
+        }
+        else if (event.key.keysym.sym == SDLK_F6 &&
+                (!GameSession::current() || !GameSession::current()->is_active()) &&
+                !Editor::is_active())
+        {
+          AchievementSystem::current()->show_achievements();
         }
         break;
 


### PR DESCRIPTION
In-game achievement system, which manages global and level achievements. Current level achievement progression is only counted towards the global one when the current level is completed. Achievement data is saved as `achievements.stad` in any profile folder. Currently, all achievements have to be hardcoded and are global for the game. World-specific custom achievements, which can be progressed through using scripting, are a potential idea for the future.

Included with this PR are also horizontal menus (currently only used for displaying achievements) and achievement notifications, which are a slightly-modified version of the regular ones and have transitions on showing and hiding, as well as display in the top-center part of the screen.

![image](https://user-images.githubusercontent.com/78196474/205450807-56cd37e6-41b9-4a45-88c7-d4402b99a142.png)
![image](https://user-images.githubusercontent.com/78196474/205450877-18ff5a0d-dd1b-4c61-8d93-6023e1dc71ac.png)

Achievements are initialized in `achievement_system.cpp`, in the initializer. Currently, 2 sample coin achievements (one level-specific and one global) are available, only for demonstration purposes.

**Note:**
Keep in mind the changes in `coin.cpp` are temporary and are used to accompany the included sample achievements.