### PR TITLE
Fix worldmap sector spawnpoint issues, testing from worldmap spawnpoints

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -341,7 +341,7 @@ Editor::test_level(const std::optional<std::pair<std::string, Vector>>& test_pos
   }
   else
   {
-    GameManager::current()->start_worldmap(*current_world, "", m_autosave_levelfile);
+    GameManager::current()->start_worldmap(*current_world, m_autosave_levelfile, test_pos);
   }
 }
 

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -90,8 +90,9 @@ void
 GameManager::start_worldmap(const World& world, const std::string& worldmap_filename,
                             const std::optional<std::pair<std::string, Vector>>& start_pos)
 {
-  start_worldmap(world, worldmap_filename, start_pos->first);
-  worldmap::WorldMapSector::current()->get_tux().set_pos(start_pos->second);
+  start_worldmap(world, worldmap_filename, start_pos ? start_pos->first : "");
+  if (start_pos)
+    worldmap::WorldMapSector::current()->get_tux().set_pos(start_pos->second);
 }
 
 bool

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -92,7 +92,7 @@ GameManager::start_worldmap(const World& world, const std::string& worldmap_file
 {
   start_worldmap(world, worldmap_filename, start_pos ? start_pos->first : "");
   if (start_pos)
-    worldmap::WorldMapSector::current()->get_tux().set_pos(start_pos->second);
+    worldmap::WorldMapSector::current()->get_tux().set_initial_pos(start_pos->second);
 }
 
 bool

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -28,6 +28,7 @@
 #include "util/reader.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
+#include "worldmap/tux.hpp"
 #include "worldmap/worldmap.hpp"
 #include "worldmap/worldmap_screen.hpp"
 
@@ -52,7 +53,8 @@ GameManager::start_level(const World& world, const std::string& level_filename,
 }
 
 void
-GameManager::start_worldmap(const World& world, const std::string& spawnpoint, const std::string& worldmap_filename)
+GameManager::start_worldmap(const World& world, const std::string& worldmap_filename,
+                            const std::string& sector, const std::string& spawnpoint)
 {
   try
   {
@@ -74,7 +76,7 @@ GameManager::start_worldmap(const World& world, const std::string& spawnpoint, c
       filename = world.get_worldmap_filename();
     }
 
-    auto worldmap = std::make_unique<worldmap::WorldMap>(filename, *m_savegame, spawnpoint);
+    auto worldmap = std::make_unique<worldmap::WorldMap>(filename, *m_savegame, sector, spawnpoint);
     auto worldmap_screen = std::make_unique<worldmap::WorldMapScreen>(std::move(worldmap));
     ScreenManager::current()->push_screen(std::move(worldmap_screen));
   }
@@ -82,6 +84,14 @@ GameManager::start_worldmap(const World& world, const std::string& spawnpoint, c
   {
     log_fatal << "Couldn't start world: " << e.what() << std::endl;
   }
+}
+
+void
+GameManager::start_worldmap(const World& world, const std::string& worldmap_filename,
+                            const std::optional<std::pair<std::string, Vector>>& start_pos)
+{
+  start_worldmap(world, worldmap_filename, start_pos->first);
+  worldmap::WorldMapSector::current()->get_tux().set_pos(start_pos->second);
 }
 
 bool

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -31,7 +31,10 @@ class GameManager final : public Currenton<GameManager>
 public:
   GameManager();
 
-  void start_worldmap(const World& world, const std::string& spawnpoint = "", const std::string& worldmap_filename = "");
+  void start_worldmap(const World& world, const std::string& worldmap_filename = "",
+                      const std::string& sector = "", const std::string& spawnpoint = "");
+  void start_worldmap(const World& world, const std::string& worldmap_filename,
+                      const std::optional<std::pair<std::string, Vector>>& start_pos);
   void start_level(const World& world, const std::string& level_filename,
                    const std::optional<std::pair<std::string, Vector>>& start_pos = std::nullopt);
 

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -805,7 +805,7 @@ GameSession::start_sequence(Player* caller, Sequence seq, const SequenceData* da
       }
       if (!data->spawnpoint.empty())
       {
-        worldmap_sector->set_initial_spawnpoint(data->spawnpoint);
+        worldmap_sector->get_worldmap().set_initial_spawnpoint(data->spawnpoint);
       }
     }
   }

--- a/src/worldmap/spawn_point.cpp
+++ b/src/worldmap/spawn_point.cpp
@@ -80,6 +80,8 @@ SpawnPointObject::get_settings()
 
   result.reorder({"auto-dir", "name", "x", "y"});
 
