### PR TITLE
Prevent propagating movement to statics like bonus blocks

### DIFF
--- a/src/collision/collision_object.cpp
+++ b/src/collision/collision_object.cpp
@@ -81,6 +81,7 @@ CollisionObject::clear_bottom_collision_list()
 void CollisionObject::propagate_movement(const Vector& movement)
 {
   for (CollisionObject* other_object : m_objects_hit_bottom) {
+    if (other_object->get_group() == COLGROUP_STATIC) continue;
     m_ground_movement_manager->register_movement(*this, *other_object, movement);
     other_object->propagate_movement(movement);
   }


### PR DESCRIPTION
Using conveyor belts, it's possible to move a bonus block or any other object in `COL_STATIC`. This fixes exactly that.

**Volume warning**:
https://github.com/SuperTux/supertux/assets/85036874/6a9f7c32-19d4-42fe-96e9-a07928cdd69c