### PR TITLE
Add physics to mole and set collision groups.

### DIFF
--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -37,7 +37,7 @@ Mole::Mole(const ReaderMapping& reader) :
   timer(),
   throw_timer()
 {
-  m_physic.enable_gravity(false);
+  m_physic.enable_gravity(true);
   SoundManager::current()->preload("sounds/fall.wav");
   SoundManager::current()->preload("sounds/squish.wav");
   SoundManager::current()->preload("sounds/dartfire.wav");
@@ -132,31 +132,31 @@ Mole::set_state(MoleState new_state)
   switch (new_state) {
     case PRE_THROWING:
       set_action("idle");
-      set_colgroup_active(COLGROUP_DISABLED);
+      set_colgroup_active(COLGROUP_MOVING_ONLY_STATIC);
       timer.start(MOLE_WAIT_TIME);
       break;
     case THROWING:
       set_action("idle");
-      set_colgroup_active(COLGROUP_DISABLED);
+      set_colgroup_active(COLGROUP_MOVING_ONLY_STATIC);
       timer.start(THROW_TIME);
       throw_timer.start(THROW_INTERVAL);
       break;
     case POST_THROWING:
       set_action("idle");
-      set_colgroup_active(COLGROUP_DISABLED);
+      set_colgroup_active(COLGROUP_MOVING_ONLY_STATIC);
       timer.start(MOLE_WAIT_TIME);
       break;
     case PEEKING:
       set_action("peeking", 1);
-      set_colgroup_active(COLGROUP_STATIC);
+      set_colgroup_active(COLGROUP_MOVING_STATIC);
       break;
     case DEAD:
       set_action("squished");
-      set_colgroup_active(COLGROUP_DISABLED);
+      set_colgroup_active(COLGROUP_MOVING_ONLY_STATIC);
       break;
     case BURNING:
       set_action("burning", 1);
-      set_colgroup_active(COLGROUP_DISABLED);
+      set_colgroup_active(COLGROUP_MOVING_ONLY_STATIC);
       break;
   }
 


### PR DESCRIPTION
@Rusty-Box said that placing moles in the editor requires precision to place correctly. With this fix, the mole can be 1 tile above and it will drop down to the ground just like if it was placed precisely.

Only minor issue is that the mole might be noticeable when falling. Maybe increase gravity on the mole?