### PR TITLE
(WIP) Improve OpenGL renderer performance

### DIFF
--- a/src/video/gl/gl_painter.hpp
+++ b/src/video/gl/gl_painter.hpp
@@ -43,6 +43,8 @@ public:
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;
 
+  void flush_batch();
+
 private:
   GLVideoSystem& m_video_system;
   GLRenderer& m_renderer;
@@ -50,6 +52,11 @@ private:
 private:
   std::vector<float> m_vertices;
   std::vector<float> m_uvs;
+  std::vector<float> m_vertex_cache;
+  std::vector<float> m_uv_cache;
+  std::vector<float> m_color_cache;
+  unsigned int m_current_texture_handle;
+  int m_srcrect_count;
 
 private:
   GLPainter(const GLPainter&) = delete;

--- a/src/video/gl/gl_screen_renderer.cpp
+++ b/src/video/gl/gl_screen_renderer.cpp
@@ -65,6 +65,9 @@ GLScreenRenderer::start_draw()
 void
 GLScreenRenderer::end_draw()
 {
+  auto& renderer = static_cast<GLScreenRenderer&>(m_video_system.get_renderer());
+  auto& painter = renderer.get_painter();
+  painter.flush_batch();
 }
 
 Rect


### PR DESCRIPTION
I noticed the OpenGL renderer for the game isn't very optimized, as it executes one draw call for every texture on screen (which is pretty bad).

This PR aims to improve the renderer by batching draw calls that use the same texture together.