### PR TITLE
Display world screenshot previews and progress

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -675,6 +675,8 @@ Menu::draw(DrawingContext& context)
                               Vector(m_pos.x, static_cast<float>(SCREEN_HEIGHT) - 48.0f - static_cast<float>(text_height) / 2.0f),
                               ALIGN_CENTER, LAYER_GUI);
   }
+
+  draw_additional(context);
 }
 
 MenuItem&

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -144,6 +144,7 @@ private:
   void process_action(const MenuAction& menuaction);
   void check_controlfield_change_event(const SDL_Event& event);
   void draw_item(DrawingContext& context, int index, float y_pos);
+  virtual void draw_additional(DrawingContext& context) {}
 
 private:
   /** position of the menu (ie. center of the menu, not top/left) */

--- a/src/gui/menu_manager.cpp
+++ b/src/gui/menu_manager.cpp
@@ -361,10 +361,11 @@ MenuManager::set_menu(std::unique_ptr<Menu> menu)
 }
 
 void
-MenuManager::clear_menu_stack()
+MenuManager::clear_menu_stack(bool skip_transition)
 {
-  transition(m_menu_stack.empty() ? nullptr : m_menu_stack.back().get(),
-             nullptr, true);
+  if (!skip_transition)
+    transition(m_menu_stack.empty() ? nullptr : m_menu_stack.back().get(),
+               nullptr, true);
   m_menu_stack.clear();
 }
 

--- a/src/gui/menu_manager.hpp
+++ b/src/gui/menu_manager.hpp
@@ -65,7 +65,7 @@ public:
   void push_menu(int id, bool skip_transition = false);
   void push_menu(std::unique_ptr<Menu> menu, bool skip_transition = false);
   void pop_menu(bool skip_transition = false);
-  void clear_menu_stack();
+  void clear_menu_stack(bool skip_transition = false);
 
   void on_window_resize();
   bool is_active() const

--- a/src/supertux/menu/sorted_contrib_menu.hpp
+++ b/src/supertux/menu/sorted_contrib_menu.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2021 mrkubax10 <mrkubax10@onet.pl>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -16,18 +17,20 @@
 
 #ifndef HEADER_SUPERTUX_SUPERTUX_MENU_SORTED_CONTRIB_MENU_HPP
 #define HEADER_SUPERTUX_SUPERTUX_MENU_SORTED_CONTRIB_MENU_HPP
-#include "gui/menu.hpp"
-#include "supertux/world.hpp"
-class SortedContribMenu : public Menu
+
+#include "supertux/menu/world_preview_menu.hpp"
+
+class SortedContribMenu final : public WorldPreviewMenu
 {
 public:
-  SortedContribMenu(std::vector<std::unique_ptr<World>>& worlds, const std::string& contrib_type, const std::string& title, const std::string& empty_message);
-  void menu_action(MenuItem& item) override;
-private:
-  std::vector<std::string> m_world_folders;
+  SortedContribMenu(std::vector<std::unique_ptr<World>>& worlds, const std::string& contrib_type,
+                    const std::string& title, const std::string& empty_message);
+
 private:
   SortedContribMenu(const SortedContribMenu&) = delete;
   SortedContribMenu& operator=(const SortedContribMenu&) = delete;
 };
+
 #endif
+
 /* EOF */

