### PR TITLE
Initialize proper UIDs for scripting badguys

### DIFF
--- a/src/scripting/badguy.hpp
+++ b/src/scripting/badguy.hpp
@@ -34,7 +34,9 @@ class BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  using GameObject::GameObject;
+  BadGuy(UID uid) :
+    GameObject<::BadGuy>(uid)
+  {}
 
 private:
   BadGuy(const BadGuy&) = delete;

--- a/src/scripting/dispenser.hpp
+++ b/src/scripting/dispenser.hpp
@@ -34,8 +34,8 @@ class Dispenser final : public scripting::BadGuy
 #ifndef SCRIPTING_API
 public:
   Dispenser(UID uid) :
-    BadGuy(uid),
     GameObject<::BadGuy>(uid),
+    BadGuy(uid),
     GameObject<::Dispenser>(uid)
   {}
 

--- a/src/scripting/dispenser.hpp
+++ b/src/scripting/dispenser.hpp
@@ -18,8 +18,8 @@
 #define HEADER_SUPERTUX_SCRIPTING_DISPENSER_HPP
 
 #ifndef SCRIPTING_API
+
 #include "scripting/badguy.hpp"
-#include "scripting/game_object.hpp"
 
 class Dispenser;
 #endif
@@ -33,7 +33,11 @@ class Dispenser final : public scripting::BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  using BadGuy::BadGuy;
+  Dispenser(UID uid) :
+    BadGuy(uid),
+    GameObject<::BadGuy>(uid),
+    GameObject<::Dispenser>(uid)
+  {}
 
 private:
   Dispenser(const Dispenser&) = delete;

--- a/src/scripting/dispenser.hpp
+++ b/src/scripting/dispenser.hpp
@@ -35,8 +35,8 @@ class Dispenser final : public scripting::BadGuy
 public:
   Dispenser(UID uid) :
     GameObject<::BadGuy>(uid),
-    BadGuy(uid),
-    GameObject<::Dispenser>(uid)
+    GameObject<::Dispenser>(uid),
+    BadGuy(uid)
   {}
 
 private:

--- a/src/scripting/game_object.hpp
+++ b/src/scripting/game_object.hpp
@@ -87,10 +87,6 @@ template<class T>
 class GameObject
 {
 public:
-  GameObject() :
-    m_uid()
-  {}
-
   GameObject(UID uid) :
     m_uid(uid)
   {}

--- a/src/scripting/willowisp.hpp
+++ b/src/scripting/willowisp.hpp
@@ -36,8 +36,8 @@ class WillOWisp final : public scripting::BadGuy
 public:
   WillOWisp(UID uid) :
     GameObject<::BadGuy>(uid),
-    BadGuy(uid),
-    GameObject<::WillOWisp>(uid)
+    GameObject<::WillOWisp>(uid),
+    BadGuy(uid)
   {}
 
 private:

--- a/src/scripting/willowisp.hpp
+++ b/src/scripting/willowisp.hpp
@@ -35,8 +35,8 @@ class WillOWisp final : public scripting::BadGuy
 #ifndef SCRIPTING_API
 public:
   WillOWisp(UID uid) :
-    BadGuy(uid),
     GameObject<::BadGuy>(uid),
+    BadGuy(uid),
     GameObject<::WillOWisp>(uid)
   {}
 

--- a/src/scripting/willowisp.hpp
+++ b/src/scripting/willowisp.hpp
@@ -19,8 +19,8 @@
 
 #ifndef SCRIPTING_API
 #include <string>
+
 #include "scripting/badguy.hpp"
-#include "scripting/game_object.hpp"
 
 class WillOWisp;
 #endif
@@ -34,7 +34,11 @@ class WillOWisp final : public scripting::BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  using BadGuy::BadGuy;
+  WillOWisp(UID uid) :
+    BadGuy(uid),
+    GameObject<::BadGuy>(uid),
+    GameObject<::WillOWisp>(uid)
+  {}
 
 private:
   WillOWisp(const WillOWisp&) = delete;


### PR DESCRIPTION
Fixes an issue, where scriptable badguys (current examples of which are `Dispenser`-s and `WillOWisp`-s) always have the UIDs of the `scripting::GameObject`-s they inherit set to their default, which is 0. The UIDs are now initialized properly.

Fixes #2356.