### PR TITLE
Fix oklab colour picker rendering when using SDL

### DIFF
--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -282,7 +282,7 @@ SDLPainter::draw_gradient(const GradientRequest& request)
     {
       rect.x = static_cast<int>(region.get_left());
       rect.y = static_cast<int>(region.get_top());
-      rect.w = static_cast<int>(region.get_right() - region.get_left());
+      rect.w = static_cast<int>(region.get_right() - region.get_left() + 1);
       rect.h = static_cast<int>(region.get_bottom() - region.get_top());
     }
     else if (direction == VERTICAL || direction == VERTICAL_SECTOR)

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -278,7 +278,14 @@ SDLPainter::draw_gradient(const GradientRequest& request)
   for (int i = 0; i < n; ++i)
   {
     SDL_Rect rect;
-    if (direction == VERTICAL || direction == VERTICAL_SECTOR)
+    if (region.get_left() || region.get_top())
+    {
+      rect.x = static_cast<int>(region.get_left());
+      rect.y = static_cast<int>(region.get_top());
+      rect.w = static_cast<int>(region.get_right() - region.get_left());
+      rect.h = static_cast<int>(region.get_bottom() - region.get_top());
+    }
+    else if (direction == VERTICAL || direction == VERTICAL_SECTOR)
     {
       rect.x = static_cast<int>(region.get_left());
       rect.y = static_cast<int>(region.get_bottom() * static_cast<float>(i) / static_cast<float>(n));

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -278,26 +278,20 @@ SDLPainter::draw_gradient(const GradientRequest& request)
   for (int i = 0; i < n; ++i)
   {
     SDL_Rect rect;
-    if (region.get_left() || region.get_top())
+
+    if (direction == VERTICAL || direction == VERTICAL_SECTOR)
     {
       rect.x = static_cast<int>(region.get_left());
-      rect.y = static_cast<int>(region.get_top());
-      rect.w = static_cast<int>(region.get_right() - region.get_left() + 1);
-      rect.h = static_cast<int>(region.get_bottom() - region.get_top());
-    }
-    else if (direction == VERTICAL || direction == VERTICAL_SECTOR)
-    {
-      rect.x = static_cast<int>(region.get_left());
-      rect.y = static_cast<int>(region.get_bottom() * static_cast<float>(i) / static_cast<float>(n));
-      rect.w = static_cast<int>(region.get_right());
-      rect.h = static_cast<int>((region.get_bottom() * static_cast<float>(i+1) / static_cast<float>(n)) - static_cast<float>(rect.y));
+      rect.y = static_cast<int>(region.get_top() + (region.get_bottom() - region.get_top()) * static_cast<float>(i) / static_cast<float>(n));
+      rect.w = static_cast<int>(region.get_right() - region.get_left());
+      rect.h = static_cast<int>(ceilf((region.get_bottom() - region.get_top()) / static_cast<float>(n)));
     }
     else
     {
-      rect.x = static_cast<int>(region.get_right() * static_cast<float>(i) / static_cast<float>(n));
+      rect.x = static_cast<int>(region.get_left() + (region.get_right() - region.get_left()) * static_cast<float>(i) / static_cast<float>(n));
       rect.y = static_cast<int>(region.get_top());
-      rect.w = static_cast<int>((region.get_right() * static_cast<float>(i+1) / static_cast<float>(n)) - static_cast<float>(rect.x));
-      rect.h = static_cast<int>(region.get_bottom());
+      rect.w = static_cast<int>(ceilf((region.get_right() - region.get_left()) / static_cast<float>(n)));
+      rect.h = static_cast<int>(region.get_bottom() - region.get_top());
     }
 
     float p = static_cast<float>(i+1) / static_cast<float>(n);


### PR DESCRIPTION
Fixes #2548 

This PR aims to fix a problem with sdl_painter.cpp that causes this issue. <s>For now, it's only a dirty fix. I'll try to come up with something better later. I'd also appreciate if others looked into it since I'm not sure I'll be able to find a proper fix myself. PRs into this branch are welcome.

![image](https://github.com/SuperTux/supertux/assets/14074789/d7c92598-8b24-4d7b-8c5d-3763b94d2cd3)

Problems:
a) it renders weird bars in the colour picker
b) this is a workaround, not a fix - it just doesn't recalculate coords when a gradient isn't at (0, 0), which, as far as I know, currently only applies to the oklab picker, but it's not a proper solution.</s>

**EDIT:**
 I figured it out. The maths in that function was all wrong, now it works properly, no dirty workarounds.

![image](https://github.com/SuperTux/supertux/assets/14074789/96171c6d-31f0-4512-9b6c-82d20cdcad6d)