### PR TITLE
Fix partial ungrab listener problem (segfault)

### DIFF
--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -177,7 +177,7 @@ public:
   void set_on_ground(bool flag);
 
   Portable* get_grabbed_object() const { return m_grabbed_object; }
-  void stop_grabbing() { m_grabbed_object = nullptr; }
+  void stop_grabbing() { ungrab_object(); }
 
   /** Checks whether the player has grabbed a certain object
       @param name Name of the object to check */


### PR DESCRIPTION
Fixes #2362

Prior to this commit, there was in player.hpp a function `stop_grabbing()` seemingly similar in function to `ungrab_object()`, except that it did not handle the ObjectRemoveListeners properly, which could result in dangling pointers. This was fixed by making the former simply call the latter. This may not be a proper fix (I'm not sure if there was an important, intended difference between the functions, but it's the kind of bug I see often in the game).

An example of this bug occurs with the Ice Block: Open any level with an ice cube and at least 1 other (generic) badguy, stomp and grab the cube, approach the other badguy and collide with it so that they both die, but __without ungrabbing the ice cube__; then, before the ice cube falls off the screen, quickly press escape and restart the level, and then restart the level again.

(I'm not sure why restarting _twice_ is necessary, might be another bug)