### PR TITLE
Allow placing tiles in edges with rect fill tool

### DIFF
--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1616,7 +1616,7 @@ EditorOverlayWidget::align_to_tilemap(const Vector& sp, int tile_size) const
 bool
 EditorOverlayWidget::is_position_inside_tilemap(const TileMap* tilemap, const Vector& pos) const
 {
-  return pos.x > 0 && pos.y > 0 && 
+  return pos.x >= 0 && pos.y >= 0 &&
          pos.x <= static_cast<float>(tilemap->get_width()) &&
          pos.y <= static_cast<float>(tilemap->get_height());
 }

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1617,8 +1617,8 @@ bool
 EditorOverlayWidget::is_position_inside_tilemap(const TileMap* tilemap, const Vector& pos) const
 {
   return pos.x >= 0 && pos.y >= 0 &&
-         pos.x <= static_cast<float>(tilemap->get_width()) &&
-         pos.y <= static_cast<float>(tilemap->get_height());
+         pos.x < static_cast<float>(tilemap->get_width()) &&
+         pos.y < static_cast<float>(tilemap->get_height());
 }
 
 /* EOF */


### PR DESCRIPTION
Placing tiles in edges with rect fill tool just won't work for some reason. This fixes that.