### PR TITLE
Allow setting anchor offset for text object position

### DIFF
--- a/src/object/text_object.cpp
+++ b/src/object/text_object.cpp
@@ -35,6 +35,7 @@ TextObject::TextObject(const std::string& name) :
   m_visible(false),
   m_centered(false),
   m_anchor(ANCHOR_MIDDLE),
+  m_anchor_offset(0, 0),
   m_pos(0, 0),
   m_front_fill_color(0.6f, 0.7f, 0.8f, 0.5f),
   m_back_fill_color(0.2f, 0.3f, 0.4f, 0.8f),
@@ -206,16 +207,15 @@ TextObject::draw(DrawingContext& context)
   float width  = m_font->get_text_width(m_wrapped_text) + 20.0f;
   float height = m_font->get_text_height(m_wrapped_text) + 20.0f;
   Vector spos = m_pos + get_anchor_pos(Rectf(0, 0, static_cast<float>(context.get_width()), static_cast<float>(context.get_height())),
-                                       width, height, m_anchor);
+                                       width, height, m_anchor) + m_anchor_offset;
   Vector sizepos = spos + (Vector(width / 2.f, height / 2.f)) - (Vector(width / 2.f, height / 2.f) * (m_fade_progress));
 
   if (m_fade_progress > 0.f)
   {
-    context.color().draw_filled_rect(Rectf((m_grower ? sizepos : spos) - Vector(4.f, 4.f), Sizef((width * (m_fader ? 1.f : m_fade_progress)) + 8.f, (height * (m_fader ? 1.f : m_fade_progress)) + 8.f)),
-      m_back_fill_color, m_roundness + 4.f, LAYER_GUI + 50);
+    const Rectf draw_rect(m_grower ? sizepos : spos, Sizef(width, height) * (m_fader ? 1.f : m_fade_progress));
 
-    context.color().draw_filled_rect(Rectf((m_grower ? sizepos : spos), Sizef(width, height) * (m_fader ? 1.f : m_fade_progress)),
-      m_front_fill_color, m_roundness, LAYER_GUI + 50);
+    context.color().draw_filled_rect(draw_rect.grown(4.0f), m_back_fill_color, m_roundness + 4.f, LAYER_GUI + 50);
+    context.color().draw_filled_rect(draw_rect, m_front_fill_color, m_roundness, LAYER_GUI + 50);
   }
 
   if (m_fader || (m_grower && m_fade_progress >= 1.f))

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -68,7 +68,6 @@ public:
 
   void set_anchor_point(AnchorPoint anchor) { m_anchor = anchor; }
   AnchorPoint get_anchor_point() const { return m_anchor; }
-  void set_anchor_offset(float x, float y) { m_anchor_offset = Vector(x, y); }
   void set_anchor_offset(const Vector& offset) { m_anchor_offset = offset; }
 
   void set_pos(const Vector& pos) { m_pos = pos; }

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -68,6 +68,7 @@ public:
 
   void set_anchor_point(AnchorPoint anchor) { m_anchor = anchor; }
   AnchorPoint get_anchor_point() const { return m_anchor; }
+  void set_anchor_offset(float x, float y) { m_anchor_offset = Vector(x, y); }
 
   void set_pos(const Vector& pos) { m_pos = pos; }
   const Vector& get_pos() const { return m_pos; }
@@ -84,6 +85,7 @@ private:
   bool m_visible;
   bool m_centered;
   AnchorPoint m_anchor;
+  Vector m_anchor_offset;
   Vector m_pos;
   Color m_front_fill_color;
   Color m_back_fill_color;

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -69,6 +69,7 @@ public:
   void set_anchor_point(AnchorPoint anchor) { m_anchor = anchor; }
   AnchorPoint get_anchor_point() const { return m_anchor; }
   void set_anchor_offset(float x, float y) { m_anchor_offset = Vector(x, y); }
+  void set_anchor_offset(const Vector& offset) { m_anchor_offset = offset; }
 
   void set_pos(const Vector& pos) { m_pos = pos; }
   const Vector& get_pos() const { return m_pos; }

--- a/src/scripting/text.cpp
+++ b/src/scripting/text.cpp
@@ -114,6 +114,13 @@ Text::get_anchor_point() const
 }
 
 void
+Text::set_anchor_offset(float x, float y)
+{
+  SCRIPT_GUARD_VOID;
+  object.set_anchor_offset(x, y);
+}
+
+void
 Text::set_front_fill_color(float red, float green, float blue, float alpha)
 {
   SCRIPT_GUARD_VOID;

--- a/src/scripting/text.cpp
+++ b/src/scripting/text.cpp
@@ -117,7 +117,7 @@ void
 Text::set_anchor_offset(float x, float y)
 {
   SCRIPT_GUARD_VOID;
-  object.set_anchor_offset(x, y);
+  object.set_anchor_offset(Vector(x, y));
 }
 
 void

--- a/src/scripting/text.hpp
+++ b/src/scripting/text.hpp
@@ -54,6 +54,7 @@ public:
   float get_pos_y() const;
   void set_anchor_point(int anchor);
   int  get_anchor_point() const;
+  void set_anchor_offset(float x, float y);
   void set_front_fill_color(float red, float green, float blue, float alpha);
   void set_back_fill_color(float red, float green, float blue, float alpha);
   void set_text_color(float red, float green, float blue, float alpha);

--- a/src/scripting/text_array.cpp
+++ b/src/scripting/text_array.cpp
@@ -227,7 +227,7 @@ TextArray::set_anchor_offset(float x, float y)
   SCRIPT_GUARD_VOID;
 
   if (auto* textItem = object.get_current_text_item()) {
-    textItem->text_object.set_anchor_offset(x, y);
+    textItem->text_object.set_anchor_offset(Vector(x, y));
   }
 }
 

