### PR TITLE
Elastic camera shake instead of linear

### DIFF
--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -109,9 +109,9 @@ Crusher::collision_solid(const CollisionHit& hit)
     crush_sound = "sounds/brick.wav";
 
   float shake_time = m_ic_size == LARGE ? 0.125f : 0.1f;
-  float shake_x = (m_sideways ? m_ic_size == LARGE ? 16.f : 8.f : 0.f)*
+  float shake_x = (m_sideways ? m_ic_size == LARGE ? 32.f : 16.f : 0.f)*
     (m_side_dir == Direction::LEFT ? -1.f : 1.f);
-  float shake_y = m_sideways ? 0.f : m_ic_size == LARGE ? 16.f : 8.f;
+  float shake_y = m_sideways ? 0.f : m_ic_size == LARGE ? 32.f : 16.f;
 
 
   switch (m_state) {

--- a/src/badguy/yeti.cpp
+++ b/src/badguy/yeti.cpp
@@ -287,7 +287,7 @@ void
 Yeti::drop_stalactite()
 {
   // make a stalactite falling down and shake camera a bit
-  Sector::get().get_camera().shake(.1f, 0, 10);
+  Sector::get().get_camera().shake(.1f, 0, 20.f);
 
   auto player = get_nearest_player();
   if (!player) return;

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -405,9 +405,9 @@ Camera::shake()
 
     // elastic easing
 
-    m_translation.x -= m_shakedepth_x * ((std::pow(2, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
+    m_translation.x -= m_shakedepth_x * ((std::pow(2.f, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
       std::sin(((0.8f * m_shakespeed * m_shaketimer.get_timegone()) - 0.75f) * (2.f * math::PI) / 3.f));
-    m_translation.y -= m_shakedepth_y * ((std::pow(2, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
+    m_translation.y -= m_shakedepth_y * ((std::pow(2.f, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
       std::sin(((0.8f * m_shakespeed * m_shaketimer.get_timegone()) - 0.75f) * (2.f * math::PI) / 3.f));
   }
 }

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -297,7 +297,7 @@ Camera::reset(const Vector& tuxpos)
 void
 Camera::shake(float duration, float x, float y)
 {
-  m_shaketimer.start(duration);
+  m_shaketimer.start(duration*100.f);
   m_shakedepth_x = x;
   m_shakedepth_y = y;
   m_shakespeed = math::PI_2 / duration;
@@ -397,8 +397,18 @@ void
 Camera::shake()
 {
   if (m_shaketimer.started()) {
-    m_translation.x -= sinf(m_shaketimer.get_timegone() * m_shakespeed) * m_shakedepth_x;
-    m_translation.y -= sinf(m_shaketimer.get_timegone() * m_shakespeed) * m_shakedepth_y;
+
+    // old method
+    
+    // m_translation.x -= sinf(m_shaketimer.get_timegone() * m_shakespeed) * m_shakedepth_x;
+    // m_translation.y -= sinf(m_shaketimer.get_timegone() * m_shakespeed) * m_shakedepth_y;
+
+    // elastic easing
+
+    m_translation.x -= m_shakedepth_x * ((std::pow(2, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
+      std::sin(((0.8f * m_shakespeed * m_shaketimer.get_timegone()) - 0.75f) * (2.f * math::PI) / 3.f));
+    m_translation.y -= m_shakedepth_y * ((std::pow(2, -0.8f * (m_shakespeed * m_shaketimer.get_timegone()))) *
+      std::sin(((0.8f * m_shakespeed * m_shaketimer.get_timegone()) - 0.75f) * (2.f * math::PI) / 3.f));
   }
 }
 

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -22,6 +22,7 @@
 #include "math/random.hpp"
 #include "object/bonus_block.hpp"
 #include "object/brick.hpp"
+#include "object/camera.hpp"
 #include "object/particles.hpp"
 #include "object/player.hpp"
 #include "object/weak_block.hpp"
@@ -68,6 +69,8 @@ Explosion::explode()
   if (state != STATE_WAITING)
     return;
   state = STATE_EXPLODING;
+
+  Sector::get().get_camera().shake(.1f, 0.f, 10.f);
 
   set_action(hurt ? "default" : "pop", 1);
   m_sprite->set_animation_loops(1); //TODO: this is necessary because set_action will not set "loops" when "action" is the default action

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2087,7 +2087,7 @@ Player::collision_solid(const CollisionHit& hit)
         Vector(m_col.m_bbox.get_left(), m_col.m_bbox.get_bottom()),
         -70, -50, 260, 280, Vector(0, 300), 3,
         Color(.4f, .4f, .4f), 3, .8f, LAYER_OBJECTS+1);
-      Sector::get().get_camera().shake(.1f, 0, 5);
+      Sector::get().get_camera().shake(.1f, 0.f, 10.f);
     }
 
   } else if (hit.top) {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2195,8 +2195,6 @@ Player::kill(bool completely)
   m_sprite->set_angle(0.0f);
   //m_santahatsprite->set_angle(0.0f);
 
-  Sector::get().get_camera().shake(0.1f, completely ? 32.f : 0.f, completely ? 32.f : 16.f);
-
   if (!completely && is_big()) {
     SoundManager::current()->play("sounds/hurt.wav", get_pos());
 
@@ -2256,6 +2254,8 @@ Player::kill(bool completely)
       SoundManager::current()->pause_music(3.0);
     }
   }
+
+  Sector::get().get_camera().shake(0.1f, m_dying ? 32.f : 0.f, m_dying ? 20.f : 10.f);
 }
 
 void

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2195,6 +2195,8 @@ Player::kill(bool completely)
   m_sprite->set_angle(0.0f);
   //m_santahatsprite->set_angle(0.0f);
 
+  Sector::get().get_camera().shake(0.1f, completely ? 32.f : 0.f, completely ? 32.f : 16.f);
+
   if (!completely && is_big()) {
     SoundManager::current()->play("sounds/hurt.wav", get_pos());
 


### PR DESCRIPTION
This PR replaces the old, more "linear" way of camera shaking with an elastic way.  This proves for a smoother and more believable camera shake, and works well in instances where the camera must shake.  I noticed it looked better both in instances where the camera continuously shakes and instances in which it only shakes once.

Also, explosions now generate a camera shake.