+  result.add_test_from_here();
+
   return result;
 }
 

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -46,7 +46,8 @@ Tux::Tux(WorldMap* worldmap) :
   m_controller(InputManager::current()->get_controller()),
   m_input_direction(Direction::NONE),
   m_direction(Direction::NONE),
-  m_tile_pos(0.0f, 0.0f),
+  m_initial_tile_pos(),
+  m_tile_pos(),
   m_offset(0),
   m_moving(false),
   m_ghost_mode(false)
@@ -371,6 +372,10 @@ Tux::update(float dt_sec)
 void
 Tux::setup()
 {
+  // Set initial tile position, if provided
+  if (m_initial_tile_pos != Vector())
+    m_tile_pos = m_initial_tile_pos;
+
   // check if we already touch a SpriteChange object
   auto sprite_change = m_worldmap->get_sector().at_object<SpriteChange>(m_tile_pos);
   change_sprite(sprite_change);

--- a/src/worldmap/tux.hpp
+++ b/src/worldmap/tux.hpp
@@ -51,7 +51,8 @@ public:
   Vector get_pos() const;
   Vector get_axis() const;
   Vector get_tile_pos() const { return m_tile_pos; }
-  void  set_tile_pos(const Vector& p) { m_tile_pos = p; }
+  void set_pos(const Vector& pos) { m_tile_pos = pos / 32.f; }
+  void set_tile_pos(const Vector& pos) { m_tile_pos = pos; }
 
   void process_special_tile(SpecialTile* special_tile);
 

--- a/src/worldmap/tux.hpp
+++ b/src/worldmap/tux.hpp
@@ -51,7 +51,7 @@ public:
   Vector get_pos() const;
   Vector get_axis() const;
   Vector get_tile_pos() const { return m_tile_pos; }
-  void set_pos(const Vector& pos) { m_tile_pos = pos / 32.f; }
+  void set_initial_pos(const Vector& pos) { m_initial_tile_pos = pos / 32.f; }
   void set_tile_pos(const Vector& pos) { m_tile_pos = pos; }
 
   void process_special_tile(SpecialTile* special_tile);
@@ -76,6 +76,7 @@ private:
 
   Direction m_input_direction;
   Direction m_direction;
+  Vector m_initial_tile_pos;
   Vector m_tile_pos;
   /** Length by which tux is away from its current tile, length is in
       input_direction direction */

--- a/src/worldmap/world_select.cpp
+++ b/src/worldmap/world_select.cpp
@@ -247,8 +247,7 @@ WorldSelect::update(float dt_sec, const Controller& controller)
   if (controller.pressed(Control::JUMP) && m_worlds[m_selected_world].unlocked) {
     m_enabled = false;
     ScreenManager::current()->pop_screen(std::make_unique<FadeToBlack>(FadeToBlack::Direction::FADEOUT, 0.25f));
-    worldmap::WorldMap::current()->change(m_worlds[m_selected_world].filename, "main");
-    log_warning << m_worlds[m_selected_world].filename << std::endl;
+    worldmap::WorldMap::current()->change(m_worlds[m_selected_world].filename, "", "main");
     return;
   }
 }

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -41,7 +41,8 @@ public:
   static Color s_teleporter_message_color;
 
 public:
-  WorldMap(const std::string& filename, Savegame& savegame, const std::string& force_spawnpoint = "");
+  WorldMap(const std::string& filename, Savegame& savegame,
+           const std::string& force_sector = "", const std::string& force_spawnpoint = "");
 
   void setup();
   void leave();
@@ -61,13 +62,17 @@ public:
 
   /** switch to another worldmap.
       filename is relative to data root path */
-  void change(const std::string& filename, const std::string& force_spawnpoint = "");
+  void change(const std::string& filename, const std::string& force_sector = "",
+              const std::string& force_spawnpoint = "");
 
   /** Mark all levels as solved or unsolved */
   void set_levels_solved(bool solved, bool perfect);
 
   /** Sets the passive message with specific time **/
   void set_passive_message(const std::string& message, float time);
+
+  /** Sets the initial spawnpoint to be forced on next setup */
+  void set_initial_spawnpoint(const std::string& spawnpoint);
 
   const std::string& get_title() const { return m_name; }
   Savegame& get_savegame() const { return m_savegame; }
@@ -87,6 +92,8 @@ private:
 private:
   WorldMapSector* m_sector; /* The currently active sector. */
   std::vector<std::unique_ptr<WorldMapSector> > m_sectors;
+
+  std::string m_force_spawnpoint;
 
   Savegame& m_savegame;
   TileSet* m_tileset;

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -64,8 +64,6 @@ WorldMapSector::WorldMapSector(WorldMap& parent) :
   m_camera(new Camera),
   m_tux(&add<Tux>(&parent)),
   m_spawnpoints(),
