### PR TITLE
Make new objects created in the editor face in their default direction rather than left.

### DIFF
--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -908,7 +908,7 @@ EditorOverlayWidget::put_object()
       target_pos = glm::floor(m_sector_pos / static_cast<float>(snap_grid_size)) * static_cast<float>(snap_grid_size);
     }
 
-    auto object = GameObjectFactory::instance().create(object_class, target_pos, Direction::LEFT);
+    auto object = GameObjectFactory::instance().create(object_class, target_pos);
     object->after_editor_set();
 
     auto* mo = dynamic_cast<MovingObject*> (object.get());


### PR DESCRIPTION
For some reason, the editor would put a `(direction "left")` entry to all newly created objects (this wouldn't save, but would mess with the object while being loaded after adding it). That includes objects that don't even support LEFT, like the PushButton, which is up and down only.

This fixes that.