### PR TITLE
[QoL] More climbable tweaks

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2204,7 +2204,8 @@ Player::collision(GameObject& other, const CollisionHit& hit)
   if (moving_object->get_group() == COLGROUP_TOUCHABLE) {
     auto trigger = dynamic_cast<TriggerBase*> (&other);
     if (trigger && !m_deactivated) {
-      if (m_controller->pressed(Control::UP))
+      auto climbable = dynamic_cast<Climbable*> (&other);
+      if ((climbable && m_controller->hold(Control::UP)) || (m_controller->pressed(Control::UP)))
         trigger->event(*this, TriggerBase::EVENT_ACTIVATE);
     }
 

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2523,18 +2523,19 @@ Player::handle_input_climbing()
 
   float vx = 0;
   float vy = 0;
-  if (m_controller->hold(Control::LEFT)) {
+  auto obj_bbox = m_climbing->get_bbox();
+  if (m_controller->hold(Control::LEFT) && m_col.m_bbox.get_left() > obj_bbox.get_left()) {
     m_dir = Direction::LEFT;
     vx -= MAX_CLIMB_XM;
   }
-  if (m_controller->hold(Control::RIGHT)) {
+  if (m_controller->hold(Control::RIGHT) && m_col.m_bbox.get_right() < obj_bbox.get_right()) {
     m_dir = Direction::RIGHT;
     vx += MAX_CLIMB_XM;
   }
-  if (m_controller->hold(Control::UP) && m_col.m_bbox.get_top() > m_climbing->get_bbox().get_top()) {
+  if (m_controller->hold(Control::UP) && m_col.m_bbox.get_top() > obj_bbox.get_top()) {
     vy -= MAX_CLIMB_YM;
   }
-  if (m_controller->hold(Control::DOWN)) {
+  if (m_controller->hold(Control::DOWN) && m_col.m_bbox.get_bottom() < obj_bbox.get_bottom()) {
     vy += MAX_CLIMB_YM;
   }
   if (m_controller->hold(Control::JUMP)) {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2501,7 +2501,7 @@ Player::stop_climbing(Climbable& /*climbable*/)
   m_physic.set_velocity(0, 0);
   m_physic.set_acceleration(0, 0);
 
-  if (m_controller->hold(Control::JUMP)) {
+  if (m_controller->hold(Control::JUMP) && !m_controller->hold(Control::DOWN)) {
     m_on_ground_flag = true;
     m_jump_early_apex = false;
     do_jump(m_player_status.bonus[get_id()] == BonusType::AIR_BONUS ? -540.0f : -480.0f);
@@ -2545,10 +2545,6 @@ Player::handle_input_climbing()
     }
   } else {
     m_can_jump = true;
-  }
-  if (m_controller->hold(Control::ACTION)) {
-    stop_climbing(*m_climbing);
-    return;
   }
   m_physic.set_velocity(vx, vy);
   m_physic.set_acceleration(0, 0);

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2204,8 +2204,7 @@ Player::collision(GameObject& other, const CollisionHit& hit)
   if (moving_object->get_group() == COLGROUP_TOUCHABLE) {
     auto trigger = dynamic_cast<TriggerBase*> (&other);
     if (trigger && !m_deactivated) {
-      auto climbable = dynamic_cast<Climbable*> (&other);
-      if ((climbable && m_controller->hold(Control::UP)) || (m_controller->pressed(Control::UP)))
+      if (m_controller->pressed(Control::UP))
         trigger->event(*this, TriggerBase::EVENT_ACTIVATE);
     }
 

--- a/src/trigger/climbable.cpp
+++ b/src/trigger/climbable.cpp
@@ -148,7 +148,7 @@ Climbable::draw(DrawingContext& context)
 void
 Climbable::event(Player& player, EventType type)
 {
-  if (type == EVENT_ACTIVATE) {
+  if (type == EVENT_ACTIVATE || (type == EVENT_TOUCH && player.get_controller().hold(Control::UP))) {
     if (player.get_grabbed_object() == nullptr){
       auto it = std::find_if(trying_to_climb.begin(), trying_to_climb.end(),
         [&player](const ClimbPlayer& element)


### PR DESCRIPTION
This PR addresses the other climbable PR #1670 I made 2 years ago, as well as #1473 and #972, but partially.

Climbing zones now have a restriction to all 4 edges to prevent Tux from leaving without jumping. I also made it so you no longer leave without jumping by pressing the ACTION key, but rather by pressing DOWN + JUMP.

Possible improvement: checking for nearby climbable zones and disable boundaries that intersect directly with other zones.