### PR TITLE
Add "show all files" option for filesystem menu

### DIFF
--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -403,15 +403,11 @@ ScriptObjectOption::add_to_menu(Menu& menu) const
 FileObjectOption::FileObjectOption(const std::string& text, std::string* pointer,
                                    std::optional<std::string> default_value,
                                    const std::string& key,
-                                   std::vector<std::string> filter,
-                                   const std::string& basedir,
-                                   bool path_relative_to_basedir,
+                                   FileSystemMenu::MenuParams& params,
                                    unsigned int flags) :
   ObjectOption(text, key, flags, pointer),
   m_default_value(std::move(default_value)),
-  m_filter(std::move(filter)),
-  m_basedir(basedir),
-  m_path_relative_to_basedir(path_relative_to_basedir)
+  m_params(params)
 {
 }
 
@@ -440,7 +436,7 @@ FileObjectOption::to_string() const
 void
 FileObjectOption::add_to_menu(Menu& menu) const
 {
-  menu.add_file(get_text(), m_value_pointer, m_filter, m_basedir, m_path_relative_to_basedir);
+  menu.add_file(get_text(), m_params);
 }
 
 ColorObjectOption::ColorObjectOption(const std::string& text, Color* pointer, const std::string& key,

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -27,6 +27,8 @@
 #include "object/path_walker.hpp"
 #include "video/color.hpp"
 
+struct FileSystemMenu::MenuParams;
+
 enum ObjectOptionFlag {
   /** Set if the value is a hidden implementation detail that
       shouldn't be exposed to the user */
@@ -283,9 +285,7 @@ public:
   FileObjectOption(const std::string& text, std::string* pointer,
                    std::optional<std::string> default_value,
                    const std::string& key,
-                   std::vector<std::string> filter,
-                   const std::string& basedir,
-                   bool path_relative_to_basedir,
+                   FileSystemMenu::MenuParams& params,
                    unsigned int flags);
 
   virtual void save(Writer& write) const override;

--- a/src/editor/particle_editor.cpp
+++ b/src/editor/particle_editor.cpp
@@ -372,9 +372,10 @@ ParticleEditor::reset_texture_ui()
   auto chg_texture_btn = std::make_unique<ControlButton>(_("Change texture..."));
   chg_texture_btn.get()->m_on_change = std::function<void()>([this](){
     const std::vector<std::string>& filter = {".jpg", ".png", ".surface"};
-    MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>(
+    MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>({
       nullptr,
       filter,
+      {},
       "/",
       false,
       [this](const std::string& new_filename) {
@@ -382,7 +383,7 @@ ParticleEditor::reset_texture_ui()
         m_particles->reinit_textures();
         this->push_version();
       }
-    ));
+    }));
   });
   chg_texture_btn.get()->set_rect(Rectf(25.f, 420, 325.f, 440));
   m_controls_textures.push_back(std::move(chg_texture_btn));

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -282,15 +282,13 @@ Menu::add_string_select(int id, const std::string& text, int default_item, const
 }
 
 ItemAction&
-Menu::add_file(const std::string& text, std::string* input, const std::vector<std::string>& extensions,
-               const std::string& basedir, bool path_relative_to_basedir,
-               const std::function<void (MenuItem&)>& item_processor, int id)
+Menu::add_file(const std::string& text, FileSystemMenu::MenuParams& params, int id)
 {
   auto item = std::make_unique<ItemAction>(text, id,
-    [input, extensions, basedir, path_relative_to_basedir, item_processor]()
+    [params]()
     {
-      MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>(input, extensions, basedir,
-          path_relative_to_basedir, nullptr, item_processor));
+      params.callback = nullptr;
+      MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>(params));
     });
   auto item_ptr = item.get();
   add_item(std::move(item));

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -52,6 +52,8 @@ class ItemImages;
 class MenuItem;
 class PathObject;
 
