### PR TITLE
Order world select properly

### DIFF
--- a/data/levels/preload_worldselect.nut
+++ b/data/levels/preload_worldselect.nut
@@ -5,6 +5,8 @@ if(!("world_select" in state)) {
   state.world_select <- {};
 }
 
+state.world_select.prefix <- "/levels/world";
+
 for(local i = 1; i <= 4; i++) {
   if(!("/levels/world" + i + "/worldmap.stwm" in state.world_select)){
     print("Initing world " + i);

--- a/src/worldmap/world_select.cpp
+++ b/src/worldmap/world_select.cpp
@@ -59,6 +59,18 @@ WorldSelect::WorldSelect(const std::string& current_world_filename) :
   if (worlds.size() > 0)
     std::reverse(worlds.begin(), worlds.end());
 
+  // Only worlds with a set prefix, which also are numbered starting with 1, will be ordered properly.
+  // This is a probably a poor solution, but I can't think of any other. - Daniel
+  std::string prefix = "";
+  vm.get_string("prefix", prefix);
+  if (!prefix.empty())
+  {
+    for (int i = 0; unsigned(i) < worlds.size(); i++)
+    {
+      worlds[i] = prefix + std::to_string(i+1) + "/worldmap.stwm";
+    }
+  }
+
   int i = 0;
   for (const auto& world : worlds) {
     sq_pushroottable(vm.get_vm());


### PR DESCRIPTION
"Fixes" (Closes #2285). I put that in quotes because it does, indeed, include what Semphris described as the "poor" solution, however I cannot seem to find a way worth the time and effort to incorporate the "better" solution.  However, I did include comments that explain why the sorter is the way it is.  It is also compatible with other possible worlds besides just the story worlds so long as they follow a similar naming scheme to each other, such as for the bonus islands.