### PR TITLE
Options for rock, portable trampoline, and potion bonus blocks.

### DIFF
--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -39,8 +39,11 @@ public:
     LIGHT,
     LIGHT_ON,
     TRAMPOLINE,
+    PORTABLE_TRAMPOLINE,
     RAIN,
-    EXPLODE
+    EXPLODE,
+    ROCK,
+    POTION
   };
 
 public:


### PR DESCRIPTION
Added editor options for creating bonus blocks that contain rocks, potions, or portable trampolines, which previously required use of the corresponding tiles or custom contents which were a hassle. 