### PR TITLE
Fix incorrect usage of "gameRandom"

### DIFF
--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -95,7 +95,7 @@ FlyingSnowBall::active_update(float dt_sec)
   // spawn smoke puffs
   if (puff_timer.check()) {
     Vector ppos = m_col.m_bbox.get_middle();
-    Vector pspeed = Vector(gameRandom.randf(-10, 10), 150);
+    Vector pspeed = Vector(graphicsRandom.randf(-10, 10), 150);
     Vector paccel = Vector(0,0);
     Sector::get().add<SpriteParticle>("images/particles/smoke.sprite",
                                            "default",

--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -77,7 +77,7 @@ Mole::throw_rock()
 {
   float angle;
   float base_angle = (m_flip == NO_FLIP ? 90.0f : 270.0f);
-  angle = math::radians(gameRandom.randf(base_angle - 15.0f, base_angle + 15.0f));
+  angle = math::radians(graphicsRandom.randf(base_angle - 15.0f, base_angle + 15.0f));
   float vx = cosf(angle) * THROW_VELOCITY;
   float vy = -sinf(angle) * THROW_VELOCITY;
 

--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -77,7 +77,7 @@ Mole::throw_rock()
 {
   float angle;
   float base_angle = (m_flip == NO_FLIP ? 90.0f : 270.0f);
-  angle = math::radians(graphicsRandom.randf(base_angle - 15.0f, base_angle + 15.0f));
+  angle = math::radians(gameRandom.randf(base_angle - 15.0f, base_angle + 15.0f));
   float vx = cosf(angle) * THROW_VELOCITY;
   float vy = -sinf(angle) * THROW_VELOCITY;
 

--- a/src/object/bullet.cpp
+++ b/src/object/bullet.cpp
@@ -61,10 +61,10 @@ void
 Bullet::update(float dt_sec)
 {
   // cause fireball color to flicker randomly
-  if (gameRandom.rand(5) != 0) {
-    lightsprite->set_color(Color(0.3f + gameRandom.randf(10) / 100.0f,
-                                 0.1f + gameRandom.randf(20.0f) / 100.0f,
-                                 gameRandom.randf(10.0f) / 100.0f));
+  if (graphicsRandom.rand(5) != 0) {
+    lightsprite->set_color(Color(0.3f + graphicsRandom.randf(10) / 100.0f,
+                                 0.1f + graphicsRandom.randf(20.0f) / 100.0f,
+                                 graphicsRandom.randf(10.0f) / 100.0f));
   } else
     lightsprite->set_color(Color(0.3f, 0.1f, 0.0f));
 

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -95,7 +95,7 @@ Candle::draw(DrawingContext& context)
   if (burning) {
     //Vector pos = get_pos() + (bbox.get_size() - candle_light_1->get_size()) / 2;
     // draw approx. 1 in 10 frames darker. Makes the candle flicker
-    if (gameRandom.rand(10) != 0 || !flicker) {
+    if (graphicsRandom.rand(10) != 0 || !flicker) {
       //context.color().draw_surface(candle_light_1, pos, layer);
       candle_light_1->draw(context.light(), m_col.m_bbox.get_middle(), m_layer);
     } else {

--- a/src/object/pulsing_light.cpp
+++ b/src/object/pulsing_light.cpp
@@ -32,7 +32,7 @@ PulsingLight::PulsingLight(const Vector& center, float cycle_len_, float min_alp
   assert(cycle_len > 0);
 
   // start with random phase offset
-  t = gameRandom.randf(0.0, cycle_len);
+  t = graphicsRandom.randf(0.0, cycle_len);
 }
 
 PulsingLight::~PulsingLight()

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -127,9 +127,9 @@ WeakBlock::update(float )
       case STATE_BURNING:
         // cause burn light to flicker randomly
         if (linked) {
-          if (gameRandom.rand(10) >= 7) {
-            lightsprite->set_color(Color(0.2f + gameRandom.randf(20.0f) / 100.0f,
-                                         0.1f + gameRandom.randf(20.0f)/100.0f,
+          if (graphicsRandom.rand(10) >= 7) {
+            lightsprite->set_color(Color(0.2f + graphicsRandom.randf(20.0f) / 100.0f,
+                                         0.1f + graphicsRandom.randf(20.0f)/100.0f,
                                          0.1f));
           } else
             lightsprite->set_color(Color(0.3f, 0.2f, 0.1f));


### PR DESCRIPTION
Replaces incorrect usage of `gameRandom` with `graphicsRandom` in contexts, where randomizations, regarding graphics, are performed. This allows for consistent randomizations, when re-using a random seed.

Feel free to let me know if a value which affects gameplay has been changed, and/or another incorrect usage has not been fixed.