--- a/src/supertux/menu/world_preview_menu.cpp
+++ b/src/supertux/menu/world_preview_menu.cpp
@@ -1,0 +1,164 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/menu/world_preview_menu.hpp"
+
+#include <physfs.h>
+
+#include "gui/menu_manager.hpp"
+#include "gui/menu_item.hpp"
+#include "supertux/game_manager.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/resources.hpp"
+#include "supertux/menu/contrib_levelset_menu.hpp"
+#include "util/file_system.hpp"
+#include "util/gettext.hpp"
+#include "video/drawing_context.hpp"
+#include "video/surface.hpp"
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
+
+const Sizef WorldPreviewMenu::s_preview_size(426.f, 240.f);
+const float WorldPreviewMenu::s_preview_fade_time = 0.1f;
+
+WorldPreviewMenu::WorldPreviewMenu(float center_x_offset, float center_y_offset) :
+  m_world_entries(),
+  m_last_world_index(-1),
+  m_preview_fade_timer(),
+  m_preview_fade_active(false),
+  m_preview_fading_out(false)
+{
+  // Adjust center position to give space for displaying previews.
+  set_center_pos(static_cast<float>(SCREEN_WIDTH) / center_x_offset,
+                 static_cast<float>(SCREEN_HEIGHT) / center_y_offset);
+
+  m_preview_fade_timer.start(s_preview_fade_time);
+}
+
+SurfacePtr
+WorldPreviewMenu::find_preview(const std::string& preview_file, const std::string& basedir)
+{
+  std::string preview_path = FileSystem::join("profile" + std::to_string(g_config->profile), preview_file);
+  if (PHYSFS_exists(preview_path.c_str())) // A preview exists.
+  {
+    return Surface::from_file(preview_path);
+  }
+  else // Preview doesn't exist, so check for a placeholder.
+  {
+    preview_path = FileSystem::join(basedir, "preview.png");
+    if (PHYSFS_exists(preview_path.c_str())) // A preview placeholder exists.
+      return Surface::from_file(preview_path);
+  }
+
+  return nullptr;
+}
+
+void
+WorldPreviewMenu::draw_additional(DrawingContext& context)
+{
+  const int index = get_active_item_id();
+  bool valid_last_index = is_valid_index();
+
+  // Update fade.
+  if (index != m_last_world_index && !m_preview_fade_active) // Index has changed, there is no current fade.
+  {
+    if (valid_last_index) // Fade out only if the last index is valid.
+      m_preview_fade_timer.start(s_preview_fade_time);
+    m_preview_fading_out = true;
+    m_preview_fade_active = true;
+  }
+  float timeleft = m_preview_fade_timer.get_timeleft();
+  if (timeleft < 0 && m_preview_fade_active) // Current fade is over.
+  {
+    m_last_world_index = index;
+    valid_last_index = is_valid_index(); // Repeat valid last index check
+    if (m_preview_fading_out) // After a fade-out, a fade-in should follow up.
+    {
+      m_preview_fade_timer.start(s_preview_fade_time);
+      timeleft = m_preview_fade_timer.get_timeleft();
+      m_preview_fading_out = false;
+    }
+    else
+    {
+      m_preview_fade_active = false;
+    }
+  }
+
+  // Set alpha according to fade.
+  float alpha = 1.f;
+  if (timeleft > 0)
+  {
+    const float alpha_val = timeleft * (1.f / s_preview_fade_time);
+    alpha = m_preview_fading_out ? alpha_val : 1.f - alpha_val;
+  }
+  const Color color_white(1, 1, 1, alpha);
+
+  // Perform actions only if current index is a valid world index.
+  if (valid_last_index)
+  {
+    // Draw progress preview of current world.
+    Rectf preview_rect(Vector(context.get_width() * 0.73f - s_preview_size.width / 2,
+                            context.get_height() / 2 - s_preview_size.height / 2), s_preview_size);
+    if (m_world_entries[m_last_world_index].preview)
+    {
+      PaintStyle style;
+      style.set_alpha(alpha);
+      context.color().draw_surface_scaled(m_world_entries[m_last_world_index].preview, preview_rect, LAYER_GUI, style);
+    }
+    else // If preview is not available, draw a filled rect with text in its place.
+    {
+      context.color().draw_filled_rect(preview_rect, Color(0, 0, 0, alpha), LAYER_GUI);
+      context.color().draw_text(Resources::normal_font, _("No preview available."),
+                                preview_rect.get_middle(), ALIGN_CENTER, LAYER_GUI, color_white);
+    }
+
+    // Draw world progress.
+    const Savegame::Progress& progress = m_world_entries[m_last_world_index].progress;
+    if (progress.progress > -2) // Progress should be drawn.
+      context.color().draw_text(Resources::normal_font,
+                                progress.progress > -1 ? std::to_string(progress.progress) + "/" + std::to_string(progress.total) : _("*NEW*"),
+                                Vector(preview_rect.get_left() + s_preview_size.width / 2, preview_rect.get_bottom() * 1.05f),
+                                ALIGN_CENTER, LAYER_GUI, color_white);
+  }
+}
+
+bool
+WorldPreviewMenu::is_valid_index() const
+{
+  return m_last_world_index >= 0 && m_last_world_index < static_cast<int>(m_world_entries.size()) &&
+         m_world_entries[m_last_world_index].is_worldmap;
+}
+
+void
+WorldPreviewMenu::menu_action(MenuItem& item)
+{
+  int index = item.get_id();
+  if (index >= 0)
+  {
+    std::unique_ptr<World> world = World::from_directory(m_world_entries[index].folder);
+    if (world->is_levelset())
+    {
+      MenuManager::instance().push_menu(std::unique_ptr<Menu>(new ContribLevelsetMenu(std::move(world))));
+    }
+    else
+    {
+      GameManager::current()->start_worldmap(*world);
+    }
+  }
+}
+
+/* EOF */

