### PR TITLE
Bump `CC-BY-SA` to 4.0 in `supertux2.appdata.xml`

### DIFF
--- a/supertux2.appdata.xml
+++ b/supertux2.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>org.supertuxproject.SuperTux</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+ AND CC-BY-SA-2.0</project_license>
+  <project_license>GPL-3.0+ AND CC-BY-SA-4.0</project_license>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>


### PR DESCRIPTION
This is a fix for #2418 by increasing the `CC-BY-SA` version to 4.0.
`CC-BY-SA-4.0` is considered a "free" license which results in the warning disappearing on Discover.

Before fix
![image](https://user-images.githubusercontent.com/63363329/229577255-523b506b-d76a-4c7e-8177-77c1ef4abfd5.png)
After fix
![image](https://github.com/SuperTux/supertux/assets/63363329/ada4620f-7777-4e5c-bea6-51aeec10cc7d)
