### PR TITLE
Make thrown bombs explode on impact

### DIFF
--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -47,12 +47,10 @@ Bomb::collision_solid(const CollisionHit& hit)
   if (is_grabbed()) {
     return;
   }
-  if (hit.top || hit.bottom)
+  if (hit.bottom)
     m_physic.set_velocity_y(0);
-  if (hit.left || hit.right)
-    m_physic.set_velocity_x(-m_physic.get_velocity_x() * 0.5f);
-  if (hit.crush)
-    m_physic.set_velocity(0, 0);
+  else
+    explode();
 
   update_on_ground_flag(hit);
 }

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -58,7 +58,7 @@ Bomb::collision_solid(const CollisionHit& hit)
 HitResponse
 Bomb::collision_player(Player& , const CollisionHit& )
 {
-  if (m_physic.get_velocity() != Vector(0.f, 0.f))
+  if (m_physic.get_velocity() != Vector())
     explode();
   return ABORT_MOVE;
 }
@@ -66,7 +66,7 @@ Bomb::collision_player(Player& , const CollisionHit& )
 HitResponse
 Bomb::collision_badguy(BadGuy& , const CollisionHit& )
 {
-  if (m_physic.get_velocity() != Vector(0.f, 0.f))
+  if (m_physic.get_velocity() != Vector())
     explode();
   return ABORT_MOVE;
 }

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -60,12 +60,16 @@ Bomb::collision_solid(const CollisionHit& hit)
 HitResponse
 Bomb::collision_player(Player& , const CollisionHit& )
 {
+  if (m_physic.get_velocity() != Vector(0.f, 0.f))
+    explode();
   return ABORT_MOVE;
 }
 
 HitResponse
 Bomb::collision_badguy(BadGuy& , const CollisionHit& )
 {
+  if (m_physic.get_velocity() != Vector(0.f, 0.f))
+    explode();
   return ABORT_MOVE;
 }
 

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -63,9 +63,9 @@ GoldBomb::collision(GameObject& object, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING)
   {
-    auto player = dynamic_cast<Player*> (&object);
+    auto player = dynamic_cast<Player*>(&object);
     if (player) return collision_player(*player, hit);
-    auto badguy = dynamic_cast<BadGuy*> (&object);
+    auto badguy = dynamic_cast<BadGuy*>(&object);
     if (badguy) return collision_badguy(*badguy, hit);
   }
 
@@ -80,7 +80,7 @@ GoldBomb::collision_player(Player& player, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING)
   {
-    if (m_physic.get_velocity() != Vector(0.f, 0.f))
+    if (m_physic.get_velocity() != Vector())
       kill_fall();
     return ABORT_MOVE;
   }
@@ -94,7 +94,7 @@ GoldBomb::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING)
   {
-    if (m_physic.get_velocity() != Vector(0.f, 0.f))
+    if (m_physic.get_velocity() != Vector())
       kill_fall();
     return ABORT_MOVE;
   }

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -47,12 +47,11 @@ void
 GoldBomb::collision_solid(const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING) {
-    if (hit.bottom) {
+    if (hit.bottom)
       m_physic.set_velocity(0, 0);
-    }else if (hit.left || hit.right)
-      m_physic.set_velocity_x(-m_physic.get_velocity_x());
-    else if (hit.top)
-      m_physic.set_velocity_y(0);
+    else
+      kill_fall();
+
     update_on_ground_flag(hit);
     return;
   }

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -61,18 +61,17 @@ GoldBomb::collision_solid(const CollisionHit& hit)
 HitResponse
 GoldBomb::collision(GameObject& object, const CollisionHit& hit)
 {
-  if (tstate == STATE_TICKING) {
-    if (m_physic.get_velocity() != Vector(0.f, 0.f))
-      kill_fall();
-    if ( dynamic_cast<Player*>(&object) ) {
-      return ABORT_MOVE;
-    }
-    if ( dynamic_cast<BadGuy*>(&object)) {
-      return ABORT_MOVE;
-    }
+  if (tstate == STATE_TICKING)
+  {
+    auto player = dynamic_cast<Player*> (&object);
+    if (player) return collision_player(*player, hit);
+    auto badguy = dynamic_cast<BadGuy*> (&object);
+    if (badguy) return collision_badguy(*badguy, hit);
   }
+
   if (is_grabbed())
     return FORCE_MOVE;
+
   return WalkingBadguy::collision(object, hit);
 }
 
@@ -83,7 +82,7 @@ GoldBomb::collision_player(Player& player, const CollisionHit& hit)
   {
     if (m_physic.get_velocity() != Vector(0.f, 0.f))
       kill_fall();
-    return FORCE_MOVE;
+    return ABORT_MOVE;
   }
   if (is_grabbed())
     return FORCE_MOVE;
@@ -97,7 +96,7 @@ GoldBomb::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
   {
     if (m_physic.get_velocity() != Vector(0.f, 0.f))
       kill_fall();
-    return FORCE_MOVE;
+    return ABORT_MOVE;
   }
   return WalkingBadguy::collision_badguy(badguy, hit);
 }
@@ -192,7 +191,7 @@ GoldBomb::kill_fall()
         EXPLOSION_STRENGTH_DEFAULT);
       run_dead_script();
     }
-      Sector::get().add<CoinExplode>(get_pos() + Vector(0, -40), !m_parent_dispenser);
+      Sector::get().add<CoinExplode>(get_pos(), !m_parent_dispenser);
   }
 }
 

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -63,6 +63,8 @@ HitResponse
 GoldBomb::collision(GameObject& object, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING) {
+    if (m_physic.get_velocity() != Vector(0.f, 0.f))
+      kill_fall();
     if ( dynamic_cast<Player*>(&object) ) {
       return ABORT_MOVE;
     }
@@ -79,7 +81,11 @@ HitResponse
 GoldBomb::collision_player(Player& player, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING)
+  {
+    if (m_physic.get_velocity() != Vector(0.f, 0.f))
+      kill_fall();
     return FORCE_MOVE;
+  }
   if (is_grabbed())
     return FORCE_MOVE;
   return BadGuy::collision_player(player, hit);
@@ -89,7 +95,11 @@ HitResponse
 GoldBomb::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
 {
   if (tstate == STATE_TICKING)
+  {
+    if (m_physic.get_velocity() != Vector(0.f, 0.f))
+      kill_fall();
     return FORCE_MOVE;
+  }
   return WalkingBadguy::collision_badguy(badguy, hit);
 }
 


### PR DESCRIPTION
Closes #2574.

This PR implements the "explode on impact with other enemies" part + it makes thrown bombs explode on contact with the (a) player.

<s>I'm not sure about the exploding on impact with walls part. It could potentially be based either on whether the hit wall is a vertical wall or a horizontal floor/ceiling, or on the thrown bomb's velocity, but I think it would be better if the bomb doesn't explode when hitting a wall at all.</s> As requested by Rusty, I made it so that the bombs will explode upon being thrown at walls and ceilings, but not floors.