### PR TITLE
Fix compiler warning unqualified call to std::move

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -237,7 +237,7 @@ Editor::update(float dt_sec, const Controller& controller)
     std::unique_ptr<Screen> screen(new ParticleEditor());
     if (m_particle_editor_filename)
       static_cast<ParticleEditor*>(screen.get())->open("particles/" + *m_particle_editor_filename);
-    ScreenManager::current()->push_screen(move(screen));
+    ScreenManager::current()->push_screen(std::move(screen));
     return;
   }
 

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -372,12 +372,12 @@ EditorLayersWidget::add_layer(GameObject* layer)
   for (auto i = m_layer_icons.begin(); i != m_layer_icons.end(); ++i) {
     const auto& li = i->get();
     if (li->get_zpos() < z_pos) {
-      m_layer_icons.insert(i, move(icon));
+      m_layer_icons.insert(i, std::move(icon));
       return;
     }
   }
 
-  m_layer_icons.push_back(move(icon));
+  m_layer_icons.push_back(std::move(icon));
 }
 
 void

--- a/src/gui/menu_script.cpp
+++ b/src/gui/menu_script.cpp
@@ -76,7 +76,7 @@ ScriptMenu::remove_line() {
 ItemScriptLine*
 ScriptMenu::add_line() {
   auto new_line = std::make_unique<std::string>();
-  script_strings.insert(script_strings.begin() + (m_active_item - 1), move(new_line));
+  script_strings.insert(script_strings.begin() + (m_active_item - 1), std::move(new_line));
 
   auto line_item = std::unique_ptr<ItemScriptLine>(
         new ItemScriptLine( (script_strings.begin()+(m_active_item-1))->get() ));

--- a/src/supertux/menu/main_menu.cpp
+++ b/src/supertux/menu/main_menu.cpp
@@ -115,7 +115,7 @@ MainMenu::menu_action(MenuItem& item)
         std::unique_ptr<Screen> screen(new Editor());
         auto fade = std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, 0.5f);
         SoundManager::current()->stop_music(0.5);
-        ScreenManager::current()->push_screen(move(screen),move(fade));
+        ScreenManager::current()->push_screen(std::move(screen), std::move(fade));
         //Editor::current()->setup();
       }
       break;


### PR DESCRIPTION

    This fixes the following warning with clang.

    supertux/src/editor/editor.cpp:240:43: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
        ScreenManager::current()->push_screen(move(screen));
                                              ^
                                              std::
    1 warning generated.

