### PR TITLE
Fix dead scripting objects when testing worldmaps

### DIFF
--- a/src/scripting/badguy.hpp
+++ b/src/scripting/badguy.hpp
@@ -34,8 +34,8 @@ class BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  BadGuy(UID uid) :
-    GameObject<::BadGuy>(uid)
+  BadGuy(::GameObject* object) :
+    GameObject<::BadGuy>(object)
   {}
 
 private:

--- a/src/scripting/dispenser.hpp
+++ b/src/scripting/dispenser.hpp
@@ -33,10 +33,10 @@ class Dispenser final : public scripting::BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  Dispenser(UID uid) :
-    GameObject<::BadGuy>(uid),
-    GameObject<::Dispenser>(uid),
-    BadGuy(uid)
+  Dispenser(::GameObject* object) :
+    GameObject<::BadGuy>(object),
+    GameObject<::Dispenser>(object),
+    BadGuy(object)
   {}
 
 private:

--- a/src/scripting/floating_image.cpp
+++ b/src/scripting/floating_image.cpp
@@ -24,7 +24,7 @@
 namespace scripting {
 
 FloatingImage::FloatingImage(const std::string& spritefile) :
-  GameObject(get_game_object_manager().add<::FloatingImage>(spritefile).get_uid())
+  GameObject(&get_game_object_manager().add<::FloatingImage>(spritefile))
 {
 }
 

--- a/src/scripting/game_object.cpp
+++ b/src/scripting/game_object.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2018 Ingo Ruhnke <grumbel@gmail.com>
+//  Copyright (C) 2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -23,15 +24,12 @@ namespace scripting {
 
 ::GameObjectManager& get_game_object_manager()
 {
-  using namespace worldmap;
-
-  if (::Sector::current() != nullptr) {
-    return ::Sector::get();
-  } else if (::worldmap::WorldMap::current() != nullptr) {
+  if (::worldmap::WorldMap::current())
     return *::worldmap::WorldMap::current();
-  } else {
-    throw std::runtime_error("Neither sector nor worldmap active");
-  }
+  if (::Sector::current())
+    return ::Sector::get();
+
+  throw std::runtime_error("Unable to perform scripting GameObject action: Neither level sector, nor worldmap active.");
 }
 
 } // namespace scripting

--- a/src/scripting/game_object.cpp
+++ b/src/scripting/game_object.cpp
@@ -1,6 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2018 Ingo Ruhnke <grumbel@gmail.com>
-//  Copyright (C) 2022 Vankata453
+//  Copyright (C) 2023 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ namespace scripting {
   if (::Sector::current())
     return ::Sector::get();
 
-  throw std::runtime_error("Unable to perform scripting GameObject action: Neither level sector, nor worldmap active.");
+  throw std::runtime_error("Unable to perform scripting GameObject action: Neither sector, nor worldmap active.");
 }
 
 } // namespace scripting

--- a/src/scripting/game_object.hpp
+++ b/src/scripting/game_object.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2018 Ingo Ruhnke <grumbel@gmail.com>
+//  Copyright (C) 2022 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -27,7 +28,7 @@
   auto object_ptr = get_object_ptr();                                   \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << m_uid << std::endl;                                    \
+              << std::endl;                                             \
     return;                                                             \
   }                                                                     \
   auto& object = *object_ptr
@@ -36,7 +37,7 @@
   auto object_ptr = get_object_ptr();                                   \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << m_uid << std::endl;                                    \
+              << std::endl;                                             \
     return {};                                                          \
   }                                                                     \
   auto& object = *object_ptr
@@ -45,7 +46,7 @@
   auto object_ptr = get_object_ptr();                                   \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << m_uid << std::endl;                                    \
+              << std::endl;                                             \
     return x;                                                           \
   }                                                                     \
   auto& object = *object_ptr
@@ -54,7 +55,7 @@
   auto object_ptr = GameObject<::OBJECT>::get_object_ptr();             \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << GameObject<::OBJECT>::m_uid << std::endl;              \
+              << std::endl;                                             \
     return;                                                             \
   }                                                                     \
   auto& object = *object_ptr
@@ -63,7 +64,7 @@
   auto object_ptr = GameObject<::OBJECT>::get_object_ptr();             \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << GameObject<::OBJECT>::m_uid << std::endl;              \
+              << std::endl;                                             \
     return {};                                                          \
   }                                                                     \
   auto& object = *object_ptr
@@ -72,12 +73,11 @@
   auto object_ptr = GameObject<::OBJECT>::get_object_ptr();             \
   if (object_ptr == nullptr) {                                          \
     log_fatal << "error: script is accessing a dead object: "           \
-              << GameObject<::OBJECT>::m_uid << std::endl;              \
+              << std::endl;                                             \
     return x;                                                           \
   }                                                                     \
   auto& object = *object_ptr
 
-class GameObjectManager;
 
 namespace scripting {
 
@@ -87,17 +87,17 @@ template<class T>
 class GameObject
 {
 public:
-  GameObject(UID uid) :
-    m_uid(uid)
+  GameObject(::GameObject* object) :
+    m_object(object)
   {}
 
   T* get_object_ptr() const
   {
-    return get_game_object_manager().get_object_by_uid<T>(m_uid);
+    return dynamic_cast<T*>(m_object);
   }
 
 protected:
-  UID m_uid;
+  ::GameObject* m_object; /* The exposed parent GameObject. */
 };
 
 } // namespace scripting

--- a/src/scripting/game_object.hpp
+++ b/src/scripting/game_object.hpp
@@ -1,6 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2018 Ingo Ruhnke <grumbel@gmail.com>
-//  Copyright (C) 2022 Vankata453
+//  Copyright (C) 2023 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/src/scripting/willowisp.hpp
+++ b/src/scripting/willowisp.hpp
@@ -34,10 +34,10 @@ class WillOWisp final : public scripting::BadGuy
 {
 #ifndef SCRIPTING_API
 public:
-  WillOWisp(UID uid) :
-    GameObject<::BadGuy>(uid),
-    GameObject<::WillOWisp>(uid),
-    BadGuy(uid)
+  WillOWisp(::GameObject* object) :
+    GameObject<::BadGuy>(object),
+    GameObject<::WillOWisp>(object),
+    BadGuy(object)
   {}
 
 private:

--- a/src/squirrel/exposed_object.hpp
+++ b/src/squirrel/exposed_object.hpp
@@ -75,7 +75,7 @@ public:
 
     log_debug << "Exposing " << m_parent->get_class_name() << " object " << name << std::endl;
 
-    auto object = std::make_unique<T>(m_parent->get_uid());
+    auto object = std::make_unique<T>(m_parent);
     expose_object(vm, table_idx, std::move(object), name);
   }
 


### PR DESCRIPTION
Fixes #1511.

The reason this bug occurs is because instead of getting the current worldmap, the function `scripting::get_game_object_manager()` returns the current sector from the editor instead. This is what causes the objects to not be found, thus triggering the "dead objects" scripting error.

This PR swaps the check for a current worldmap with the one for the current sector, by prioritizing the current worldmap. Upon testing, it seems to be working fine with levels, loaded from the worldmap, worldmaps, loaded from the editor, and other cases similar to these. There may be a better way to solve this issue in general, though.

Another change featured in this PR is that instead of `scripting::GameObject`s storing UIDs of their exposed parents, and afterwards having to search through the whole current `GameObjectManager` for their parent object, they now store a pointer to their parent `GameObject`, which is more optimized.