-  m_force_spawnpoint(),
-  m_main_is_default(true),
   m_initial_fade_tilemap(),
   m_fade_direction()
 {
@@ -130,14 +128,6 @@ WorldMapSector::setup()
   // register worldmap_table as "worldmap" in scripting
   m_squirrel_environment->expose_self();
   m_squirrel_environment->expose("settings", std::make_unique<scripting::WorldMapSector>(this));
-
-  /** Force spawnpoint, if the property is set. **/
-  if (!m_force_spawnpoint.empty())
-  {
-    move_to_spawnpoint(m_force_spawnpoint, false);
-    m_force_spawnpoint.clear();
-    m_main_is_default = true;
-  }
 
   /** Perform scripting related actions. **/
   // Run default.nut just before init script
@@ -290,7 +280,8 @@ WorldMapSector::update(float dt_sec)
       if (!teleporter->get_worldmap().empty())
       {
         // Change worldmap.
-        m_parent.change(teleporter->get_worldmap(), teleporter->get_spawnpoint());
+        m_parent.change(teleporter->get_worldmap(), teleporter->get_sector(),
+                        teleporter->get_spawnpoint());
       }
       else
       {
@@ -555,7 +546,7 @@ WorldMapSector::move_to_spawnpoint(const std::string& spawnpoint, bool pan)
   }
 
   log_warning << "Spawnpoint '" << spawnpoint << "' not found." << std::endl;
-  if (spawnpoint != "main" && m_main_is_default) {
+  if (spawnpoint != "main") {
     move_to_spawnpoint("main");
   }
 }
@@ -565,16 +556,6 @@ WorldMapSector::set_initial_fade_tilemap(const std::string& tilemap_name, int di
 {
   m_initial_fade_tilemap = tilemap_name;
   m_fade_direction = direction;
-}
-
-void
-WorldMapSector::set_initial_spawnpoint(const std::string& spawnpoint_name)
-{
-  m_force_spawnpoint = spawnpoint_name;
-
-  // If spawnpoint we specified can not be found,
-  // don't bother moving to the main spawnpoint.
-  m_main_is_default = false;
 }
 
 

--- a/src/worldmap/worldmap_sector.hpp
+++ b/src/worldmap/worldmap_sector.hpp
@@ -105,9 +105,6 @@ public:
   /** Sets the name of the tilemap that should fade when worldmap is set up. */
   void set_initial_fade_tilemap(const std::string& tilemap_name, int direction);
 
-  /** Sets the initial spawnpoint on worldmap setup */
-  void set_initial_spawnpoint(const std::string& spawnpoint_name);
-
   bool in_worldmap() const override { return true; }
 
   TileSet* get_tileset() const override;
@@ -127,11 +124,8 @@ private:
 
   std::unique_ptr<Camera> m_camera;
   Tux* m_tux;
-
   std::vector<std::unique_ptr<SpawnPoint> > m_spawnpoints;
-  std::string m_force_spawnpoint;
 
-  bool m_main_is_default;
   std::string m_initial_fade_tilemap;
   int m_fade_direction;
 

--- a/src/worldmap/worldmap_state.cpp
+++ b/src/worldmap/worldmap_state.cpp
@@ -101,7 +101,6 @@ WorldMapState::load_state()
     // Set default properties.
     if (!m_worldmap.m_sector)
       m_worldmap.set_sector("main", "", false); // If no current sector is present, set it to "main", or the default one.
-    m_worldmap.get_sector().move_to_spawnpoint("main"); // Move Tux to the "main" spawnpoint.
 
     // Create a new initial save.
     save_state();
@@ -147,7 +146,7 @@ WorldMapState::load_levels()
   WORLDMAP_STATE_SQUIRREL_VM_GUARD;
   WORLDMAP_STATE_SECTOR_GUARD;
 
-  vm.get_table_entry("levels");
+  vm.get_or_create_table_entry("levels");
   for (auto& level : sector.get_objects_by_type<LevelTile>()) {
     sq_pushstring(vm.get_vm(), level.get_level_filename().c_str(), -1);
     if (SQ_SUCCEEDED(sq_get(vm.get_vm(), -2)))


### PR DESCRIPTION
Fixes issues, related to loading a worldmap with a forced spawnpoint. It can now be set both with `set_initial_spawnpoint` on `WorldMap`, and by providing it to the initializer of the class. The forced spawnpoint overrides the saved Tux position state on the worldmap sector.

This PR also adds the ability to initialize a worldmap with a forced sector, allowing for teleporting on a different sector, other than "main", on a different worldmap.

Another addition is the "Test from here" option for worldmap spawnpoints. The worldmap will be tested from the current sector, Tux being on the position of the chosen spawnpoint to test from.