### PR TITLE
CMake: Fix cmake_minimum_required() call location warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@
 #   make
 #
 
+cmake_minimum_required(VERSION 3.1)
 
 ## Project name to use as command prefix.
 
@@ -39,7 +40,6 @@ project(SUPERTUX)
 
 ### CMake configuration
 
-cmake_minimum_required(VERSION 3.1)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   cmake_policy(SET CMP0008 NEW)


### PR DESCRIPTION

    CMake Warning (dev) at CMakeLists.txt:37 (project):
      cmake_minimum_required() should be called prior to this top-level project()
      call.  Please see the cmake-commands(7) manual for usage documentation of
      both commands.
    This warning is for project developers.  Use -Wno-dev to suppress it.

