### PR TITLE
Fix editor not updating direction of badguys, conveyor belts and bumpers

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1085,7 +1085,7 @@ BadGuy::after_editor_set()
   }
   else
   {
-    std::string action_str = dir_to_string(m_dir);
+    std::string action_str = dir_to_string(m_start_dir);
 
     if (m_sprite->has_action("editor-" + action_str)) {
       set_action("editor-" + action_str);

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -80,10 +80,10 @@ Bumper::collision(GameObject& other, const CollisionHit& hit)
   return ABORT_MOVE;
 }
 
-Physic*
+Physic&
 Bumper::get_physic()
 {
-  return &m_physic;
+  return m_physic;
 }
 
 void

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -31,34 +31,32 @@ const float BOUNCE_X = 700.0f;
 
 Bumper::Bumper(const ReaderMapping& reader) :
   MovingSprite(reader, "images/objects/trampoline/bumper.sprite", LAYER_OBJECTS, COLGROUP_MOVING),
-  physic(),
-  left()
+  m_physic(),
+  m_facing_left()
 {
-	reader.get("left", left);
-  m_sprite->set_action(left ? "left-normal" : "right-normal");
-	physic.enable_gravity(false);
+  reader.get("left", m_facing_left);
+  m_sprite->set_action(m_facing_left ? "left-normal" : "right-normal");
+  m_physic.enable_gravity(false);
 }
-  
+
 ObjectSettings
 Bumper::get_settings()
 {
   ObjectSettings result = MovingSprite::get_settings();
 
-  result.add_bool(_("Facing Left"), &left, "left", false);
-
+  result.add_bool(_("Facing Left"), &m_facing_left, "left", false);
   result.reorder({"left", "sprite", "x", "y"});
-
   return result;
 }
-  
+
 void
 Bumper::update(float dt_sec)
 {
   if (m_sprite->animation_done())
   {
-    m_sprite->set_action(left ? "left-normal" : "right-normal");
+    m_sprite->set_action(m_facing_left ? "left-normal" : "right-normal");
   }
-  m_col.set_movement(physic.get_movement (dt_sec));
+  m_col.set_movement(m_physic.get_movement (dt_sec));
 }
 
 HitResponse
@@ -67,20 +65,26 @@ Bumper::collision(GameObject& other, const CollisionHit& hit)
   auto player = dynamic_cast<Player*> (&other);
   if (player)
   {
-	  float BOUNCE_DIR = left ? -BOUNCE_X : BOUNCE_X;
-	  player->get_physic().set_velocity(0.f, player->is_swimming() ? 0.f : BOUNCE_Y);
+    float BOUNCE_DIR = m_facing_left ? -BOUNCE_X : BOUNCE_X;
+    player->get_physic().set_velocity(0.f, player->is_swimming() ? 0.f : BOUNCE_Y);
     player->sideways_push(BOUNCE_DIR);
     SoundManager::current()->play(TRAMPOLINE_SOUND, get_pos());
-    m_sprite->set_action((left ? "left-swinging" : "right-swinging"), 1);
+    m_sprite->set_action((m_facing_left ? "left-swinging" : "right-swinging"), 1);
   }
-	
-	auto bumper = dynamic_cast<Bumper*> (&other);
-	if (bumper)
+  auto bumper = dynamic_cast<Bumper*> (&other);
+  if (bumper)
   {
-    physic.set_velocity_y(0);
-	  return FORCE_MOVE;
-	}
+    m_physic.set_velocity_y(0);
+    return FORCE_MOVE;
+  }
   return ABORT_MOVE;
+}
+
+void
+Bumper::after_editor_set()
+{
+  MovingSprite::after_editor_set();
+  m_sprite->set_action(m_facing_left ? "left-normal" : "right-normal");
 }
 
 void

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -80,6 +80,12 @@ Bumper::collision(GameObject& other, const CollisionHit& hit)
   return ABORT_MOVE;
 }
 
