### PR TITLE
Replaced `ubuntu-latest` with `ubuntu-20.04`

### DIFF
--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -12,7 +12,7 @@ if [ "$SOURCE" = "ON" ]; then
     cpack --config CPackSourceConfig.cmake -G TGZ;
 fi
 
-if ([ "$OS_NAME" = "ubuntu-latest" ] || [ "$OS_NAME" = "ubuntu-18.04" ]) && [ "$PACKAGE" = "ON" ]; then
+if ([ "$OS_NAME" = "ubuntu-20.04" ] || [ "$OS_NAME" = "ubuntu-18.04" ]) && [ "$PACKAGE" = "ON" ]; then
     ../.ci_scripts/build_appimage.sh
     # extract built appimages for uploading
     mv ~/out/* .

--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [32, 64]
-        os: [ubuntu-latest, ubuntu-18.04]
+        os: [ubuntu-20.04, ubuntu-18.04]
         compiler: [gcc, clang]
         build_type: [Debug, Release]
         glbinding: [ON, OFF]
@@ -39,7 +39,7 @@ jobs:
           - arch: 32
             glbinding: ON
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             build_type: Release
             compiler: gcc
             arch: 64
@@ -47,7 +47,7 @@ jobs:
             release: ON
             source: ON
             documentation: ON
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             build_type: Debug
             compiler: gcc
             arch: 64
@@ -103,14 +103,14 @@ jobs:
       - name: Install 32-bit dependencies
         if: ${{ matrix.arch == 32 }}
         env:
-          DOWNGRADE_PCRE: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
+          DOWNGRADE_PCRE: ${{ matrix.os == 'ubuntu-20.04' && '1' || '' }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
 
           if [ "$DOWNGRADE_PCRE" ]; then
             # Github is adding a lot of unnecessary deb.sury.org
-            # packages into ubuntu-latest, this causes
+            # packages into ubuntu-20.04, this causes
             # libharfbuzz-dev:i386 to fail due to issues related to
             # libpcre2-8-0 from deb.sury.org. Remove all that and
             # downgrade to official versions.
@@ -173,7 +173,7 @@ jobs:
           GLBINDING: ${{ matrix.glbinding }}
           # FIXME: GoogleTest isn't detected by CMake on Ubuntu 18.04
           # (also check the step that invokes the tests with ./test_supertux2)
-          TESTS: ${{ matrix.os == 'ubuntu-latest' }}
+          TESTS: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           cmake --version
           $CXX --version
@@ -194,7 +194,7 @@ jobs:
       - name: Run tests
         # FIXME: GoogleTest isn't detected by CMake on Ubuntu 18.04
         # (also check the step that invokes CMake with -DBUILD_TESTS)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         working-directory: build
         run: ./test_supertux2
 


### PR DESCRIPTION
Given that Ubuntu 20.04 is a rather recent OS as of committing, and that apps built against a recent glibc are not compatible with older glibc's, I considered preferable to pick the lazy option and retain nightlies on Ubuntu 20.04 rather than upgrading to 22.04.