### PR TITLE
Code style changes to satisfy CppCheck

### DIFF
--- a/src/audio/stream_sound_source.cpp
+++ b/src/audio/stream_sound_source.cpp
@@ -138,8 +138,8 @@ StreamSoundSource::fillBufferAndQueue(ALuint buffer)
   std::unique_ptr<char[]> bufferdata(new char[STREAMFRAGMENTSIZE]);
   size_t bytesread = 0;
   do {
-    bytesread += m_file->read(bufferdata.get() + bytesread,
-                            STREAMFRAGMENTSIZE - bytesread);
+    bytesread += m_file->read(static_cast<char *>(bufferdata.get()) + bytesread,
+      STREAMFRAGMENTSIZE - bytesread);
     // end of sound file
     if (bytesread < STREAMFRAGMENTSIZE) {
       if (m_looping)

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -96,7 +96,7 @@ Crusher::on_type_change(int old_type)
 HitResponse
 Crusher::collision(GameObject& other, const CollisionHit& hit)
 {
-  auto player = dynamic_cast<Player*>(&other);
+  auto* player = dynamic_cast<Player*>(&other);
 
   // If the other object is the player, and the collision is at the
   // bottom of the crusher, hurt the player.
@@ -110,12 +110,12 @@ Crusher::collision(GameObject& other, const CollisionHit& hit)
     return FORCE_MOVE;
   }
 
-  auto badguy = dynamic_cast<BadGuy*>(&other);
+  auto* badguy = dynamic_cast<BadGuy*>(&other);
   if (badguy && m_state == CRUSHING) {
     badguy->kill_fall();
   }
 
-  const auto heavy_coin = dynamic_cast<HeavyCoin*>(&other);
+  const auto* heavy_coin = dynamic_cast<HeavyCoin*>(&other);
   if (heavy_coin) {
     return ABORT_MOVE;
   }


### PR DESCRIPTION
* `heavy_coin` was of type `HeavyCoin * const` and not `const HeavyCoin *`. I've added asterisks to the other `auto`s for pointer types, too, for consistency.
* void pointer arithmetic has undefined behaviour, so the return value of a unique_ptr's get method call in `StreamSoundSource::fillBufferAndQueue` needs to be converted to char*.