### PR TITLE
Fix sprite fallback issues

### DIFF
--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -67,13 +67,10 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const std::string& sprit
     m_sprite = SpriteManager::current()->create(m_default_sprite_name);
     m_sprite_found = false;
   }
-  else
+  else if (!change_sprite(m_sprite_name)) // If sprite change fails, change back to default.
   {
-    if (!change_sprite(m_sprite_name)) // If sprite change fails, change back to default.
-    {
-      m_sprite = SpriteManager::current()->create(m_default_sprite_name);
-      m_sprite_found = false;
-    }
+    change_sprite(m_default_sprite_name);
+    m_sprite_found = false;
   }
 
   update_hitbox();
@@ -91,10 +88,8 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, int layer_, CollisionGro
 {
   reader.get("x", m_col.m_bbox.get_left());
   reader.get("y", m_col.m_bbox.get_top());
-  if (!reader.get("sprite", m_sprite_name))
-    throw std::runtime_error("no sprite name set");
+  m_sprite_found = reader.get("sprite", m_sprite_name);
 
-  m_sprite_found = true;
   //m_default_sprite_name = m_sprite_name;
   m_sprite = SpriteManager::current()->create(m_sprite_name);
   update_hitbox();
@@ -182,20 +177,10 @@ MovingSprite::set_action(const std::string& action, int loops, AnchorPoint ancho
 bool
 MovingSprite::change_sprite(const std::string& new_sprite_name)
 {
-  SpritePtr new_sprite;
-  try
-  {
-    new_sprite = SpriteManager::current()->create(m_sprite_name);
-  }
-  catch (std::exception& err)
-  {
-    log_warning << "Sprite change failed: Sprite '" << new_sprite_name << "' cannot be loaded: " << err.what() << std::endl;
-    return false;
-  }
-
-  m_sprite = std::move(new_sprite);
+  m_sprite = SpriteManager::current()->create(new_sprite_name);
   m_sprite_name = new_sprite_name;
-  return true;
+
+  return SpriteManager::current()->last_load_successful();
 }
 
 ObjectSettings
@@ -216,7 +201,10 @@ MovingSprite::after_editor_set()
   MovingObject::after_editor_set();
 
   std::string current_action = m_sprite->get_action();
-  m_sprite = SpriteManager::current()->create(m_sprite_name);
+  if (!change_sprite(m_sprite_name)) // If sprite change fails, change back to default.
+  {
+    change_sprite(m_default_sprite_name);
+  }
   m_sprite->set_action(current_action);
 
   update_hitbox();

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -27,9 +27,18 @@ class ReaderMapping;
 
 class SpriteData final
 {
+  friend class Sprite;
+
 public:
-  /** cur has to be a pointer to data in the form of ((hitbox 5 10 0 0) ...) */
-  SpriteData(const ReaderMapping& cur);
+  /**
+   * Sprite from data.
+   * `mapping` has to be a pointer to data in the form of "((hitbox 5 10 0 0) ...)".
+   */
+  SpriteData(const ReaderMapping& mapping);
+  /** Single-image sprite */
+  SpriteData(const std::string& image);
+  /** Dummy texture sprite */
+  SpriteData();
 
   const std::string& get_name() const
   {
@@ -37,8 +46,6 @@ public:
   }
 
 private:
-  friend class Sprite;
-
   struct Action
   {
     Action();
@@ -77,12 +84,15 @@ private:
     std::vector<SurfacePtr> surfaces;
   };
 
-  typedef std::map <std::string, std::unique_ptr<Action> > Actions;
+  typedef std::map<std::string, std::unique_ptr<Action> > Actions;
+
+  static std::unique_ptr<Action> create_action_from_surface(SurfacePtr surface);
 
   void parse_action(const ReaderMapping& mapping);
   /** Get an action */
   const Action* get_action(const std::string& act) const;
 
+private:
   Actions actions;
   std::string name;
 };

--- a/src/sprite/sprite_manager.cpp
+++ b/src/sprite/sprite_manager.cpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+//                2023 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -16,73 +17,93 @@
 
 #include "sprite/sprite_manager.hpp"
 
+#include <optional>
+#include <sstream>
+
 #include "sprite/sprite.hpp"
 #include "util/file_system.hpp"
+#include "util/log.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
 #include "util/string_util.hpp"
 
-#include <sstream>
+std::unique_ptr<SpriteData> SpriteManager::s_dummy_sprite_data = nullptr;
 
 SpriteManager::SpriteManager() :
-  sprites()
+  m_sprites(),
+  m_load_successful(false)
 {
+  if (!s_dummy_sprite_data)
+    s_dummy_sprite_data.reset(new SpriteData());
 }
 
 SpritePtr
 SpriteManager::create(const std::string& name)
 {
-  Sprites::iterator i = sprites.find(name);
+  Sprites::iterator i = m_sprites.find(name);
   SpriteData* data;
-  if (i == sprites.end()) {
-    // try loading the spritefile
-    data = load(name);
-    if (data == nullptr) {
-      std::stringstream msg;
-      msg << "Sprite '" << name << "' not found.";
-      throw std::runtime_error(msg.str());
+  if (i == m_sprites.end())
+  {
+    // Try loading the sprite file.
+    try
+    {
+      data = load(name);
     }
-  } else {
+    catch (const std::exception& err)
+    {
+      log_warning << "Error loading sprite '" << name << "', using dummy texture: " << err.what() << std::endl;
+      m_load_successful = false;
+      return SpritePtr(new Sprite(*s_dummy_sprite_data)); // Return a dummy sprite.
+    }
+  }
+  else
+  {
     data = i->second.get();
   }
 
+  m_load_successful = true;
   return SpritePtr(new Sprite(*data));
 }
 
 SpriteData*
 SpriteManager::load(const std::string& filename)
 {
-  ReaderDocument doc = [filename](){
-    try {
-      if (StringUtil::has_suffix(filename, ".sprite")) {
-        return ReaderDocument::from_file(filename);
-      } else {
-        std::stringstream text;
-        text << "(supertux-sprite (action "
-             << "(name \"default\") "
-             << "(images \"" << FileSystem::basename(filename) << "\")))";
-        return ReaderDocument::from_stream(text, filename);
-      }
-    } catch(const std::exception& e) {
+  std::unique_ptr<SpriteData> sprite_data;
+
+  if (StringUtil::has_suffix(filename, ".sprite"))
+  {
+    std::optional<ReaderDocument> doc;
+    try
+    {
+      doc = ReaderDocument::from_file(filename);
+    }
+    catch (const std::exception& err)
+    {
       std::ostringstream msg;
       msg << "Parse error when trying to load sprite '" << filename
-      << "': " << e.what() << "\n";
+          << "': " << err.what();
       throw std::runtime_error(msg.str());
     }
-  }();
+    auto root = doc->get_root();
 
-  auto root = doc.get_root();
-
-  if (root.get_name() != "supertux-sprite") {
-    std::ostringstream msg;
-    msg << "'" << filename << "' is not a supertux-sprite file";
-    throw std::runtime_error(msg.str());
-  } else {
-    auto data = std::make_unique<SpriteData>(root.get_mapping());
-    sprites[filename] = std::move(data);
-
-    return sprites[filename].get();
+    if (root.get_name() != "supertux-sprite")
+    {
+      std::ostringstream msg;
+      msg << "'" << filename << "' is not a supertux-sprite file";
+      throw std::runtime_error(msg.str());
+    }
+    else
+    {
+      sprite_data = std::make_unique<SpriteData>(root.get_mapping());
+    }
   }
+  else
+  {
+    sprite_data = std::make_unique<SpriteData>(filename);
+  }
+
+  m_sprites[filename] = std::move(sprite_data);
+  return m_sprites[filename].get();
 }
 
 /* EOF */

--- a/src/sprite/sprite_manager.hpp
+++ b/src/sprite/sprite_manager.hpp
@@ -1,5 +1,6 @@
 //  SuperTux
 //  Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+//                2023 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,29 +18,40 @@
 #ifndef HEADER_SUPERTUX_SPRITE_SPRITE_MANAGER_HPP
 #define HEADER_SUPERTUX_SPRITE_SPRITE_MANAGER_HPP
 
+#include "util/currenton.hpp"
+
 #include <map>
 #include <memory>
 #include <string>
 
 #include "sprite/sprite_ptr.hpp"
-#include "util/currenton.hpp"
 
 class SpriteData;
 
 class SpriteManager final : public Currenton<SpriteManager>
 {
 private:
+  static std::unique_ptr<SpriteData> s_dummy_sprite_data;
+
+private:
   typedef std::map<std::string, std::unique_ptr<SpriteData> > Sprites;
-  Sprites sprites;
+  Sprites m_sprites;
+  bool m_load_successful;
 
 public:
   SpriteManager();
+
+  bool last_load_successful() const { return m_load_successful; }
 
   /** loads a sprite. */
   SpritePtr create(const std::string& filename);
 
 private:
   SpriteData* load(const std::string& filename);
+
+private:
+  SpriteManager(const SpriteManager&) = delete;
+  SpriteManager& operator=(const SpriteManager&) = delete;
 };
 
 #endif

--- a/src/video/texture_manager.hpp
+++ b/src/video/texture_manager.hpp
@@ -39,8 +39,10 @@ struct SDL_Surface;
 
 class TextureManager final : public Currenton<TextureManager>
 {
-public:
   friend class Texture;
+
+private:
+  static const std::string s_dummy_texture;
 
 public:
   TextureManager();
@@ -51,8 +53,11 @@ public:
   TexturePtr get(const std::string& filename,
                  const std::optional<Rect>& rect,
                  const Sampler& sampler = Sampler());
+  TexturePtr create_dummy_texture();
 
   void debug_print(std::ostream& out) const;
+
+  bool last_load_successful() const { return m_load_successful; }
 
 private:
   const SDL_Surface& get_surface(const std::string& filename);
@@ -67,11 +72,10 @@ private:
   TexturePtr create_image_texture_raw(const std::string& filename, const Sampler& sampler);
   TexturePtr create_image_texture_raw(const std::string& filename, const Rect& rect, const Sampler& sampler);
 
-  TexturePtr create_dummy_texture();
-
 private:
   std::map<Texture::Key, std::weak_ptr<Texture> > m_image_textures;
   std::map<std::string, SDLSurfacePtr> m_surfaces;
+  bool m_load_successful;
 
 private:
   TextureManager(const TextureManager&) = delete;


### PR DESCRIPTION
Previously, missing `.sprite` files, when attempted to be loaded, would immediately close the game, due to throwing fatal errors. The issue is now fixed. Such errors are caught, and the fallback/dummy texture takes the sprite's place.

Other than `.sprite` file load errors being caught, single-image sprites also throw an error, which is later caught, when the chosen image fails to load.

`MovingSprite`s now return to their default sprite, if a custom-set sprite fails to load.

Fixes #2341. Closes #2250.