+struct FileSystemMenu::MenuParams;
+
 class Menu
 {
 public:
@@ -94,9 +96,7 @@ public:
   ItemScriptLine& add_script_line(std::string* input, int id = -1);
   ItemIntField& add_intfield(const std::string& text, int* input, int id = -1, bool positive = false);
   ItemFloatField& add_floatfield(const std::string& text, float* input, int id = -1, bool positive = false);
-  ItemAction& add_file(const std::string& text, std::string* input, const std::vector<std::string>& extensions,
-                       const std::string& basedir, bool path_relative_to_basedir,
-                       const std::function<void (MenuItem&)>& item_processor = {}, int id = -1);
+  ItemAction& add_file(const std::string& text, FileSystemMenu::MenuParams& params, int id = -1);
 
   ItemColor& add_color(const std::string& text, Color* color, int id = -1);
   ItemColorDisplay& add_color_display(Color* color, int id = -1);

--- a/src/gui/menu_filesystem.hpp
+++ b/src/gui/menu_filesystem.hpp
@@ -21,10 +21,19 @@
 
 class FileSystemMenu final : public Menu
 {
+  struct MenuParams
+  {
+    std::string* filename;
+    const std::vector<std::string>& extensions;
+    const std::vector<std::string>& additional_extensions;
+    const std::string& basedir;
+    bool path_relative_to_basedir;
+    const std::function<void(std::string)> callback = nullptr;
+    const std::function<void (MenuItem&)>& item_processor = {};
+  };
+
 public:
-  FileSystemMenu(std::string* filename, const std::vector<std::string>& extensions,
-                 const std::string& basedir, bool path_relative_to_basedir, const std::function<void(std::string)> callback = nullptr,
-                 const std::function<void (MenuItem&)>& item_processor = {});
+  FileSystemMenu(MenuParams& params);
   ~FileSystemMenu() override;
 
   void menu_action(MenuItem& item) override;
@@ -34,15 +43,10 @@ private:
   bool has_right_suffix(const std::string& file) const;
 
 private:
-  std::string* m_filename;
+  MenuParams& m_params;
   std::string m_directory;
-  std::vector<std::string> m_extensions;
-  std::string m_basedir;
   std::vector<std::string> m_directories;
   std::vector<std::string> m_files;
-  bool m_path_relative_to_basedir;
-  std::function<void(std::string)> m_callback;
-  std::function<void (MenuItem&)> m_item_processor;
 
 private:
   FileSystemMenu(const FileSystemMenu&) = delete;

--- a/src/supertux/menu/editor_converters_menu.cpp
+++ b/src/supertux/menu/editor_converters_menu.cpp
@@ -61,7 +61,7 @@ EditorConvertersMenu::EditorConvertersMenu() :
   add_label(_("Convert Tiles"));
   add_hl();
 
-  add_file(_("Select Tile Conversion File"), &m_tile_conversion_file, { "sttc" }, "images/converters", false,
+  add_file(_("Select Tile Conversion File"), {&m_tile_conversion_file, { ".sttc" }, {}, "images/converters", false,
            [this](MenuItem& item) {
              auto it = m_converters.find(item.get_text());
              if (it == m_converters.end())
@@ -70,7 +70,7 @@ EditorConvertersMenu::EditorConvertersMenu() :
              item.set_text("\"" + it->second.title + "\"");
              item.set_help(it->second.description + (it->second.author.empty() ? "" :
                            "\n\n" + fmt::format(fmt::runtime(_("By: {}")), it->second.author)));
-           });
+           }});
 
   add_entry(MNID_CONVERT_TILES, _("Convert Tiles By File"))
     .set_help(_("Convert all tiles in the current level by a file, specified above."));

--- a/src/supertux/menu/editor_level_menu.cpp
+++ b/src/supertux/menu/editor_level_menu.cpp
@@ -35,7 +35,7 @@ EditorLevelMenu::EditorLevelMenu() :
   add_textfield(_("Contact"), &(level->m_contact));
   add_textfield(_("License"), &(level->m_license));
   add_textfield(_("Level Note"), &(level->m_note));
-  add_file(_("Tileset"), &(level->m_tileset), std::vector<std::string>(1, ".strf"), {}, true);
+  add_file(_("Tileset"), {&(level->m_tileset), { ".strf" }, {} ,"", true});
 
   if (!is_worldmap) {
     add_floatfield(_("Target Time"), &(level->m_target_time));

--- a/src/supertux/menu/editor_levelset_menu.cpp
+++ b/src/supertux/menu/editor_levelset_menu.cpp
@@ -52,7 +52,7 @@ EditorLevelsetMenu::initialize()
   add_textfield(_("Name"), &m_world->m_title);
   add_textfield(_("Description"), &m_world->m_description);
   add_string_select(1, _("Type"), &m_levelset_type, {_("Worldmap"), _("Levelset")});
-  add_file(_("Title Screen Level"), &m_world->m_title_level, { ".stl" }, m_world->m_basedir, false)
+  add_file(_("Title Screen Level"), {&m_world->m_title_level, { ".stl" }, {}, m_world->m_basedir, false})
     .set_help(_("A level to be used for the title screen, after exiting the world."));
   add_hl();
   add_back(_("OK"));

--- a/src/supertux/menu/particle_editor_menu.cpp
+++ b/src/supertux/menu/particle_editor_menu.cpp
@@ -101,9 +101,10 @@ ParticleEditorMenu::menu_action(MenuItem& item)
       //MenuManager::instance().set_menu(MenuStorage::PARTICLE_EDITOR_OPEN);
     {
       const std::vector<std::string>& filter = {".stcp"};
-      MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>(
+      MenuManager::instance().push_menu(std::make_unique<FileSystemMenu>({
         &ParticleEditor::current()->m_filename,
         filter,
+        {},
         "/particles",
         true,
         [](const std::string& new_filename) {
@@ -111,7 +112,7 @@ ParticleEditorMenu::menu_action(MenuItem& item)
                                         ParticleEditor::current()->m_filename);
           MenuManager::instance().clear_menu_stack();
         }
-      ));
+      }));
     }
       break;
 

--- a/src/supertux/menu/particle_editor_open.cpp
+++ b/src/supertux/menu/particle_editor_open.cpp
@@ -33,9 +33,7 @@ ParticleEditorOpen::ParticleEditorOpen() :
 
   add_hl();
 
-  std::vector<std::string> extensions;
-  extensions.push_back("stcp");
-  add_file(_("File"), &m_filename, extensions, "/particles/", true);
+  add_file(_("File"), {&m_filename, { ".stcp" }, {}, "/particles/", true});
   add_entry(MNID_OPEN, _("Open"));
 
   add_hl();

--- a/src/supertux/menu/web_asset_menu.cpp
+++ b/src/supertux/menu/web_asset_menu.cpp
@@ -68,13 +68,13 @@ WebAssetMenu::menu_action(MenuItem& item)
     {
       std::vector<std::string> empty_vec;
       MenuManager::instance().push_menu(
-        std::make_unique<FileSystemMenu>(nullptr, empty_vec, "", false, [](const std::string& file) {
+        std::make_unique<FileSystemMenu>({nullptr, empty_vec, empty_vec, "", false, [](const std::string& file) {
           std::string fullpath(std::string(PHYSFS_getRealDir(file.c_str())) + "/" + file);
           FileSystem::open_path(fullpath);
-        })
+        }})
       );
-    }
       break;
+    }
 
     default:
       break;


### PR DESCRIPTION
For example: choosing the sprite for a bonus block will show a gigantic list mostly of pngs when only the sprites matter

Fix this by only showing the pngs optionally via checkbox