--- a/src/scripting/text_array.cpp
+++ b/src/scripting/text_array.cpp
@@ -222,6 +222,16 @@ TextArray::get_anchor_point() const
 }
 
 void
+TextArray::set_anchor_offset(float x, float y)
+{
+  SCRIPT_GUARD_VOID;
+
+  if (auto* textItem = object.get_current_text_item()) {
+    textItem->text_object.set_anchor_offset(x, y);
+  }
+}
+
+void
 TextArray::set_front_fill_color(float red, float green, float blue, float alpha)
 {
   SCRIPT_GUARD_VOID;

--- a/src/scripting/text_array.hpp
+++ b/src/scripting/text_array.hpp
@@ -77,6 +77,7 @@ public:
   float get_pos_y() const;
   void set_anchor_point(int anchor);
   int get_anchor_point() const;
+  void set_anchor_offset(float x, float y);
   void set_front_fill_color(float red, float green, float blue, float alpha);
   void set_back_fill_color(float red, float green, float blue, float alpha);
   void set_text_color(float red, float green, float blue, float alpha);

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -9644,6 +9644,45 @@ static SQInteger Text_get_anchor_point_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Text_set_anchor_offset_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_anchor_offset' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::Text*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_anchor_offset(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_anchor_offset'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Text_set_front_fill_color_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -10558,6 +10597,45 @@ static SQInteger TextArray_get_anchor_point_wrapper(HSQUIRRELVM vm)
     return SQ_ERROR;
   } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_anchor_point'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger TextArray_set_anchor_offset_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_anchor_offset' called without instance"));
+    return SQ_ERROR;
+  }
+  auto _this = reinterpret_cast<scripting::TextArray*> (data);
+
+  if (_this == nullptr) {
+    return SQ_ERROR;
+  }
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_anchor_offset(static_cast<float> (arg0), static_cast<float> (arg1));
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_anchor_offset'"));
     return SQ_ERROR;
   }
 
@@ -16252,6 +16330,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
     throw SquirrelError(v, "Couldn't register function 'get_anchor_point'");
   }
 
+  sq_pushstring(v, "set_anchor_offset", -1);
+  sq_newclosure(v, &Text_set_anchor_offset_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_anchor_offset'");
+  }
+
   sq_pushstring(v, "set_front_fill_color", -1);
   sq_newclosure(v, &Text_set_front_fill_color_wrapper, 0);
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnnnn");
@@ -16443,6 +16528,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|t");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'get_anchor_point'");
+  }
+
+  sq_pushstring(v, "set_anchor_offset", -1);
+  sq_newclosure(v, &TextArray_set_anchor_offset_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, "x|tnn");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_anchor_offset'");
   }
 
   sq_pushstring(v, "set_front_fill_color", -1);

--- a/src/trigger/text_area.cpp
+++ b/src/trigger/text_area.cpp
@@ -35,7 +35,8 @@ TextArea::TextArea(const ReaderMapping& mapping) :
   m_current_text(0),
   m_status(Status::NOT_STARTED),
   m_timer(),
-  m_anchor(AnchorPoint::ANCHOR_MIDDLE)
+  m_anchor(AnchorPoint::ANCHOR_MIDDLE),
+  m_anchor_offset(0, 0)
 {
   float w, h;
 
@@ -47,6 +48,8 @@ TextArea::TextArea(const ReaderMapping& mapping) :
   mapping.get("delay", m_delay);
   mapping.get("once", m_once);
   mapping.get("fade-delay", m_fade_delay);
+  mapping.get("anchor-offset-x", m_anchor_offset.x);
+  mapping.get("anchor-offset-y", m_anchor_offset.y);
 
   std::string anchor;
   if (mapping.get("anchor-point", anchor))
@@ -96,6 +99,7 @@ TextArea::event(Player& player, EventType type)
         m_status = Status::FADING_IN;
         m_timer.start(m_fade_delay);
         text_object.set_anchor_point(m_anchor);
+        text_object.set_anchor_offset(m_anchor_offset);
         text_object.set_text(m_items[m_current_text]);
         text_object.fade_in(m_fade_delay);
       }
@@ -139,6 +143,7 @@ TextArea::update(float dt_sec)
           m_status = Status::FADING_IN;
           m_timer.start(m_fade_delay);
           text_object.set_anchor_point(m_anchor);
+          text_object.set_anchor_offset(m_anchor_offset);
           text_object.set_text(m_items[m_current_text]);
           text_object.fade_in(m_fade_delay);
         }
@@ -162,6 +167,8 @@ TextArea::get_settings()
                     get_anchor_names(), g_anchor_keys,
                     static_cast<int>(AnchorPoint::ANCHOR_MIDDLE),
                     "anchor-point");
+  settings.add_float(_("Anchor offset X"), &m_anchor_offset.x, "anchor-offset-x");
+  settings.add_float(_("Anchor offset Y"), &m_anchor_offset.y, "anchor-offset-y");
   settings.add_string_array(_("Texts"), "texts", m_items);
 
   return settings;

--- a/src/trigger/text_area.hpp
+++ b/src/trigger/text_area.hpp
@@ -57,6 +57,7 @@ private:
   Status m_status;
   Timer m_timer;
   AnchorPoint m_anchor;
+  Vector m_anchor_offset;
 
 private:
   TextArea(const TextArea&) = delete;


### PR DESCRIPTION
Adds the ability to set an anchor offset for the position of a `TextObject`.

The function that allows this is `set_anchor_offset(float x, float y)`, available for both `TextObject` and `TextArray`. To add to the `x` or `y` value, a positive number must be provided. Otherwise, to subtract from those values, a negative number must be provided.