### PR TITLE
Cache dependencies in Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,16 @@ jobs:
           # Fetch the whole tree so git describe works
           fetch-depth: 0
           submodules: true
+
+      - name: Use cached dependencies
+        id: cache-dependencies
+        uses: actions/cache@v3
+        with:
+          path: C:/vcpkg/installed
+          key: ${{ runner.os }}-${{ matrix.arch }}-dependencies-${{ hashFiles('.github/workflows/windows.yml') }}
+
       - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         env:
           ARCH: ${{ matrix.arch }}
         run: |


### PR DESCRIPTION
Allows for caching "vcpkg" dependencies in the Windows GitHub Actions workflow to improve workflow run time.

Cache is reset when a cache file is deleted (may happen automatically when not used for a while), or the `windows.yml` workflow file is modified.