+Physic*
+Bumper::get_physic()
+{
+  return &m_physic;
+}
+
 void
 Bumper::after_editor_set()
 {

--- a/src/object/bumper.hpp
+++ b/src/object/bumper.hpp
@@ -40,7 +40,7 @@ public:
   virtual void after_editor_set() override;
   virtual void on_flip(float height) override;
 
-  Physic *get_physic();
+  Physic& get_physic();
 
 private:
   Physic m_physic;

--- a/src/object/bumper.hpp
+++ b/src/object/bumper.hpp
@@ -27,22 +27,23 @@ public:
   Bumper(const ReaderMapping& reader);
 
   virtual ObjectSettings get_settings() override;
-  
+
   virtual void update(float dt_sec) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
-  
+
   static std::string class_name() { return "bumper"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bumper"); }
   virtual std::string get_display_name() const override { return display_name(); }
 
+  virtual void after_editor_set() override;
   virtual void on_flip(float height) override;
 
-  Physic physic;
+  Physic m_physic;
 
 private:
-  bool left;
-	
+  bool m_facing_left;
+
 private:
   Bumper(const Bumper&) = delete;
   Bumper& operator=(const Bumper&) = delete;

--- a/src/object/bumper.hpp
+++ b/src/object/bumper.hpp
@@ -17,6 +17,7 @@
 #define HEADER_SUPERTUX_OBJECT_BUMPER_HPP
 
 #include "object/moving_sprite.hpp"
+
 #include "supertux/physic.hpp"
 
 class Player;
@@ -39,9 +40,10 @@ public:
   virtual void after_editor_set() override;
   virtual void on_flip(float height) override;
 
-  Physic m_physic;
+  Physic *get_physic();
 
 private:
+  Physic m_physic;
   bool m_facing_left;
 
 private:

--- a/src/object/conveyor_belt.cpp
+++ b/src/object/conveyor_belt.cpp
@@ -128,8 +128,8 @@ ConveyorBelt::after_editor_set()
 
   if (m_length <= 0)
     m_length = 1;
-  m_col.m_bbox.set_size(32.0f * static_cast<float>(m_length), 32.0f);
   m_sprite->set_action(dir_to_string(m_dir));
+  update_hitbox();
 }
 
 void

--- a/src/object/conveyor_belt.cpp
+++ b/src/object/conveyor_belt.cpp
@@ -123,6 +123,7 @@ ConveyorBelt::after_editor_set()
   if (m_length <= 0)
     m_length = 1;
   m_col.m_bbox.set_size(32.0f * static_cast<float>(m_length), 32.0f);
+  m_sprite->set_action(dir_to_string(m_dir));
 }
 
 void

--- a/src/object/conveyor_belt.cpp
+++ b/src/object/conveyor_belt.cpp
@@ -128,8 +128,7 @@ ConveyorBelt::after_editor_set()
 
   if (m_length <= 0)
     m_length = 1;
-  m_sprite->set_action(dir_to_string(m_dir));
-  update_hitbox();
+  set_action(dir_to_string(m_dir));
 }
 
 void

--- a/src/object/fallblock.cpp
+++ b/src/object/fallblock.cpp
@@ -83,13 +83,13 @@ FallBlock::update(float dt_sec)
         case SHAKE:
           break;
         case FALL:
-          bumper.physic.enable_gravity(true);
+          bumper.m_physic.enable_gravity(true);
           break;
         case LAND:
-          bumper.physic.enable_gravity(false);
-          bumper.physic.set_gravity_modifier(0.f);
-          bumper.physic.set_velocity_y(0.f);
-          bumper.physic.reset();
+          bumper.m_physic.enable_gravity(false);
+          bumper.m_physic.set_gravity_modifier(0.f);
+          bumper.m_physic.set_velocity_y(0.f);
+          bumper.m_physic.reset();
           break;
       }
     }

--- a/src/object/fallblock.cpp
+++ b/src/object/fallblock.cpp
@@ -83,13 +83,13 @@ FallBlock::update(float dt_sec)
         case SHAKE:
           break;
         case FALL:
-          bumper.get_physic()->enable_gravity(true);
+          bumper.get_physic().enable_gravity(true);
           break;
         case LAND:
-          bumper.get_physic()->enable_gravity(false);
-          bumper.get_physic()->set_gravity_modifier(0.f);
-          bumper.get_physic()->set_velocity_y(0.f);
-          bumper.get_physic()->reset();
+          bumper.get_physic().enable_gravity(false);
+          bumper.get_physic().set_gravity_modifier(0.f);
+          bumper.get_physic().set_velocity_y(0.f);
+          bumper.get_physic().reset();
           break;
       }
     }

--- a/src/object/fallblock.cpp
+++ b/src/object/fallblock.cpp
@@ -28,43 +28,43 @@
 
 FallBlock::FallBlock(const ReaderMapping& reader) :
   MovingSprite(reader, "images/objects/fallblock/cave-4x4.sprite", LAYER_OBJECTS, COLGROUP_STATIC),
-  state(IDLE),
-  physic(),
-  timer()
+  m_state(IDLE),
+  m_physic(),
+  m_timer()
 {
   SoundManager::current()->preload("sounds/cracking.wav");
   SoundManager::current()->preload("sounds/thud.ogg");
-  physic.enable_gravity(false);
+  m_physic.enable_gravity(false);
 }
 
 void
 FallBlock::update(float dt_sec)
 {
-  switch (state)
+  switch (m_state)
   {
     case IDLE:
       set_group(COLGROUP_STATIC);
       if (found_victim_down())
       {
-        state = SHAKE;
+        m_state = SHAKE;
         SoundManager::current()->play("sounds/cracking.wav", get_pos());
-        timer.start(0.5f);
+        m_timer.start(0.5f);
       }
       break;
     case SHAKE:
-      if (timer.check())
+      if (m_timer.check())
       {
-        state = FALL;
-        physic.reset();
-        physic.enable_gravity(true);
+        m_state = FALL;
+        m_physic.reset();
+        m_physic.enable_gravity(true);
       }
       break;
     case FALL:
-      m_col.set_movement(physic.get_movement (dt_sec));
+      m_col.set_movement(m_physic.get_movement (dt_sec));
       set_group(COLGROUP_MOVING_STATIC);
       break;
     case LAND:
-      m_col.set_movement(physic.get_movement (dt_sec));
+      m_col.set_movement(m_physic.get_movement (dt_sec));
       set_group(COLGROUP_MOVING_STATIC);
       break;
   }
@@ -76,20 +76,20 @@ FallBlock::update(float dt_sec)
     && (bumper_bbox.get_bottom() > (m_col.m_bbox.get_top() - 8))
     && (bumper_bbox.get_top() < (m_col.m_bbox.get_bottom() + 8)))
     {
-      switch (state)
+      switch (m_state)
       {
         case IDLE:
           break;
         case SHAKE:
           break;
         case FALL:
-          bumper.m_physic.enable_gravity(true);
+          bumper.get_physic()->enable_gravity(true);
           break;
         case LAND:
-          bumper.m_physic.enable_gravity(false);
-          bumper.m_physic.set_gravity_modifier(0.f);
-          bumper.m_physic.set_velocity_y(0.f);
-          bumper.m_physic.reset();
+          bumper.get_physic()->enable_gravity(false);
+          bumper.get_physic()->set_gravity_modifier(0.f);
+          bumper.get_physic()->set_velocity_y(0.f);
+          bumper.get_physic()->reset();
           break;
       }
     }
