### PR TITLE
Add an option for crisp graphics

### DIFF
--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -73,6 +73,7 @@ Config::Config() :
   addons(),
   developer_mode(false),
   christmas_mode(false),
+  crisp_graphics(true),
   transitions_enabled(true),
   confirmation_dialog(false),
   pause_on_focusloss(true),
@@ -165,6 +166,7 @@ Config::load()
   config_mapping.get("show_player_pos", show_player_pos);
   config_mapping.get("show_controller", show_controller);
   config_mapping.get("developer", developer_mode);
+  config_mapping.get("crisp_graphics", crisp_graphics);
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
   config_mapping.get("custom_mouse_cursor", custom_mouse_cursor);
@@ -408,6 +410,7 @@ Config::save()
   if (is_christmas()) {
     writer.write("christmas", christmas_mode);
   }
+  writer.write("crisp_graphics", crisp_graphics);
   writer.write("transitions_enabled", transitions_enabled);
   writer.write("locale", locale);
   writer.write("repository_url", repository_url);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -110,6 +110,7 @@ public:
 
   bool developer_mode;
   bool christmas_mode;
+  bool crisp_graphics;
   bool transitions_enabled;
   bool confirmation_dialog;
   bool pause_on_focusloss;

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -71,6 +71,7 @@ enum OptionsMenuIDs {
   MNID_RUMBLING,
   MNID_DEVELOPER_MODE,
   MNID_CHRISTMAS_MODE,
+  MNID_CRISP_GRAPHICS,
   MNID_TRANSITIONS,
   MNID_CONFIRMATION_DIALOG,
   MNID_PAUSE_ON_FOCUSLOSS,
@@ -454,6 +455,7 @@ OptionsMenu::OptionsMenu(bool complete) :
     add_toggle(MNID_CHRISTMAS_MODE, _("Christmas Mode"), &g_config->christmas_mode);
   }
 
+  add_toggle(MNID_CRISP_GRAPHICS, _("Crisp Graphics"), &g_config->crisp_graphics).set_help(_("Render graphics at nearest pixel. Restart to take effect"));
   add_toggle(MNID_CONFIRMATION_DIALOG, _("Confirmation Dialog"), &g_config->confirmation_dialog).set_help(_("Confirm aborting level"));
   add_toggle(MNID_PAUSE_ON_FOCUSLOSS, _("Pause on focus loss"), &g_config->pause_on_focusloss)
     .set_help(_("Automatically pause the game when the window loses focus"));

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -455,7 +455,9 @@ OptionsMenu::OptionsMenu(bool complete) :
     add_toggle(MNID_CHRISTMAS_MODE, _("Christmas Mode"), &g_config->christmas_mode);
   }
 
-  add_toggle(MNID_CRISP_GRAPHICS, _("Crisp Graphics"), &g_config->crisp_graphics).set_help(_("Render graphics at nearest pixel. Restart to take effect"));
+  if (g_config->video != VideoSystem::Enum::VIDEO_SDL)
+    add_toggle(MNID_CRISP_GRAPHICS, _("Crisp Graphics"), &g_config->crisp_graphics).set_help(_("Render graphics at nearest pixel. Restart to take effect"));
+
   add_toggle(MNID_CONFIRMATION_DIALOG, _("Confirmation Dialog"), &g_config->confirmation_dialog).set_help(_("Confirm aborting level"));
   add_toggle(MNID_PAUSE_ON_FOCUSLOSS, _("Pause on focus loss"), &g_config->pause_on_focusloss)
     .set_help(_("Automatically pause the game when the window loses focus"));

--- a/src/video/gl/gl_texture.cpp
+++ b/src/video/gl/gl_texture.cpp
@@ -18,6 +18,8 @@
 
 #include <assert.h>
 
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "video/glutil.hpp"
 #include "video/sampler.hpp"
 #include "video/sdl_surface.hpp"
@@ -199,8 +201,8 @@ GLTexture::set_texture_params()
 {
   assert_gl();
 
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, static_cast<GLint>(m_sampler.get_filter()));
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, static_cast<GLint>(m_sampler.get_filter()));
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, g_config->crisp_graphics ? GL_NEAREST : static_cast<GLint>(m_sampler.get_filter()));
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_config->crisp_graphics ? GL_NEAREST : static_cast<GLint>(m_sampler.get_filter()));
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, static_cast<GLint>(m_sampler.get_wrap_s()));
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, static_cast<GLint>(m_sampler.get_wrap_t()));

--- a/src/video/gl/gl_texture.cpp
+++ b/src/video/gl/gl_texture.cpp
@@ -201,8 +201,10 @@ GLTexture::set_texture_params()
 {
   assert_gl();
 
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, g_config->crisp_graphics ? GL_NEAREST : static_cast<GLint>(m_sampler.get_filter()));
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, g_config->crisp_graphics ? GL_NEAREST : static_cast<GLint>(m_sampler.get_filter()));
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+    g_config->crisp_graphics ? static_cast<GLint>(GL_NEAREST) : static_cast<GLint>(m_sampler.get_filter()));
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+    g_config->crisp_graphics ? static_cast<GLint>(GL_NEAREST) : static_cast<GLint>(m_sampler.get_filter()));
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, static_cast<GLint>(m_sampler.get_wrap_s()));
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, static_cast<GLint>(m_sampler.get_wrap_t()));


### PR DESCRIPTION
Fixes #1112 by including the GL_NEAREST parameter for rendering, however this can appear poor on different magnifications because it renders to the nearest pixel, so I included the option to render either more "crisp" or with the more blurry (current) look.  Like other graphical options, it requires a restart to take effect.

I have not tested this against the entire game so it is possible something breaks... Let me know if that is the case.