--- a/src/supertux/menu/world_preview_menu.hpp
+++ b/src/supertux/menu/world_preview_menu.hpp
@@ -1,0 +1,71 @@
+//  SuperTux
+//  Copyright (C) 2022 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_MENU_WORLD_PREVIEW_MENU_HPP
+#define HEADER_SUPERTUX_SUPERTUX_MENU_WORLD_PREVIEW_MENU_HPP
+
+#include "gui/menu.hpp"
+
+#include "math/sizef.hpp"
+#include "supertux/savegame.hpp"
+#include "supertux/timer.hpp"
+#include "supertux/world.hpp"
+#include "video/surface_ptr.hpp"
+
+/* Represents a menu that should show world preview screenshots and progress. */
+class WorldPreviewMenu : public Menu
+{
+protected:
+  static const Sizef s_preview_size;
+  static const float s_preview_fade_time;
+
+public:
+  WorldPreviewMenu(float center_x_offset = 1, float center_y_offset = 1);
+
+  void menu_action(MenuItem& item) override;
+
+protected:
+  SurfacePtr find_preview(const std::string& preview_file, const std::string& basedir);
+
+  void draw_additional(DrawingContext& context) override;
+
+  bool is_valid_index() const;
+
+protected:
+  struct WorldEntry
+  {
+    const bool is_worldmap;
+    const std::string folder;
+    const SurfacePtr preview;
+    const Savegame::Progress progress;
+  };
+
+protected:
+  std::vector<WorldEntry> m_world_entries;
+
+  int m_last_world_index;
+  Timer m_preview_fade_timer;
+  bool m_preview_fade_active;
+  bool m_preview_fading_out;
+
+private:
+  WorldPreviewMenu(const WorldPreviewMenu&) = delete;
+  WorldPreviewMenu& operator=(const WorldPreviewMenu&) = delete;
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/menu/world_set_menu.cpp
+++ b/src/supertux/menu/world_set_menu.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Matthew <thebatmankiller3@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -18,35 +19,37 @@
 
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
-#include "supertux/game_manager.hpp"
 #include "supertux/menu/menu_storage.hpp"
-#include "supertux/world.hpp"
 #include "util/gettext.hpp"
 
-WorldSetMenu::WorldSetMenu()
+WorldSetMenu::WorldSetMenu() :
+  WorldPreviewMenu(2.5f, 2)
 {
-   add_label(_("Start Game"));
-   add_hl();
-   add_entry(WORLDSET_STORY, _("Story Mode"));
-   add_entry(WORLDSET_CONTRIB, _("Contrib Levels"));
-   add_hl();
-   add_back(_("Back"));
+  add_label(_("Start Game"));
+  add_hl();
+  add_entry(0, _("Story Mode"));
+  add_entry(1, _("Contrib Levels"));
+  add_hl();
+  add_back(_("Back"));
+
+  // Add Story Mode entry.
+  const std::string preview_file = "previews/world1.png";
+  const std::string basedir = "levels/world1";
+  m_world_entries.push_back({ true, "levels/world1", find_preview(preview_file, basedir), { -2, -2 } });
 }
 
-void WorldSetMenu::menu_action(MenuItem& item)
+void
+WorldSetMenu::menu_action(MenuItem& item)
 {
   switch (item.get_id())
   {
-    case WORLDSET_STORY:
-    {
-      std::unique_ptr<World> world = World::from_directory("levels/world1");
-      GameManager::current()->start_worldmap(*world);
-      break;
-    }
-
-    case WORLDSET_CONTRIB:
+    case 1:
 	    MenuManager::instance().push_menu(MenuStorage::CONTRIB_MENU);
 	    break;
+
+    default:
+      WorldPreviewMenu::menu_action(item);
+      break;
   }
 }
 

--- a/src/supertux/menu/world_set_menu.hpp
+++ b/src/supertux/menu/world_set_menu.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2015 Matthew <thebatmankiller3@gmail.com>
+//                2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,15 +18,9 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_MENU_WORLD_SET_MENU_HPP
 #define HEADER_SUPERTUX_SUPERTUX_MENU_WORLD_SET_MENU_HPP
 
-#include "gui/menu.hpp"
+#include "supertux/menu/world_preview_menu.hpp"
 
-enum WorldSetMenuIDs
-{
-  WORLDSET_STORY,
-  WORLDSET_CONTRIB
-};
-
-class WorldSetMenu final : public Menu
+class WorldSetMenu final : public WorldPreviewMenu
 {
 public:
   WorldSetMenu();

--- a/src/supertux/menu/worldmap_menu.cpp
+++ b/src/supertux/menu/worldmap_menu.cpp
@@ -19,9 +19,8 @@
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
 #include "supertux/menu/menu_storage.hpp"
-#include "supertux/screen_fade.hpp"
-#include "supertux/screen_manager.hpp"
 #include "util/gettext.hpp"
+#include "worldmap/worldmap.hpp"
 
 WorldmapMenu::WorldmapMenu()
 {
@@ -43,8 +42,8 @@ WorldmapMenu::menu_action(MenuItem& item)
       break;
 
     case MNID_QUITWORLDMAP:
-      MenuManager::instance().clear_menu_stack();
-      ScreenManager::current()->pop_screen();
+      MenuManager::instance().clear_menu_stack(true); // Skip transition.
+      worldmap::WorldMap::current()->quit();
       break;
   }
 }

--- a/src/supertux/savegame.hpp
+++ b/src/supertux/savegame.hpp
@@ -66,7 +66,15 @@ public:
 class Savegame final
 {
 public:
+  struct Progress
+  {
+    int progress;
+    int total;
+  };
+
+public:
   static std::unique_ptr<Savegame> from_file(const std::string& filename);
+  static Progress progress_from_file(const std::string& filename);
 
 public:
   Savegame(const std::string& filename);
@@ -75,12 +83,15 @@ public:
   PlayerStatus& get_player_status() const { return *m_player_status; }
 
   std::string get_title() const;
+  const std::string& get_filename() const { return m_filename; }
 
   std::vector<std::string> get_levelsets();
   LevelsetState get_levelset_state(const std::string& name);
   void set_levelset_state(const std::string& basedir,
                           const std::string& level_filename,
                           bool solved);
+
+  const Progress& get_progress() const { return m_progress; }
 
   std::vector<std::string> get_worldmaps();
   WorldmapState get_worldmap_state(const std::string& name);
@@ -90,11 +101,12 @@ public:
   bool is_title_screen() const;
 
 private:
-  void load();
+  void load(bool progress_only = false);
   void clear_state_table();
 
 private:
   std::string m_filename;
+  Progress m_progress;
   std::unique_ptr<PlayerStatus> m_player_status;
 
 private:

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -122,6 +122,9 @@ public:
 
   const std::string& get_title() const { return m_name; }
 
+  /** Request to quit worldmap. */
+  void quit();
+
   /** switch to another worldmap.
       filename is relative to data root path */
   void change(const std::string& filename, const std::string& force_spawnpoint="");
@@ -169,6 +172,7 @@ private:
 
   void load(const std::string& filename);
   void on_escape_press();
+  void take_preview_screenshot();
 
 private:
   std::unique_ptr<SquirrelEnvironment> m_squirrel_environment;
@@ -202,6 +206,8 @@ private:
   bool m_in_level;
 
   bool m_in_world_select;
+
+  Timer m_quit_timer;
 
 private:
   WorldMap(const WorldMap&) = delete;


### PR DESCRIPTION
`WorldSetMenu` and `SortedContribMenu` now inherit the new `WorldPreviewMenu` class, which allows displaying profile-specific world previews and progress. A preview for a world is generated each time the user leaves its worldmap. Only worldmap levelsets support this feature.
Supported also are optional placeholder world previews, which have to be named `preview.png`, and stored in the relative to `levels` directory for the world.

![image](https://user-images.githubusercontent.com/78196474/205510977-2ca5ecfc-57e2-4ac8-8752-72f430301c8a.png)
![image](https://user-images.githubusercontent.com/78196474/205510999-4ff67544-937c-484d-9fbc-aa19eef5796d.png)