@@ -100,18 +100,18 @@ HitResponse
 FallBlock::collision(GameObject& other, const CollisionHit& hit)
 {
   auto fallblock = dynamic_cast<FallBlock*> (&other);
-  if (fallblock && hit.bottom && (state == FALL || state == LAND))
+  if (fallblock && hit.bottom && (m_state == FALL || m_state == LAND))
   {
-    physic.set_velocity_y(0.0f);
+    m_physic.set_velocity_y(0.0f);
     return CONTINUE;
   }
 
   auto player = dynamic_cast<Player*>(&other);
-  if (state == IDLE && player && player->get_bbox().get_bottom() < m_col.m_bbox.get_top())
+  if (m_state == IDLE && player && player->get_bbox().get_bottom() < m_col.m_bbox.get_top())
   {
-    state = SHAKE;
+    m_state = SHAKE;
     SoundManager::current()->play("sounds/cracking.wav", get_pos());
-    timer.start(0.5f);
+    m_timer.start(0.5f);
   }
   return FORCE_MOVE;
 }
@@ -121,14 +121,14 @@ FallBlock::collision_solid(const CollisionHit& hit)
 {
   if (hit.top || hit.bottom || hit.crush)
   {
-    physic.set_velocity(0.0f, 0.0f);
+    m_physic.set_velocity(0.0f, 0.0f);
   }
 
-  if (state == FALL && hit.bottom)
+  if (m_state == FALL && hit.bottom)
   {
     Sector::get().get_camera().shake(0.125f, 0.0f, 10.0f);
     SoundManager::current()->play("sounds/thud.ogg", get_pos());
-    state = LAND;
+    m_state = LAND;
   }
 }
 
@@ -137,7 +137,7 @@ FallBlock::draw(DrawingContext& context)
 {
   Vector pos = get_pos();
   // shaking
-  if (state == SHAKE)
+  if (m_state == SHAKE)
   {
     pos.x += static_cast<float>(graphicsRandom.rand(-8, 8));
     pos.y += static_cast<float>(graphicsRandom.rand(-5, 5));

--- a/src/object/fallblock.hpp
+++ b/src/object/fallblock.hpp
@@ -17,6 +17,7 @@
 #define HEADER_SUPERTUX_OBJECT_FALLBLOCK_HPP
 
 #include "object/moving_sprite.hpp"
+
 #include "supertux/physic.hpp"
 #include "supertux/timer.hpp"
 
@@ -52,14 +53,14 @@ protected:
   };
 
 private:
-  State state;
+  State m_state;
 
-  Physic physic;
-  Timer timer;
-
-  bool found_victim_down() const;
+  Physic m_physic;
+  Timer m_timer;
 
 private:
+  bool found_victim_down() const;
+
   FallBlock(const FallBlock&) = delete;
   FallBlock& operator=(const FallBlock&) = delete;
 };

--- a/src/object/fallblock.hpp
+++ b/src/object/fallblock.hpp
@@ -27,21 +27,21 @@ class FallBlock : public MovingSprite
 {
 public:
   FallBlock(const ReaderMapping& reader);
-  
+
   virtual void update(float dt_sec) override;
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void collision_solid(const CollisionHit& hit) override;
 
   virtual void draw(DrawingContext& context) override;
-  
+
   static std::string class_name() { return "fallblock"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Falling Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
 
   virtual void on_flip(float height) override;
-  
+
 protected:
   enum State
   {
@@ -50,13 +50,13 @@ protected:
     FALL,
     LAND
   };
-  
+
 private:
   State state;
-    
+
   Physic physic;
   Timer timer;
-  
+
   bool found_victim_down() const;
 
 private:


### PR DESCRIPTION
This PR fixes the editor not updating sprite actions of badguys, bumpers and conveyor belts upon changing their direction. It also fixes the formatting in all the files I touched - indentation, `m_` prefix for member variables and CRLF → LF.