### PR TITLE
Fix MovingSprites not having their hitboxes updated

### DIFF
--- a/src/badguy/angrystone.cpp
+++ b/src/badguy/angrystone.cpp
@@ -36,7 +36,7 @@ AngryStone::AngryStone(const ReaderMapping& reader) :
   m_physic.set_velocity_x(0);
   m_physic.set_velocity_y(0);
   m_physic.enable_gravity(true);
-  m_sprite->set_action("idle");
+  set_action("idle");
 }
 
 void
@@ -113,7 +113,7 @@ AngryStone::active_update(float dt_sec) {
             attackDirection.y = -1;
           }
           if ((attackDirection.x != oldWallDirection.x) || (attackDirection.y != oldWallDirection.y)) {
-            m_sprite->set_action("charging");
+            set_action("charging");
             timer.start(CHARGE_TIME);
             state = CHARGING;
           }
@@ -126,7 +126,7 @@ AngryStone::active_update(float dt_sec) {
             attackDirection.y = 0;
           }
           if ((attackDirection.x != oldWallDirection.x) || (attackDirection.y != oldWallDirection.y)) {
-            m_sprite->set_action("charging");
+            set_action("charging");
             timer.start(CHARGE_TIME);
             state = CHARGING;
           }
@@ -136,7 +136,7 @@ AngryStone::active_update(float dt_sec) {
 
     case CHARGING: {
       if (timer.check()) {
-        m_sprite->set_action("attacking");
+        set_action("attacking");
         timer.start(ATTACK_TIME);
         state = ATTACKING;
         m_physic.enable_gravity(false);
@@ -151,7 +151,7 @@ AngryStone::active_update(float dt_sec) {
       if (timer.check()) {
         timer.start(RECOVER_TIME);
         state = RECOVERING;
-        m_sprite->set_action("idle");
+        set_action("idle");
         m_physic.enable_gravity(true);
         m_physic.set_velocity_x(0);
         m_physic.set_velocity_y(0);
@@ -161,7 +161,7 @@ AngryStone::active_update(float dt_sec) {
     case RECOVERING: {
       if (timer.check()) {
         state = IDLE;
-        m_sprite->set_action("idle");
+        set_action("idle");
         m_physic.enable_gravity(true);
         m_physic.set_velocity_x(0);
         m_physic.set_velocity_y(0);

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -269,7 +269,7 @@ BadGuy::update(float dt_sec)
       m_is_active_flag = false;
       m_col.set_movement(m_physic.get_movement(dt_sec));
       if ( on_ground() && m_sprite->animation_done() ) {
-        m_sprite->set_action("gear", m_dir, 1);
+        set_action("gear", m_dir, 1);
         set_state(STATE_GEAR);
       }
       int pa = graphicsRandom.rand(0,3);
@@ -811,14 +811,14 @@ BadGuy::grab(MovingObject& object, const Vector& pos, Direction dir_)
     m_unfreeze_timer.stop();
     if (m_sprite->has_action("iced-left"))
     {
-      m_sprite->set_action("iced", m_dir, 1);
+      set_action("iced", m_dir, 1);
       // when the sprite doesn't have sepaigrate actions for left and right, it tries to use an universal one.
     }
     else
     {
       if (m_sprite->has_action("iced"))
       {
-        m_sprite->set_action("iced", 1);
+        set_action("iced", 1);
       }
       // when no iced action exists, default to shading badguy blue
       else
@@ -899,12 +899,12 @@ BadGuy::freeze()
   set_pos(Vector(get_bbox().get_left(), get_bbox().get_bottom() - freezesize_y));
 
   if (m_sprite->has_action("iced-left"))
-    m_sprite->set_action("iced", m_dir, 1);
+    set_action("iced", m_dir, 1);
   // when the sprite doesn't have separate actions for left and right, it tries to use an universal one.
   else
   {
     if (m_sprite->has_action("iced"))
-      m_sprite->set_action("iced", 1);
+      set_action("iced", 1);
     // when no iced action exists, default to shading badguy blue
     else
     {
@@ -986,11 +986,11 @@ BadGuy::ignite()
 
     // melt it!
     if (m_sprite->has_action("ground-melting-left") && on_ground()) {
-      m_sprite->set_action("ground-melting", m_dir, 1);
+      set_action("ground-melting", m_dir, 1);
       SoundManager::current()->play("sounds/splash.ogg", get_pos());
       set_state(STATE_GROUND_MELTING);
     } else {
-      m_sprite->set_action("melting", m_dir, 1);
+      set_action("melting", m_dir, 1);
       SoundManager::current()->play("sounds/sizzle.ogg", get_pos());
       set_state(STATE_MELTING);
     }
@@ -1001,13 +1001,13 @@ BadGuy::ignite()
     // burn it!
     m_glowing = true;
     SoundManager::current()->play("sounds/fire.ogg", get_pos());
-    m_sprite->set_action("burning", m_dir, 1);
+    set_action("burning", m_dir, 1);
     set_state(STATE_BURNING);
     run_dead_script();
   } else if (m_sprite->has_action("inside-melting-left")) {
     // melt it inside!
     SoundManager::current()->play("sounds/splash.ogg", get_pos());
-    m_sprite->set_action("inside-melting", m_dir, 1);
+    set_action("inside-melting", m_dir, 1);
     set_state(STATE_INSIDE_MELTING);
     run_dead_script();
   } else {
@@ -1061,25 +1061,25 @@ BadGuy::after_editor_set()
   if (m_dir == Direction::AUTO)
   {
     if (m_sprite->has_action("editor-left")) {
-      m_sprite->set_action("editor-left");
+      set_action("editor-left");
     } else if (m_sprite->has_action("editor-right")) {
-      m_sprite->set_action("editor-right");
+      set_action("editor-right");
     } else if (m_sprite->has_action("left")) {
-      m_sprite->set_action("left");
+      set_action("left");
     } else if (m_sprite->has_action("normal")) {
-      m_sprite->set_action("normal");
+      set_action("normal");
     } else if (m_sprite->has_action("idle")) {
-      m_sprite->set_action("idle");
+      set_action("idle");
     } else if (m_sprite->has_action("idle-left")) {
-      m_sprite->set_action("idle-left");
+      set_action("idle-left");
     } else if (m_sprite->has_action("flying-left")) {
-      m_sprite->set_action("flying-left");
+      set_action("flying-left");
     } else if (m_sprite->has_action("walking-left")) {
-      m_sprite->set_action("walking-left");
+      set_action("walking-left");
     } else if (m_sprite->has_action("flying")) {
-      m_sprite->set_action("flying");
+      set_action("flying");
     } else if (m_sprite->has_action("standing-left")) {
-      m_sprite->set_action("standing-left");
+      set_action("standing-left");
     } else {
       log_warning << "couldn't find editor sprite for badguy direction='auto': " << get_class_name() << std::endl;
     }
@@ -1089,25 +1089,25 @@ BadGuy::after_editor_set()
     std::string action_str = dir_to_string(m_dir);
 
     if (m_sprite->has_action("editor-" + action_str)) {
-      m_sprite->set_action("editor-" + action_str);
+      set_action("editor-" + action_str);
     } else if (m_sprite->has_action(action_str)) {
-      m_sprite->set_action(action_str);
+      set_action(action_str);
     } else if (m_sprite->has_action("idle-" + action_str)) {
-      m_sprite->set_action("idle-" + action_str);
+      set_action("idle-" + action_str);
     } else if (m_sprite->has_action("flying-" + action_str)) {
-      m_sprite->set_action("flying-" + action_str);
+      set_action("flying-" + action_str);
     } else if (m_sprite->has_action("standing-" + action_str)) {
-      m_sprite->set_action("standing-" + action_str);
+      set_action("standing-" + action_str);
     } else if (m_sprite->has_action("walking-" + action_str)) {
-      m_sprite->set_action("walking-" + action_str);
+      set_action("walking-" + action_str);
     } else if (m_sprite->has_action("left")) {
-      m_sprite->set_action("left");
+      set_action("left");
     } else if (m_sprite->has_action("normal")) {
-      m_sprite->set_action("normal");
+      set_action("normal");
     } else if (m_sprite->has_action("idle")) {
-      m_sprite->set_action("idle");
+      set_action("idle");
     } else if (m_sprite->has_action("flying")) {
-      m_sprite->set_action("flying");
+      set_action("flying");
     } else {
       log_warning << "couldn't find editor sprite for badguy direction='" << action_str << "': "
                   << get_class_name() << std::endl;

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -145,7 +145,7 @@ Bomb::grab(MovingObject& object, const Vector& pos, Direction dir_)
 
   // We actually face the opposite direction of Tux here to make the fuse more
   // visible instead of hiding it behind Tux
-  m_sprite->set_action_continued(m_dir == Direction::LEFT ? "ticking-right" : "ticking-left");
+  set_action("ticking", m_dir, Sprite::LOOPS_CONTINUED);
   set_colgroup_active(COLGROUP_DISABLED);
 }
 

--- a/src/badguy/bouncing_snowball.cpp
+++ b/src/badguy/bouncing_snowball.cpp
@@ -33,7 +33,7 @@ void
 BouncingSnowball::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -BSNOWBALL_WALKSPEED : BSNOWBALL_WALKSPEED);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 void
@@ -42,7 +42,7 @@ BouncingSnowball::active_update(float dt_sec)
   BadGuy::active_update(dt_sec);
   if ((m_sprite->get_action() == "left-up" || m_sprite->get_action() == "right-up") && m_sprite->animation_done())
   {
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
   }
   Rectf lookbelow = get_bbox();
   lookbelow.set_bottom(lookbelow.get_bottom() + 48);
@@ -50,18 +50,18 @@ BouncingSnowball::active_update(float dt_sec)
   bool groundBelow = !Sector::get().is_free_of_statics(lookbelow);
   if (groundBelow && (m_physic.get_velocity_y() >= 64.0f))
   {
-    m_sprite->set_action(m_dir == Direction::LEFT ? "left-down" : "right-down");
+    set_action(m_dir, "down");
   }
   if (!groundBelow && (m_sprite->get_action() == "left-down" || m_sprite->get_action() == "right-down"))
   {
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
   }
 }
 
 bool
 BouncingSnowball::collision_squished(GameObject& object)
 {
-  m_sprite->set_action("squished");
+  set_action("squished");
   kill_squished(object);
   return true;
 }
@@ -78,7 +78,7 @@ BouncingSnowball::collision_solid(const CollisionHit& hit)
     if (get_state() == STATE_ACTIVE) {
       float bounce_speed = -m_physic.get_velocity_y()*0.8f;
       m_physic.set_velocity_y(std::min(JUMPSPEED, bounce_speed));
-	    m_sprite->set_action(m_dir == Direction::LEFT ? "left-up" : "right-up", /* loops = */ 1);
+	    set_action(m_dir, "up", /* loops = */ 1);
     } else {
       m_physic.set_velocity_y(0);
     }
@@ -90,7 +90,7 @@ BouncingSnowball::collision_solid(const CollisionHit& hit)
   // The direction must correspond, else we got fake bounces on slopes.
   if ((hit.left && m_dir == Direction::LEFT) || (hit.right && m_dir == Direction::RIGHT)) {
     m_dir = m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
     m_physic.set_velocity_x(-m_physic.get_velocity_x());
   }
 
@@ -107,7 +107,7 @@ void
 BouncingSnowball::after_editor_set()
 {
   BadGuy::after_editor_set();
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 /* EOF */

--- a/src/badguy/captainsnowball.cpp
+++ b/src/badguy/captainsnowball.cpp
@@ -81,7 +81,7 @@ CaptainSnowball::collision_solid(const CollisionHit& hit)
 bool
 CaptainSnowball::collision_squished(GameObject& object)
 {
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -481,16 +481,16 @@ Crusher::set_state(CrusherState state_, bool force)
   switch (state_)
   {
   case IDLE:
-    m_sprite->set_action("idle");
+    set_action("idle");
     break;
   case CRUSHING:
     m_physic.reset();
     if (not_ice())
-      m_sprite->set_action("crushing");
+      set_action("crushing");
     break;
   case RECOVERING:
     if (not_ice())
-      m_sprite->set_action("recovering");
+      set_action("recovering");
     break;
   default:
     log_debug << "Crusher in invalid state" << std::endl;
@@ -669,17 +669,17 @@ CrusherRoot::start_animation()
   switch (m_direction)
   {
   case Crusher::Direction::DOWN:
-    m_sprite->set_action("downwards");
+    set_action("downwards");
     m_sprite->set_animation_loops(1);
     break;
 
   case Crusher::Direction::LEFT:
-    m_sprite->set_action("sideways-left");
+    set_action("sideways-left");
     m_sprite->set_animation_loops(1);
     break;
 
   case Crusher::Direction::RIGHT:
-    m_sprite->set_action("sideways-right");
+    set_action("sideways-right");
     m_sprite->set_animation_loops(1);
     break;
   }

--- a/src/badguy/dart.cpp
+++ b/src/badguy/dart.cpp
@@ -65,7 +65,7 @@ void
 Dart::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -::DART_SPEED : ::DART_SPEED);
-  m_sprite->set_action("flying", m_dir);
+  set_action("flying", m_dir);
 }
 
 void

--- a/src/badguy/darttrap.cpp
+++ b/src/badguy/darttrap.cpp
@@ -57,7 +57,7 @@ DartTrap::DartTrap(const ReaderMapping& reader) :
 void
 DartTrap::initialize()
 {
-  m_sprite->set_action("idle", m_dir);
+  set_action("idle", m_dir);
 }
 
 void
@@ -102,7 +102,7 @@ void
 DartTrap::load()
 {
   state = LOADING;
-  m_sprite->set_action("loading", m_dir, 1);
+  set_action("loading", m_dir, 1);
 }
 
 void
@@ -119,7 +119,7 @@ DartTrap::fire()
   SoundManager::current()->play("sounds/dartfire.wav", get_pos());
   Sector::get().add<Dart>(Vector(px, py), m_dir, this);
   state = IDLE;
-  m_sprite->set_action("idle", m_dir);
+  set_action("idle", m_dir);
 }
 
 ObjectSettings

--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -326,14 +326,14 @@ Dispenser::freeze()
   const std::string cannon_iced = "iced-" + Cannon_Direction_to_string(m_dir);
   if (m_type == DispenserType::CANNON && m_sprite->has_action(cannon_iced))
   {
-    m_sprite->set_action(cannon_iced, 1);
+    set_action(cannon_iced, 1);
     // When the dispenser is a cannon, it uses the respective "iced" action, based on the current direction.
   }
   else
   {
     if (m_type == DispenserType::DROPPER && m_sprite->has_action("dropper-iced"))
     {
-      m_sprite->set_action("dropper-iced", 1);
+      set_action("dropper-iced", 1);
       // When the dispenser is a dropper, it uses the "dropper-iced".
     }
     else
@@ -388,7 +388,7 @@ Dispenser::set_correct_action()
   switch (m_type)
   {
     case DispenserType::CANNON:
-      m_sprite->set_action(Cannon_Direction_to_string(m_dir));
+      set_action(Cannon_Direction_to_string(m_dir));
       break;
 
     case DispenserType::POINT:

--- a/src/badguy/fish_chasing.cpp
+++ b/src/badguy/fish_chasing.cpp
@@ -76,7 +76,7 @@ FishChasing::active_update(float dt_sec) {
     }
     break;
   case FOUND:
-    m_sprite->set_action("notice", m_dir, 1);
+    set_action("notice", m_dir, 1);
 
     if (std::abs(glm::length(m_physic.get_velocity())) >= 1.f) {
       m_physic.set_velocity(m_physic.get_velocity() / 1.25f);
@@ -97,7 +97,7 @@ FishChasing::active_update(float dt_sec) {
     else if (glm::length(dist) >= 1 && m_in_water && !m_frozen)
     {
       m_dir = (m_physic.get_velocity_x() <= 0.f ? Direction::LEFT : Direction::RIGHT);
-      m_sprite->set_action("chase", m_dir);
+      set_action("chase", m_dir);
       Vector dir = glm::normalize(dist);
       m_physic.set_velocity(dir * m_chase_speed);
     }
@@ -108,7 +108,7 @@ FishChasing::active_update(float dt_sec) {
     }
     break;
   case LOST:
-    m_sprite->set_action("swim", m_dir);
+    set_action("swim", m_dir);
 
     if (m_in_water && !m_frozen)
     {

--- a/src/badguy/fish_jumping.cpp
+++ b/src/badguy/fish_jumping.cpp
@@ -107,7 +107,7 @@ FishJumping::active_update(float dt_sec)
 
   // set sprite
   if (!m_frozen && !is_ignited())
-    m_sprite->set_action((m_physic.get_velocity_y() == 0.f && m_in_water) ? "wait" :
+    set_action((m_physic.get_velocity_y() == 0.f && m_in_water) ? "wait" :
       m_physic.get_velocity_y() < 0.f ? "normal" : "down");
 
   // we can't afford flying out of the tilemap, 'cause the engine would remove us.
@@ -141,7 +141,7 @@ FishJumping::freeze()
 {
   BadGuy::freeze();
   m_physic.enable_gravity(true);
-  m_sprite->set_action(m_physic.get_velocity_y() < 0 ? "iced" : "iced-down");
+  set_action(m_physic.get_velocity_y() < 0 ? "iced" : "iced-down");
   m_sprite->set_color(Color(1.0f, 1.0f, 1.0f));
   m_wait_timer.stop();
   if (m_beached_timer.started())
@@ -159,7 +159,7 @@ void
 FishJumping::kill_fall()
 {
   if (!is_ignited())
-    m_sprite->set_action("normal");
+  set_action("normal");
   BadGuy::kill_fall();
 }
 

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -62,7 +62,7 @@ void
 FishSwimming::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -128.f : 128.f);
-  m_sprite->set_action("swim", m_dir);
+  set_action("swim", m_dir);
   m_state = FishYState::BALANCED;
 }
 
@@ -197,7 +197,7 @@ FishSwimming::turn_around()
     return;
 
   m_dir = (m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT);
-  m_sprite->set_action("swim", m_dir);
+  set_action("swim", m_dir);
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -128.f : 128.f);
 }
 

--- a/src/badguy/flame.cpp
+++ b/src/badguy/flame.cpp
@@ -110,7 +110,7 @@ void
 Flame::freeze()
 {
   SoundManager::current()->play("sounds/sizzle.ogg", get_pos());
-  m_sprite->set_action("fade", 1);
+  set_action("fade", 1);
   Sector::get().add<SpriteParticle>("images/particles/smoke.sprite",
                                          "default",
                                          m_col.m_bbox.get_middle(), ANCHOR_MIDDLE,

--- a/src/badguy/flyingsnowball.cpp
+++ b/src/badguy/flyingsnowball.cpp
@@ -40,7 +40,7 @@ FlyingSnowBall::FlyingSnowBall(const ReaderMapping& reader) :
 void
 FlyingSnowBall::initialize()
 {
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 void
@@ -52,7 +52,7 @@ FlyingSnowBall::activate()
 bool
 FlyingSnowBall::collision_squished(GameObject& object)
 {
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   m_physic.enable_gravity(true);
   m_physic.set_acceleration_y(0);
   m_physic.set_velocity_y(0);
@@ -89,7 +89,7 @@ FlyingSnowBall::active_update(float dt_sec)
   auto player = get_nearest_player();
   if (player) {
     m_dir = (player->get_pos().x > get_pos().x) ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
   }
 
   // spawn smoke puffs

--- a/src/badguy/ghosttree.cpp
+++ b/src/badguy/ghosttree.cpp
@@ -63,7 +63,7 @@ void
 GhostTree::die()
 {
   mystate = STATE_DYING;
-  m_sprite->set_action("dying", 1);
+  set_action("dying", 1);
   glow_sprite->set_action("dying", 1);
 
   for (const auto& willo : willowisps) {
@@ -170,7 +170,7 @@ GhostTree::active_update(float /*dt_sec*/)
         suck_lantern->ungrab(*this, Direction::RIGHT);
         suck_lantern->remove_me();
         suck_lantern = nullptr;
-        m_sprite->set_action("swallow", 1);
+        set_action("swallow", 1);
       } else {
         pos += glm::normalize(delta);
         suck_lantern->grab(*this, pos, Direction::RIGHT);
@@ -181,7 +181,7 @@ GhostTree::active_update(float /*dt_sec*/)
         if (is_color_deadly(suck_lantern_color)) {
           die();
         } else {
-          m_sprite->set_action("normal");
+          set_action("normal");
           mystate = STATE_IDLE;
           spawn_lantern();
         }

--- a/src/badguy/ghoul.cpp
+++ b/src/badguy/ghoul.cpp
@@ -41,7 +41,7 @@ Ghoul::Ghoul(const ReaderMapping& reader) :
 
   init_path(reader, running);
   
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 bool
@@ -50,7 +50,7 @@ Ghoul::collision_squished(GameObject& object)
   auto player = Sector::get().get_nearest_player(m_col.m_bbox);
   if (player)
     player->bounce (*this);
-  m_sprite->set_action("squished", 1);
+  set_action("squished", 1);
   kill_fall();
   return true;
 }
@@ -113,11 +113,11 @@ Ghoul::active_update(float dt_sec)
   const Rectf& player_bbox = player->get_bbox();
   
   if (player_bbox.get_right() < m_col.m_bbox.get_left()) {
-    m_sprite->set_action("left", -1);
+    set_action("left", -1);
   }
   
   if (player_bbox.get_left() > m_col.m_bbox.get_right()) {
-    m_sprite->set_action("right", -1);
+    set_action("right", -1);
   }
 
   switch (m_mystate) {

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -214,14 +214,14 @@ GoldBomb::grab(MovingObject& object, const Vector& pos, Direction dir_)
   if (tstate == STATE_TICKING){
     // We actually face the opposite direction of Tux here to make the fuse more
     // visible instead of hiding it behind Tux
-    m_sprite->set_action_continued(m_dir == Direction::LEFT ? "ticking-right" : "ticking-left");
+    set_action("ticking", m_dir, Sprite::LOOPS_CONTINUED);
     set_colgroup_active(COLGROUP_DISABLED);
   }
   else if (m_frozen){
-    m_sprite->set_action("iced", dir_);
+    set_action("iced", dir_);
   }
   else if (dynamic_cast<Owl*>(&object))
-    m_sprite->set_action(dir_);
+    set_action(dir_);
   m_col.set_movement(pos - get_pos());
   m_dir = dir_;
   set_colgroup_active(COLGROUP_DISABLED);

--- a/src/badguy/iceflame.cpp
+++ b/src/badguy/iceflame.cpp
@@ -42,7 +42,7 @@ void
 Iceflame::ignite()
 {
   SoundManager::current()->play("sounds/sizzle.ogg", get_pos());
-  m_sprite->set_action("fade", 1);
+  set_action("fade", 1);
   Sector::get().add<SpriteParticle>("images/particles/smoke.sprite",
                                          "default",
                                          m_col.m_bbox.get_middle(), ANCHOR_MIDDLE,

--- a/src/badguy/jumpy.cpp
+++ b/src/badguy/jumpy.cpp
@@ -30,7 +30,7 @@ Jumpy::Jumpy(const ReaderMapping& reader) :
   pos_groundhit(0.0f, 0.0f),
   groundhit_pos_set(false)
 {
-  m_sprite->set_action("left-middle");
+  set_action(m_dir, "middle");
   // TODO create a nice sound for this...
   //SoundManager::current()->preload("sounds/skid.wav");
 }
@@ -86,17 +86,17 @@ Jumpy::active_update(float dt_sec)
 
   if (!groundhit_pos_set)
   {
-    m_sprite->set_action("editor", m_dir);
+    set_action("editor", m_dir);
     return;
   }
 
   if ( get_pos().y < (pos_groundhit.y - JUMPY_MID_TOLERANCE ) )
-    m_sprite->set_action(m_dir == Direction::LEFT ? "left-up" : "right-up");
+    set_action(m_dir, "up");
   else if ( get_pos().y >= (pos_groundhit.y - JUMPY_MID_TOLERANCE) &&
             get_pos().y < (pos_groundhit.y - JUMPY_LOW_TOLERANCE) )
-    m_sprite->set_action(m_dir == Direction::LEFT ? "left-middle" : "right-middle");
+    set_action(m_dir, "middle");
   else
-    m_sprite->set_action(m_dir == Direction::LEFT ? "left-down" : "right-down");
+    set_action(m_dir, "down");
 }
 
 void

--- a/src/badguy/kamikazesnowball.cpp
+++ b/src/badguy/kamikazesnowball.cpp
@@ -38,7 +38,7 @@ KamikazeSnowball::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -KAMIKAZE_SPEED : KAMIKAZE_SPEED);
   m_physic.enable_gravity(false);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 bool
@@ -46,7 +46,7 @@ KamikazeSnowball::collision_squished(GameObject& object)
 {
   if (m_frozen)
     return BadGuy::collision_squished(object);
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }
@@ -70,7 +70,7 @@ KamikazeSnowball::collision_solid(const CollisionHit& hit)
 void
 KamikazeSnowball::kill_collision()
 {
-  m_sprite->set_action("collision", m_dir);
+  set_action("collision", m_dir);
   SoundManager::current()->play(SPLAT_SOUND, get_pos());
   m_physic.set_velocity_x(0);
   m_physic.set_velocity_y(0);
@@ -111,7 +111,7 @@ LeafShot::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -LEAFSHOT_SPEED : LEAFSHOT_SPEED);
   m_physic.enable_gravity(false);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 bool
@@ -140,7 +140,7 @@ LeafShot::collision_squished(GameObject& object)
 {
   if (m_frozen)
     return BadGuy::collision_squished(object);
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   // Spawn death particles
   spawn_explosion_sprites(3, "images/particles/leafshot.sprite");
   kill_squished(object);

--- a/src/badguy/kugelblitz.cpp
+++ b/src/badguy/kugelblitz.cpp
@@ -46,7 +46,7 @@ Kugelblitz::Kugelblitz(const ReaderMapping& reader) :
   lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
 {
   m_start_position.x = m_col.m_bbox.get_left();
-  m_sprite->set_action("falling");
+  set_action("falling");
   m_physic.enable_gravity(false);
   m_countMe = false;
 
@@ -111,7 +111,7 @@ Kugelblitz::hit(const CollisionHit& hit_)
       pos_groundhit = get_pos();
       groundhit_pos_set = true;
     }
-    m_sprite->set_action("flying");
+    set_action("flying");
     m_physic.set_velocity_y(0);
     //Set random initial speed and direction
     direction = gameRandom.rand(2)? 1: -1;
@@ -167,7 +167,7 @@ Kugelblitz::explode()
 {
   if (!dying) {
     SoundManager::current()->play("sounds/lightning.wav", m_col.m_bbox.p1());
-    m_sprite->set_action("pop");
+    set_action("pop");
     lifetime.start(0.2f);
     dying = true;
   }

--- a/src/badguy/livefire.cpp
+++ b/src/badguy/livefire.cpp
@@ -78,7 +78,7 @@ LiveFire::active_update(float dt_sec) {
 
       if (inReach_left && inReach_right && inReach_top && inReach_bottom) {
         // wake up
-        m_sprite->set_action("waking", m_dir, 1);
+        set_action("waking", m_dir, 1);
         state = STATE_WAKING;
       }
     }
@@ -127,7 +127,7 @@ LiveFire::kill_fall()
                                          pspeed, paccel,
                                          LAYER_BACKGROUNDTILES+2);
   // extinguish the flame
-  m_sprite->set_action("extinguish", m_dir, 1);
+  set_action("extinguish", m_dir, 1);
   m_physic.set_velocity_y(0);
   m_physic.set_acceleration_y(0);
   m_physic.enable_gravity(false);
@@ -152,7 +152,7 @@ void
 LiveFireAsleep::draw(DrawingContext& context)
 {
   if (Editor::is_active()) {
-    m_sprite->set_action("sleeping", m_dir);
+    set_action("sleeping", m_dir);
     BadGuy::draw(context);
   } else {
     LiveFire::draw(context);
@@ -163,7 +163,7 @@ void
 LiveFireAsleep::initialize()
 {
   m_physic.set_velocity_x(0);
-  m_sprite->set_action("sleeping", m_dir);
+  set_action("sleeping", m_dir);
 }
 
 /* The following defines a dormant version that never wakes */
@@ -178,7 +178,7 @@ void
 LiveFireDormant::draw(DrawingContext& context)
 {
   if (Editor::is_active()) {
-    m_sprite->set_action("sleeping", m_dir);
+    set_action("sleeping", m_dir);
     BadGuy::draw(context);
   } else {
     LiveFire::draw(context);
@@ -189,7 +189,7 @@ void
 LiveFireDormant::initialize()
 {
   m_physic.set_velocity_x(0);
-  m_sprite->set_action("sleeping", m_dir);
+  set_action("sleeping", m_dir);
 }
 
 /* EOF */

--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -131,31 +131,31 @@ Mole::set_state(MoleState new_state)
 {
   switch (new_state) {
     case PRE_THROWING:
-      m_sprite->set_action("idle");
+      set_action("idle");
       set_colgroup_active(COLGROUP_DISABLED);
       timer.start(MOLE_WAIT_TIME);
       break;
     case THROWING:
-      m_sprite->set_action("idle");
+      set_action("idle");
       set_colgroup_active(COLGROUP_DISABLED);
       timer.start(THROW_TIME);
       throw_timer.start(THROW_INTERVAL);
       break;
     case POST_THROWING:
-      m_sprite->set_action("idle");
+      set_action("idle");
       set_colgroup_active(COLGROUP_DISABLED);
       timer.start(MOLE_WAIT_TIME);
       break;
     case PEEKING:
-      m_sprite->set_action("peeking", 1);
+      set_action("peeking", 1);
       set_colgroup_active(COLGROUP_STATIC);
       break;
     case DEAD:
-      m_sprite->set_action("squished");
+      set_action("squished");
       set_colgroup_active(COLGROUP_DISABLED);
       break;
     case BURNING:
-      m_sprite->set_action("burning", 1);
+      set_action("burning", 1);
       set_colgroup_active(COLGROUP_DISABLED);
       break;
   }

--- a/src/badguy/mole_rock.cpp
+++ b/src/badguy/mole_rock.cpp
@@ -60,7 +60,7 @@ MoleRock::initialize()
   m_physic.set_velocity(initial_velocity);
 
   // Randomly select a rock size to display.
-  m_sprite->set_action(graphicsRandom.rand(2) == 0 ? "small" : "medium");
+  set_action(graphicsRandom.rand(2) == 0 ? "small" : "medium");
 }
 
 void

--- a/src/badguy/mrbomb.cpp
+++ b/src/badguy/mrbomb.cpp
@@ -131,11 +131,11 @@ MrBomb::grab(MovingObject& object, const Vector& pos, Direction dir_)
 {
   Portable::grab(object, pos, dir_);
   if (dynamic_cast<Owl*>(&object))
-    m_sprite->set_action(dir_);
+    set_action(dir_);
   else
   {
     assert(m_frozen);
-    m_sprite->set_action("iced", dir_);
+    set_action("iced", dir_);
   }
   m_col.set_movement(pos - get_pos());
   m_dir = dir_;

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -251,8 +251,7 @@ MrIceBlock::set_state(IceState state_)
     flat_timer.stop();
     break;
   case ICESTATE_WAKING:
-    m_sprite->set_action(m_dir == Direction::LEFT ? "waking-left" : "waking-right",
-      /* loops = */ 1);
+    set_action("waking", m_dir, /* loops = */ 1);
     break;
   default:
     assert(false);

--- a/src/badguy/owl.cpp
+++ b/src/badguy/owl.cpp
@@ -52,7 +52,7 @@ Owl::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -FLYING_SPEED : FLYING_SPEED);
   m_physic.enable_gravity(false);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 
   // If we add the carried object to the sector while we're editing
   // a level with the editor, it gets written to the level file,
@@ -188,7 +188,7 @@ Owl::unfreeze(bool melt)
   BadGuy::unfreeze(melt);
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -FLYING_SPEED : FLYING_SPEED);
   m_physic.enable_gravity(false);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 bool

--- a/src/badguy/plant.cpp
+++ b/src/badguy/plant.cpp
@@ -37,7 +37,7 @@ Plant::initialize()
 
   state = PLANT_SLEEPING;
   m_physic.set_velocity_x(0);
-  m_sprite->set_action("sleeping", m_dir);
+  set_action("sleeping", m_dir);
 }
 
 void
@@ -47,7 +47,7 @@ Plant::collision_solid(const CollisionHit& hit)
     m_physic.set_velocity_y(0);
   } else if (hit.left || hit.right) {
     m_dir = m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
     m_physic.set_velocity_x(-m_physic.get_velocity_x());
   }
 }
@@ -59,7 +59,7 @@ Plant::collision_badguy(BadGuy& , const CollisionHit& hit)
 
   if (hit.left || hit.right) {
     m_dir = m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
     m_physic.set_velocity_x(-m_physic.get_velocity_x());
   }
 
@@ -83,7 +83,7 @@ Plant::active_update(float dt_sec) {
 
       if (inReach_left && inReach_right && inReach_top && inReach_bottom) {
         // wake up
-        m_sprite->set_action("waking", m_dir);
+        set_action("waking", m_dir);
         if (!timer.started()) timer.start(WAKE_TIME);
         state = PLANT_WAKING;
       }
@@ -93,7 +93,7 @@ Plant::active_update(float dt_sec) {
   if (state == PLANT_WAKING) {
     if (timer.check()) {
       // start walking
-      m_sprite->set_action(m_dir);
+      set_action(m_dir);
       m_physic.set_velocity_x(m_dir == Direction::LEFT ? -PLANT_SPEED : PLANT_SPEED);
       state = PLANT_WALKING;
     }
@@ -106,7 +106,7 @@ Plant::ignite()
 {
   BadGuy::ignite();
   if (state == PLANT_SLEEPING && m_sprite->has_action("sleeping-burning-left")) {
-    m_sprite->set_action("sleeping-burning", m_dir, 1);
+    set_action("sleeping-burning", m_dir, 1);
   }
 }
 /* EOF */

--- a/src/badguy/scrystallo.cpp
+++ b/src/badguy/scrystallo.cpp
@@ -41,7 +41,7 @@ SCrystallo::initialize()
 {
   state = SCRYSTALLO_SLEEPING;
   m_physic.enable_gravity(false);
-  m_sprite->set_action("editor", m_dir);
+  set_action("editor", m_dir);
 }
 
 ObjectSettings
@@ -96,7 +96,7 @@ SCrystallo::active_update(float dt_sec)
       Vector dist = (p2 - p1);
       if (glm::length(dist) <= m_range)
       {
-        m_sprite->set_action("waking", m_dir, 1);
+        set_action("waking", m_dir, 1);
         state = SCRYSTALLO_WAKING;
       }
     }

--- a/src/badguy/skullyhop.cpp
+++ b/src/badguy/skullyhop.cpp
@@ -36,7 +36,7 @@ SkullyHop::initialize()
 {
   // initial state is JUMPING, because we might start airborne
   state = JUMPING;
-  m_sprite->set_action("jumping", m_dir);
+  set_action("jumping", m_dir);
 }
 
 void
@@ -45,15 +45,15 @@ SkullyHop::set_state(SkullyHopState newState)
   if (newState == STANDING) {
     m_physic.set_velocity_x(0);
     m_physic.set_velocity_y(0);
-    m_sprite->set_action("standing", m_dir);
+    set_action("standing", m_dir);
 
     recover_timer.start(0.5);
   } else
     if (newState == CHARGING) {
-      m_sprite->set_action("charging", m_dir, 1);
+      set_action("charging", m_dir, 1);
     } else
       if (newState == JUMPING) {
-        m_sprite->set_action("jumping", m_dir);
+        set_action("jumping", m_dir);
 const float HORIZONTAL_SPEED = 220; /**< x-speed when jumping */
         m_physic.set_velocity_x(m_dir == Direction::LEFT ? -HORIZONTAL_SPEED : HORIZONTAL_SPEED);
 const float VERTICAL_SPEED = -450;   /**< y-speed when jumping */
@@ -70,7 +70,7 @@ SkullyHop::collision_squished(GameObject& object)
   if (m_frozen)
     return BadGuy::collision_squished(object);
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }
@@ -105,7 +105,7 @@ SkullyHop::collision_solid(const CollisionHit& hit)
   // check if we hit left or right while moving in either direction
   if (hit.left || hit.right) {
     m_dir = m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action("jumping", m_dir);
+    set_action("jumping", m_dir);
     m_physic.set_velocity_x(-0.25f*m_physic.get_velocity_x());
   }
 }

--- a/src/badguy/skydive.cpp
+++ b/src/badguy/skydive.cpp
@@ -29,7 +29,7 @@ SkyDive::SkyDive(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/skydive/skydive.sprite")
 {
   SoundManager::current()->preload("sounds/explosion.wav");
-  m_sprite->set_action("normal", 1);
+  set_action("normal", 1);
 }
 
 void
@@ -114,7 +114,7 @@ SkyDive::ungrab(MovingObject& object, Direction dir_)
   }
   else if (!m_frozen)
   {
-    m_sprite->set_action("falling", 1);
+    set_action("falling", 1);
     m_physic.set_velocity_y(0);
     m_physic.set_acceleration_y(0);
   }

--- a/src/badguy/smartball.cpp
+++ b/src/badguy/smartball.cpp
@@ -28,7 +28,7 @@ SmartBall::SmartBall(const ReaderMapping& reader)
 bool
 SmartBall::collision_squished(GameObject& object)
 {
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -65,7 +65,7 @@ void
 Snail::be_flat()
 {
   state = STATE_FLAT;
-  m_sprite->set_action("flat", m_dir, /* loops = */ -1);
+  set_action("flat", m_dir, /* loops = */ -1);
 
   m_physic.set_velocity_x(0);
   m_physic.set_velocity_y(0);
@@ -77,7 +77,7 @@ void
 Snail::be_grabbed()
 {
   state = STATE_GRABBED;
-  m_sprite->set_action("flat", m_dir, /* loops = */ -1);
+  set_action("flat", m_dir, /* loops = */ -1);
 }
 
 void
@@ -87,7 +87,7 @@ Snail::be_kicked(bool upwards)
     state = STATE_KICKED_DELAY;
   else
     state = STATE_KICKED;
-  m_sprite->set_action("flat", m_dir, /* loops = */ -1);
+  set_action("flat", m_dir, /* loops = */ -1);
 
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -SNAIL_KICK_SPEED : SNAIL_KICK_SPEED);
   m_physic.set_velocity_y(0);
@@ -101,11 +101,12 @@ void
 Snail::wake_up()
 {
   state = STATE_WAKING;
-  m_sprite->set_action(m_dir == Direction::LEFT ? "waking-left" : "waking-right", /* loops = */ 1);
+  set_action("waking", m_dir, /* loops = */ 1);
 }
 
 bool
-Snail::can_break() const {
+Snail::can_break() const
+{
   return state == STATE_KICKED;
 }
 
@@ -186,7 +187,7 @@ Snail::collision_solid(const CollisionHit& hit)
 
         if ( ( m_dir == Direction::LEFT && hit.left ) || ( m_dir == Direction::RIGHT && hit.right) ){
           m_dir = (m_dir == Direction::LEFT) ? Direction::RIGHT : Direction::LEFT;
-          m_sprite->set_action("flat", m_dir, /* loops = */ -1);
+          set_action("flat", m_dir, /* loops = */ -1);
 
           m_physic.set_velocity_x(-m_physic.get_velocity_x());
         }

--- a/src/badguy/snowball.cpp
+++ b/src/badguy/snowball.cpp
@@ -34,7 +34,7 @@ SnowBall::SnowBall(const Vector& pos, Direction d, const std::string& script)
 bool
 SnowBall::collision_squished(GameObject& object)
 {
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }

--- a/src/badguy/spidermite.cpp
+++ b/src/badguy/spidermite.cpp
@@ -33,7 +33,7 @@ SpiderMite::SpiderMite(const ReaderMapping& reader) :
 void
 SpiderMite::initialize()
 {
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
   mode = FLY_UP;
   m_physic.set_velocity_y(MOVE_SPEED);
   timer.start(FLYTIME/2);
@@ -45,7 +45,7 @@ SpiderMite::collision_squished(GameObject& object)
   if (m_frozen)
     return BadGuy::collision_squished(object);
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }
@@ -83,7 +83,7 @@ SpiderMite::active_update(float dt_sec)
   auto player = get_nearest_player();
   if (player) {
     m_dir = (player->get_pos().x > get_pos().x) ? Direction::RIGHT : Direction::LEFT;
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
   }
 }
 

--- a/src/badguy/sspiky.cpp
+++ b/src/badguy/sspiky.cpp
@@ -31,7 +31,7 @@ SSpiky::initialize()
 {
   state = SSPIKY_SLEEPING;
   m_physic.set_velocity_x(0);
-  m_sprite->set_action("sleeping", m_dir);
+  set_action("sleeping", m_dir);
 }
 
 void
@@ -74,7 +74,7 @@ SSpiky::active_update(float dt_sec) {
 
       if (inReach_left && inReach_right && inReach_top && inReach_bottom) {
         // wake up
-        m_sprite->set_action("waking", m_dir, 1);
+        set_action("waking", m_dir, 1);
         state = SSPIKY_WAKING;
       }
     }

--- a/src/badguy/stalactite.cpp
+++ b/src/badguy/stalactite.cpp
@@ -118,7 +118,7 @@ Stalactite::squish()
   m_physic.set_velocity_x(0);
   m_physic.set_velocity_y(0);
   set_state(STATE_SQUISHED);
-  m_sprite->set_action("squished");
+  set_action("squished");
   SoundManager::current()->play("sounds/icecrash.ogg", get_pos());
   set_group(COLGROUP_MOVING_ONLY_STATIC);
   run_dead_script();

--- a/src/badguy/stumpy.cpp
+++ b/src/badguy/stumpy.cpp
@@ -56,7 +56,7 @@ Stumpy::initialize()
 {
   switch (mystate) {
     case STATE_INVINCIBLE:
-      m_sprite->set_action("dizzy", m_dir);
+      set_action("dizzy", m_dir);
       m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
       m_physic.set_velocity_x(0);
       break;
@@ -99,7 +99,7 @@ Stumpy::collision_squished(GameObject& object)
 
   // if we can die, we do
   if (mystate == STATE_NORMAL) {
-    m_sprite->set_action("squished", m_dir);
+    set_action("squished", m_dir);
     m_col.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
     kill_squished(object);
     // spawn some particles

--- a/src/badguy/toad.cpp
+++ b/src/badguy/toad.cpp
@@ -40,7 +40,7 @@ Toad::initialize()
 {
   // initial state is JUMPING, because we might start airborne
   state = JUMPING;
-  m_sprite->set_action("jumping", m_dir);
+  set_action("jumping", m_dir);
 }
 
 void
@@ -50,12 +50,12 @@ Toad::set_state(ToadState newState)
     m_physic.set_velocity_x(0);
     m_physic.set_velocity_y(0);
     if (!m_frozen)
-      m_sprite->set_action("idle", m_dir);
+      set_action("idle", m_dir);
 
     recover_timer.start(TOAD_RECOVER_TIME);
   } else
     if (newState == JUMPING) {
-      m_sprite->set_action("jumping", m_dir);
+      set_action("jumping", m_dir);
       m_physic.set_velocity_x(m_dir == Direction::LEFT ? -HORIZONTAL_SPEED : HORIZONTAL_SPEED);
       m_physic.set_velocity_y(VERTICAL_SPEED);
       SoundManager::current()->play( HOP_SOUND, get_pos());
@@ -65,7 +65,7 @@ Toad::set_state(ToadState newState)
         // face player
         if (player && (player->get_bbox().get_right() < m_col.m_bbox.get_left()) && (m_dir == Direction::RIGHT)) m_dir = Direction::LEFT;
         if (player && (player->get_bbox().get_left() > m_col.m_bbox.get_right()) && (m_dir == Direction::LEFT)) m_dir = Direction::RIGHT;
-        m_sprite->set_action("idle", m_dir);
+        set_action("idle", m_dir);
       }
 
   state = newState;
@@ -76,7 +76,7 @@ Toad::collision_squished(GameObject& object)
 {
   if (m_frozen)
     return BadGuy::collision_squished(object);
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }

--- a/src/badguy/totem.cpp
+++ b/src/badguy/totem.cpp
@@ -61,11 +61,11 @@ Totem::initialize()
   if (!carried_by) {
 static const float WALKSPEED = 100;
     m_physic.set_velocity_x(m_dir == Direction::LEFT ? -WALKSPEED : WALKSPEED);
-    m_sprite->set_action("walking", m_dir);
+    set_action("walking", m_dir);
     return;
   } else {
     synchronize_with(carried_by);
-    m_sprite->set_action("stacked", m_dir);
+    set_action("stacked", m_dir);
     return;
   }
 }
@@ -133,7 +133,7 @@ Totem::collision_squished(GameObject& object)
     jump_off();
   }
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
 
   kill_squished(object);
@@ -251,7 +251,7 @@ Totem::synchronize_with(Totem* base)
 
   if (m_dir != base->m_dir) {
     m_dir = base->m_dir;
-    m_sprite->set_action("stacked", m_dir);
+    set_action("stacked", m_dir);
   }
 
   Vector pos = base->get_pos();

--- a/src/badguy/treewillowisp.cpp
+++ b/src/badguy/treewillowisp.cpp
@@ -66,7 +66,7 @@ void
 TreeWillOWisp::vanish()
 {
   mystate = STATE_VANISHING;
-  m_sprite->set_action("vanishing", 1);
+  set_action("vanishing", 1);
   set_colgroup_active(COLGROUP_DISABLED);
 
   if (m_parent_dispenser != nullptr)

--- a/src/badguy/viciousivy.cpp
+++ b/src/badguy/viciousivy.cpp
@@ -52,9 +52,9 @@ ViciousIvy::active_update(float dt_sec)
     bool float_here = (Sector::get().is_free_of_statics(floatbox));
 
     if (!float_here) {
-      m_sprite->set_action(m_dir == Direction::LEFT ? "left" : "right");
+      set_action(m_dir);
     } else {
-      m_sprite->set_action(m_dir == Direction::LEFT ? "float-left" : "float-right");
+      set_action("float", m_dir);
       if (m_physic.get_velocity_y() >= 35.f) {
         m_physic.set_velocity_y(35.f);
       }
@@ -70,7 +70,7 @@ ViciousIvy::collision_squished(GameObject& object)
   if (m_frozen)
     return WalkingBadguy::collision_squished(object);
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   // Spawn death particles
   spawn_explosion_sprites(3, "images/particles/viciousivy.sprite");
   kill_squished(object);

--- a/src/badguy/walking_badguy.cpp
+++ b/src/badguy/walking_badguy.cpp
@@ -74,7 +74,7 @@ WalkingBadguy::initialize()
 {
   if (m_frozen)
     return;
-  m_sprite->set_action(m_dir == Direction::LEFT ? walk_left_action : walk_right_action);
+  set_action(m_dir == Direction::LEFT ? walk_left_action : walk_right_action);
   m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -walk_speed : walk_speed);
   m_physic.set_acceleration_x (0.0);
@@ -203,7 +203,7 @@ WalkingBadguy::turn_around()
     return;
   m_dir = m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT;
   if (get_state() == STATE_INIT || get_state() == STATE_INACTIVE || get_state() == STATE_ACTIVE) {
-    m_sprite->set_action(m_dir == Direction::LEFT ? walk_left_action : walk_right_action);
+    set_action(m_dir == Direction::LEFT ? walk_left_action : walk_right_action);
   }
   m_physic.set_velocity_x(-m_physic.get_velocity_x());
   m_physic.set_acceleration_x (-m_physic.get_acceleration_x ());

--- a/src/badguy/walkingleaf.cpp
+++ b/src/badguy/walkingleaf.cpp
@@ -36,10 +36,10 @@ WalkingLeaf::active_update(float dt_sec)
     bool float_here = (Sector::get().is_free_of_statics(floatbox));
 
     if (!float_here) {
-      m_sprite->set_action(m_dir == Direction::LEFT ? "left" : "right");
+      set_action(m_dir);
     }
     else {
-      m_sprite->set_action(m_dir == Direction::LEFT ? "float-left" : "float-right");
+      set_action("float", m_dir);
       if (m_physic.get_velocity_y() >= 35.f) {
         m_physic.set_velocity_y(35.f);
       }
@@ -55,7 +55,7 @@ WalkingLeaf::collision_squished(GameObject& object)
   if (m_frozen)
     return WalkingBadguy::collision_squished(object);
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   // Spawn death particles
   spawn_explosion_sprites(3, "images/particles/walkingleaf.sprite");
   kill_squished(object);

--- a/src/badguy/willowisp.cpp
+++ b/src/badguy/willowisp.cpp
@@ -85,7 +85,7 @@ WillOWisp::WillOWisp(const ReaderMapping& reader) :
   m_sprite->set_color(m_color);
   m_glowing = true;
 
-  m_sprite->set_action("idle");
+  set_action("idle");
 }
 
 void
@@ -215,7 +215,7 @@ void
 WillOWisp::vanish()
 {
   m_mystate = STATE_VANISHING;
-  m_sprite->set_action("vanishing", 1);
+  set_action("vanishing", 1);
   set_colgroup_active(COLGROUP_DISABLED);
 
   if (m_parent_dispenser != nullptr)
@@ -247,7 +247,7 @@ WillOWisp::collision_player(Player& player, const CollisionHit& ) {
     return ABORT_MOVE;
 
   m_mystate = STATE_WARPING;
-  m_sprite->set_action("warping", 1);
+  set_action("warping", 1);
 
   if (!m_hit_script.empty()) {
     Sector::get().run_script(m_hit_script, "hit-script");

--- a/src/badguy/yeti.cpp
+++ b/src/badguy/yeti.cpp
@@ -160,7 +160,7 @@ Yeti::active_update(float dt_sec)
     case BE_ANGRY:
       if (state_timer.check() && on_ground()) {
         m_physic.set_velocity_y(STOMP_VY);
-        m_sprite->set_action("stomp", m_dir);
+        set_action("stomp", m_dir);
         SoundManager::current()->play("sounds/yeti_gna.wav", get_pos());
       }
       break;
@@ -173,7 +173,7 @@ Yeti::active_update(float dt_sec)
           Sector::get().get_camera().shake(.05f, 0, 5);
         }
         m_dir = newdir;
-        m_sprite->set_action("jump", m_dir);
+        set_action("jump", m_dir);
       }
       if (state_timer.check()) {
         BadGuy::kill_fall();
@@ -196,7 +196,7 @@ Yeti::active_update(float dt_sec)
 void
 Yeti::jump_down()
 {
-  m_sprite->set_action("jump", m_dir);
+  set_action("jump", m_dir);
   m_physic.set_velocity_x((m_dir==Direction::RIGHT)?(+JUMP_DOWN_VX):(-JUMP_DOWN_VX));
   m_physic.set_velocity_y(JUMP_DOWN_VY);
   state = JUMP_DOWN;
@@ -205,7 +205,7 @@ Yeti::jump_down()
 void
 Yeti::run()
 {
-  m_sprite->set_action("walking", m_dir);
+  set_action("walking", m_dir);
   m_physic.set_velocity_x((m_dir==Direction::RIGHT)?(+RUN_VX):(-RUN_VX));
   m_physic.set_velocity_y(0);
   state = RUN;
@@ -214,7 +214,7 @@ Yeti::run()
 void
 Yeti::jump_up()
 {
-  m_sprite->set_action("jump", m_dir);
+  set_action("jump", m_dir);
   m_physic.set_velocity_x((m_dir==Direction::RIGHT)?(+JUMP_UP_VX):(-JUMP_UP_VX));
   m_physic.set_velocity_y(JUMP_UP_VY);
   state = JUMP_UP;
@@ -226,7 +226,7 @@ Yeti::be_angry()
   //turn around
   m_dir = (m_dir==Direction::RIGHT) ? Direction::LEFT : Direction::RIGHT;
 
-  m_sprite->set_action("stand", m_dir);
+  set_action("stand", m_dir);
   m_physic.set_velocity_x(0);
   stomp_count = 0;
   state = BE_ANGRY;
@@ -330,7 +330,7 @@ Yeti::collision_solid(const CollisionHit& hit)
       case BE_ANGRY:
         // we just landed
         if (!state_timer.started()) {
-          m_sprite->set_action((m_dir==Direction::RIGHT)?"stand-right":"stand-left");
+          set_action("stand", m_dir);
           stomp_count++;
           drop_stalactite();
 

--- a/src/badguy/yeti_stalactite.cpp
+++ b/src/badguy/yeti_stalactite.cpp
@@ -59,7 +59,7 @@ YetiStalactite::update(float dt_sec)
     set_state(STATE_ACTIVE);
     state = STALACTITE_HANGING;
     // Hopefully we shouldn't come into contact with anything...
-    m_sprite->set_action("normal");
+    set_action("normal");
     set_pos(m_start_position);
     set_colgroup_active(COLGROUP_TOUCHABLE);
   }
@@ -75,7 +75,7 @@ YetiStalactite::draw(DrawingContext& context)
       m_sprite->get_action() != "yeti-stalactite" &&
       m_sprite->has_action("yeti-stalactite"))
   {
-    m_sprite->set_action("yeti-stalactite");
+    set_action("yeti-stalactite");
     BadGuy::draw(context);
     return;
   }

--- a/src/badguy/zeekling.cpp
+++ b/src/badguy/zeekling.cpp
@@ -39,7 +39,7 @@ void
 Zeekling::initialize()
 {
   m_physic.set_velocity_x(m_dir == Direction::LEFT ? -speed : speed);
-  m_sprite->set_action(m_dir);
+  set_action(m_dir);
 }
 
 bool
@@ -48,7 +48,7 @@ Zeekling::collision_squished(GameObject& object)
   if (m_frozen)
     return BadGuy::collision_squished(object);
 
-  m_sprite->set_action("squished", m_dir);
+  set_action("squished", m_dir);
   kill_squished(object);
   return true;
 }
@@ -58,19 +58,19 @@ Zeekling::onBumpHorizontal()
 {
   if (state == FLYING) {
     m_dir = (m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT);
-    m_sprite->set_action(m_dir);
+    set_action(m_dir);
     m_physic.set_velocity_x(m_dir == Direction::LEFT ? -speed : speed);
   } else
     if (state == DIVING) {
       m_dir = (m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT);
       state = FLYING;
-      m_sprite->set_action(m_dir);
+      set_action(m_dir);
       m_physic.set_velocity_x(m_dir == Direction::LEFT ? -speed : speed);
       m_physic.set_velocity_y(0);
     } else
       if (state == CLIMBING) {
         m_dir = (m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT);
-        m_sprite->set_action(m_dir);
+        set_action(m_dir);
         m_physic.set_velocity_x(m_dir == Direction::LEFT ? -speed : speed);
       } else {
         assert(false);
@@ -92,7 +92,7 @@ Zeekling::onBumpVertical()
     if (state == DIVING) {
       state = CLIMBING;
       m_physic.set_velocity_y(-speed);
-      m_sprite->set_action(m_dir);
+      set_action(m_dir);
     } else
       if (state == CLIMBING) {
         state = FLYING;
@@ -181,7 +181,7 @@ Zeekling::active_update(float dt_sec) {
     if (should_we_dive()) {
       state = DIVING;
       m_physic.set_velocity_y(2*fabsf(m_physic.get_velocity_x()));
-      m_sprite->set_action("diving", m_dir);
+      set_action("diving", m_dir);
     }
     BadGuy::active_update(dt_sec);
     return;

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -37,7 +37,7 @@ MovingSprite::MovingSprite(const Vector& pos, const std::string& sprite_name_,
   m_flip(NO_FLIP)
 {
   m_col.m_bbox.set_pos(pos);
-  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
   set_group(collision_group);
 }
 
@@ -55,7 +55,7 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const Vector& pos, int l
 
   //m_default_sprite_name = m_sprite_name;
   m_sprite = SpriteManager::current()->create(m_sprite_name);
-  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
   set_group(collision_group);
 }
 
@@ -82,7 +82,7 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const std::string& sprit
       m_sprite = SpriteManager::current()->create(m_default_sprite_name);
   }
 
-  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
   set_group(collision_group);
 }
 
@@ -101,7 +101,7 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, int layer_, CollisionGro
 
   //m_default_sprite_name = m_sprite_name;
   m_sprite = SpriteManager::current()->create(m_sprite_name);
-  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
   set_group(collision_group);
 }
 
@@ -123,10 +123,37 @@ MovingSprite::get_sprite_name() const
 }
 
 void
-MovingSprite::set_action(const std::string& action, int loops)
+MovingSprite::update_hitbox()
 {
-  m_sprite->set_action(action, loops);
   m_col.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+}
+
+void
+MovingSprite::set_action(const std::string& name, int loops)
+{
+  m_sprite->set_action(name, loops);
+  update_hitbox();
+}
+
+void
+MovingSprite::set_action(const std::string& name, const Direction& dir, int loops)
+{
+  m_sprite->set_action(name, dir, loops);
+  update_hitbox();
+}
+
+void
+MovingSprite::set_action(const Direction& dir, const std::string& name, int loops)
+{
+  m_sprite->set_action(dir, name, loops);
+  update_hitbox();
+}
+
+void
+MovingSprite::set_action(const Direction& dir, int loops)
+{
+  m_sprite->set_action(dir, loops);
+  update_hitbox();
 }
 
 void
@@ -134,7 +161,7 @@ MovingSprite::set_action_centered(const std::string& action, int loops)
 {
   Vector old_size = m_col.m_bbox.get_size().as_vector();
   m_sprite->set_action(action, loops);
-  m_col.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
   set_pos(get_pos() - (m_col.m_bbox.get_size().as_vector() - old_size) / 2.0f);
 }
 
@@ -143,10 +170,9 @@ MovingSprite::set_action(const std::string& action, int loops, AnchorPoint ancho
 {
   Rectf old_bbox = m_col.m_bbox;
   m_sprite->set_action(action, loops);
-  float w = m_sprite->get_current_hitbox_width();
-  float h = m_sprite->get_current_hitbox_height();
-  m_col.set_size(w, h);
-  set_pos(get_anchor_pos(old_bbox, w, h, anchorPoint));
+  update_hitbox();
+  set_pos(get_anchor_pos(old_bbox, m_sprite->get_current_hitbox_width(),
+                         m_sprite->get_current_hitbox_height(), anchorPoint));
 }
 
 bool
@@ -187,7 +213,7 @@ MovingSprite::after_editor_set()
   m_sprite = SpriteManager::current()->create(m_sprite_name);
   m_sprite->set_action(current_action);
 
-  m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  update_hitbox();
 }
 
 void

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -67,7 +67,22 @@ public:
 
   /** Set new action for sprite and resize bounding box.  use with
       care as you can easily get stuck when resizing the bounding box. */
-  void set_action(const std::string& action, int loops = -1);
+  void set_action(const std::string& name, int loops = -1);
+
+  /** Sets the action from an action name and a particular direction
+      in the form of "name-direction", eg. "walk-left".
+   */
+  void set_action(const std::string& name, const Direction& dir, int loops = -1);
+
+  /** Sets the action from an action name and a particular direction
+      in the form of "direction-name", eg. "left-up".
+   */
+  void set_action(const Direction& dir, const std::string& name, int loops = -1);
+
+  /** Sets the action from a string from a particular direction
+      in the form of "direction", e.g. "left".
+   */
+  void set_action(const Direction& dir, int loops = -1);
 
   /** Set new action for sprite and re-center bounding box.  use with
       care as you can easily get stuck when resizing the bounding
@@ -78,6 +93,10 @@ public:
       anchorPoint.  use with care as you can easily get stuck when
       resizing the bounding box. */
   void set_action(const std::string& action, int loops, AnchorPoint anchorPoint);
+
+protected:
+  /** Update hitbox, based on sprite. */
+  void update_hitbox();
 
 protected:
   std::string m_sprite_name;

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1931,7 +1931,7 @@ Player::draw(DrawingContext& context)
     else if (m_climbing) {
       action = "climbgrow";
     }
-    m_sprite->set_action_continued(action + sa_postfix);
+    m_sprite->set_action(action + sa_postfix, Sprite::LOOPS_CONTINUED);
   }
   else if (m_stone) {
     m_sprite->set_action("earth-stone");
@@ -2025,7 +2025,7 @@ Player::draw(DrawingContext& context)
         m_idle_stage = 0;
         m_idle_timer.start(static_cast<float>(TIME_UNTIL_IDLE) / 1000.0f);
 
-        m_sprite->set_action_continued(sa_prefix+("-" + IDLE_STAGES[m_idle_stage])+sa_postfix);
+        m_sprite->set_action(sa_prefix+("-" + IDLE_STAGES[m_idle_stage])+sa_postfix, Sprite::LOOPS_CONTINUED);
       }
       else if (m_idle_timer.check() || m_sprite->animation_done()) {
         m_idle_stage++;
@@ -2041,7 +2041,7 @@ Player::draw(DrawingContext& context)
         }
       }
       else {
-        m_sprite->set_action_continued(sa_prefix+("-" + IDLE_STAGES[m_idle_stage])+sa_postfix);
+        m_sprite->set_action(sa_prefix+("-" + IDLE_STAGES[m_idle_stage])+sa_postfix, Sprite::LOOPS_CONTINUED);
       }
     }
     else {

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -70,6 +70,12 @@ Sprite::set_action(const std::string& name, const Direction& dir, int loops)
 }
 
 void
+Sprite::set_action(const Direction& dir, const std::string& name, int loops)
+{
+  set_action(dir_to_string(dir) + "-" + name, loops);
+}
+
+void
 Sprite::set_action(const Direction& dir, int loops)
 {
   set_action(dir_to_string(dir), loops);
@@ -87,6 +93,14 @@ Sprite::set_action(const std::string& name, int loops)
     return;
   }
 
+  // The action's loops were set to continued; use the ones from the previous action.
+  if (loops == LOOPS_CONTINUED)
+  {
+    m_action = newaction;
+    update();
+    return;
+  }
+
   // If the new action has a loops property,
   // we prefer that over the parameter.
   m_animation_loops = newaction->has_custom_loops ? newaction->loops : loops;
@@ -98,22 +112,6 @@ Sprite::set_action(const std::string& name, int loops)
   }
 
   m_action = newaction;
-}
-
-void
-Sprite::set_action_continued(const std::string& name)
-{
-  if (m_action && m_action->name == name)
-    return;
-
-  const SpriteData::Action* newaction = m_data.get_action(name);
-  if (!newaction) {
-    log_debug << "Action '" << name << "' not found." << std::endl;
-    return;
-  }
-
-  m_action = newaction;
-  update();
 }
 
 bool

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -26,6 +26,11 @@
 class Sprite final
 {
 public:
+  enum Loops {
+    LOOPS_CONTINUED = -100
+  };
+
+public:
   Sprite(SpriteData& data);
   ~Sprite();
 
@@ -39,17 +44,19 @@ public:
   void set_action(const std::string& name, int loops = -1);
 
   /** Composes action (or state) string from an action name and a particular direction
-   * in the form of "name-direction", eg. "walk-left" 
+   * in the form of "name-direction", eg. "walk-left"
    */
   void set_action(const std::string& name, const Direction& dir, int loops = -1);
+
+  /** Composes action (or state) string from an action name and a particular direction
+   * in the form of "direction-name", eg. "left-up"
+   */
+  void set_action(const Direction& dir, const std::string& name, int loops = -1);
 
   /** Composes action (or state) string from a particular direction
    * in the form of "direction", e.g. "left"
    */
   void set_action(const Direction& dir, int loops = -1);
-
-  /** Set action (or state), but keep current frame number, loop counter, etc. */
-  void set_action_continued(const std::string& name);
 
   /** Set number of animation cycles until animation stops */
   void set_animation_loops(int loops = -1) { m_animation_loops = loops; }


### PR DESCRIPTION
Previously, many badguys were calling the `set_action()` function on their sprite (`m_sprite`) directly, instead of executing the function with the same name from their parent `MovingSprite` class, which also updates the hitbox size, alongside changing the sprite.

The overloads of `set_action()`, which allow for a `Direction` to be provided as a parameter, were also implemented in `MovingSprite`.

The `Sprite::set_action_continued()` function was removed and its functionality was moved into `Sprite::set_action()`, where an enumerator is provided as `loops` to specify if the action's loops should be continued. This allows for using the `Direction` overloads to set continued actions as well.

Fixes #2339.