### PR TITLE
Add the ability to get player input from the scripting API.

### DIFF
--- a/src/scripting/player.cpp
+++ b/src/scripting/player.cpp
@@ -16,9 +16,8 @@
 
 #include "scripting/player.hpp"
 
-#include "object/player.hpp"
-
 #include "control/controller.hpp"
+#include "object/player.hpp"
 
 namespace scripting {
 

--- a/src/scripting/player.cpp
+++ b/src/scripting/player.cpp
@@ -18,6 +18,8 @@
 
 #include "object/player.hpp"
 
+#include "control/controller.hpp"
+
 namespace scripting {
 
 bool
@@ -236,6 +238,27 @@ Player::get_action() const
 {
   SCRIPT_GUARD_DEFAULT;
   return object.get_action();
+}
+
+bool
+Player::get_input_pressed(const std::string& input)
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.get_controller().pressed(Control_from_string(input).value());
+}
+
+bool
+Player::get_input_held(const std::string& input)
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.get_controller().hold(Control_from_string(input).value());
+}
+
+bool
+Player::get_input_released(const std::string& input)
+{
+  SCRIPT_GUARD_DEFAULT;
+  return object.get_controller().released(Control_from_string(input).value());
 }
 
 } // namespace scripting

--- a/src/scripting/player.hpp
+++ b/src/scripting/player.hpp
@@ -211,6 +211,25 @@ public:
    * Gets the player's current action/animation.
    */
   std::string get_action() const;
+
+  /**
+   * Gets whether the current input on the keyboard/controller/touchpad has been pressed.
+   * @param string $input Can be “left”, “right”, “up”, “down”, “jump”, “action”, “start”, “escape”,
+      “menu-select”, “menu-select-space”, “menu-back”, “remove”, “cheat-menu”, “debug-menu”, “console”,
+      “peek-left”, “peek-right”, “peek-up” or “peek-down”.
+   */
+  bool get_input_pressed(const std::string& input);
+
+  /**
+   * Gets whether the current input on the keyboard/controller/touchpad is being held.
+   * @param string $input Valid values are listed above.
+   */
+  bool get_input_held(const std::string& input);
+  /**
+   * Gets whether the current input on the keyboard/controller/touchpad has been released.
+   * @param string $input Valid values are listed above.
+   */
+  bool get_input_released(const std::string& input);
 };
 
 } // namespace scripting

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -7356,6 +7356,99 @@ static SQInteger Player_get_action_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Player_get_input_pressed_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'get_input_pressed' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::Player* _this = reinterpret_cast<scripting::Player*> (data);
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    bool return_value = _this->get_input_pressed(arg0);
+
+    sq_pushbool(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_input_pressed'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_get_input_held_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'get_input_held' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::Player* _this = reinterpret_cast<scripting::Player*> (data);
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    bool return_value = _this->get_input_held(arg0);
+
+    sq_pushbool(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_input_held'"));
+    return SQ_ERROR;
+  }
+
+}
+
+static SQInteger Player_get_input_released_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'get_input_released' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::Player* _this = reinterpret_cast<scripting::Player*> (data);
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    bool return_value = _this->get_input_released(arg0);
+
+    sq_pushbool(vm, return_value);
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_input_released'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Rain_release_hook(SQUserPointer ptr, SQInteger )
 {
   scripting::Rain* _this = reinterpret_cast<scripting::Rain*> (ptr);
@@ -15272,6 +15365,27 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'get_action'");
+  }
+
+  sq_pushstring(v, "get_input_pressed", -1);
+  sq_newclosure(v, &Player_get_input_pressed_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".s");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_input_pressed'");
+  }
+
+  sq_pushstring(v, "get_input_held", -1);
+  sq_newclosure(v, &Player_get_input_held_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".s");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_input_held'");
+  }
+
+  sq_pushstring(v, "get_input_released", -1);
+  sq_newclosure(v, &Player_get_input_released_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".s");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_input_released'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {


### PR DESCRIPTION
This adds `Tux.get_input_pressed(string input)`, `Tux.get_input_held(string input)`, and `Tux.get_input_released(string input)` to the scripting API. These functions can be used to get input from the players keyboard/controller/touch screen.