### PR TITLE
CI: Remove deprecated ubuntu-18.04 from GitHub Actions

### DIFF
--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [32, 64]
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04]
         compiler: [gcc, clang]
         build_type: [Debug, Release]
         glbinding: [ON, OFF]


### PR DESCRIPTION

    Ubuntu 18.04 Actions runner image was deprecated. See
    https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

