### PR TITLE
Fix missing cstdint include

### DIFF
--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -17,6 +17,7 @@
 #ifndef HEADER_SUPERTUX_UTIL_READER_MAPPING_HPP
 #define HEADER_SUPERTUX_UTIL_READER_MAPPING_HPP
 
+#include <cstdint>
 #include <optional>
 
 #include "util/reader_iterator.hpp"


### PR DESCRIPTION
For some reason, compiling the game on some systems results in a compilation error due to a missing `#include <cstdint>` line in one of the files.

This PR fixes this issue.