### PR TITLE
Fix scripted objects not changing hitbox according to sprite action

### DIFF
--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -61,17 +61,20 @@ public:
   bool change_sprite(const std::string& new_sprite_name);
   void spawn_explosion_sprites(int count, const std::string& sprite_path);
 
-protected:
-  /** set new action for sprite and resize bounding box.  use with
-      care as you can easily get stuck when resizing the bounding box. */
-  void set_action(const std::string& action, int loops);
+  /** Get various sprite properties. **/
+  Sprite* get_sprite() const { return m_sprite.get(); }
+  const std::string& get_action() const { return m_sprite->get_action(); }
 
-  /** set new action for sprite and re-center bounding box.  use with
+  /** Set new action for sprite and resize bounding box.  use with
+      care as you can easily get stuck when resizing the bounding box. */
+  void set_action(const std::string& action, int loops = -1);
+
+  /** Set new action for sprite and re-center bounding box.  use with
       care as you can easily get stuck when resizing the bounding
       box. */
-  void set_action_centered(const std::string& action, int loops);
+  void set_action_centered(const std::string& action, int loops = -1);
 
-  /** set new action for sprite and align bounding boxes at
+  /** Set new action for sprite and align bounding boxes at
       anchorPoint.  use with care as you can easily get stuck when
       resizing the bounding box. */
   void set_action(const std::string& action, int loops, AnchorPoint anchorPoint);

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -166,12 +166,6 @@ Platform::stop_moving()
 }
 
 void
-Platform::set_action(const std::string& action, int repeat)
-{
-  MovingSprite::set_action(action, repeat);
-}
-
-void
 Platform::move_to(const Vector& pos)
 {
   Vector shift = pos - m_col.m_bbox.p1();

--- a/src/object/platform.hpp
+++ b/src/object/platform.hpp
@@ -63,9 +63,6 @@ public:
 
   /** Stop platform at next node */
   void stop_moving();
-
-  /** Updates the platform to the given action  */
-  void set_action(const std::string& action, int repeat);
   /** @} */
 
 private:

--- a/src/object/scripted_object.cpp
+++ b/src/object/scripted_object.cpp
@@ -157,18 +157,6 @@ ScriptedObject::enable_gravity(bool f)
 }
 
 void
-ScriptedObject::set_action(const std::string& animation)
-{
-  m_sprite->set_action(animation);
-}
-
-std::string
-ScriptedObject::get_action() const
-{
-  return m_sprite->get_action();
-}
-
-void
 ScriptedObject::update(float dt_sec)
 {
   if (!physic_enabled)

--- a/src/object/scripted_object.hpp
+++ b/src/object/scripted_object.hpp
@@ -44,10 +44,6 @@ public:
 
   virtual void on_flip(float height) override;
 
-  // --- scripting Interface stuff ---
-  void set_action(const std::string& animation);
-  std::string get_action() const;
-
   void move(float x, float y);
   float get_pos_x() const;
   float get_pos_y() const;


### PR DESCRIPTION
Scripted objects no longer use a self-defined `set_action` function for changing the sprite action. Instead, they now use the function with the same name from the base `MovingSprite` class. `MovingSprite::set_action`, as opposed to the removed `ScriptedObject::set_action` function, changes the hitbox according to the one defined for the sprite action.

The now unneeded `ScriptedObject::get_action` function is also removed and replaced with a `public` one, added in `MovingSprite`.

Provides a fix for one of the issues mentioned in #2339.