### PR TITLE
Re-disable gravity for Sleeping Crystallo, fix missing sprite actions

### DIFF
--- a/data/images/creatures/crystallo/crystallo.sprite
+++ b/data/images/creatures/crystallo/crystallo.sprite
@@ -157,4 +157,23 @@
     (loops 1)
     (mirror-action "waking-left")
   )
+  (action
+    (name "jumping-left")
+    (fps 14)
+    (hitbox 10 12 32 26)
+    (loops 1)
+    (images "jump-0.png"
+            "jump-1.png"
+            "jump-2.png"
+            "jump-3.png"
+            "jump-4.png"
+            "jump-5.png")
+  )
+  (action
+    (name "jumping-right")
+    (fps 14)
+    (hitbox 8 12 32 26)
+    (loops 1)
+    (mirror-action "jumping-left")
+  )
 )

--- a/src/badguy/rcrystallo.cpp
+++ b/src/badguy/rcrystallo.cpp
@@ -42,9 +42,16 @@ RCrystallo::RCrystallo(const Vector& pos, const Vector& start_pos, float vel_x, 
   m_state(RCRYSTALLO_ROOF),
   m_radius(radius)
 {
-  if (fall) m_state = RCRYSTALLO_DETECT;
+  if (fall)
+  {
+    m_state = RCRYSTALLO_DETECT;
+    m_physic.set_gravity_modifier(0.f);
+  }
+  else
+  {
+    m_physic.set_gravity_modifier(-1.f);
+  }
   m_physic.set_velocity_x(vel_x);
-  m_physic.set_gravity_modifier(0.f);
   m_sprite = std::move(sprite);
   m_dead_script = script;
   m_start_position = start_pos;

--- a/src/badguy/rcrystallo.cpp
+++ b/src/badguy/rcrystallo.cpp
@@ -44,7 +44,7 @@ RCrystallo::RCrystallo(const Vector& pos, const Vector& start_pos, float vel_x, 
 {
   if (fall) m_state = RCRYSTALLO_DETECT;
   m_physic.set_velocity_x(vel_x);
-  m_physic.set_gravity_modifier(-1.f);
+  m_physic.set_gravity_modifier(0.f);
   m_sprite = std::move(sprite);
   m_dead_script = script;
   m_start_position = start_pos;

--- a/src/badguy/scrystallo.cpp
+++ b/src/badguy/scrystallo.cpp
@@ -92,8 +92,8 @@ SCrystallo::active_update(float dt_sec)
   switch (m_state)
   {
   case SCRYSTALLO_SLEEPING:
-    m_physic.set_velocity_x(0.f);
-    m_physic.set_acceleration_x(0.f);
+    m_physic.set_velocity(0.f, 0.f);
+    m_physic.set_acceleration(0.f, 0.f);
     // The entity is sleeping peacefully.
     if (player)
     {
@@ -109,8 +109,8 @@ SCrystallo::active_update(float dt_sec)
     BadGuy::active_update(dt_sec);
     break;
   case SCRYSTALLO_WAKING:
-    m_physic.set_velocity_x(0.f);
-    m_physic.set_acceleration_x(0.f);
+    m_physic.set_velocity(0.f, 0.f);
+    m_physic.set_acceleration(0.f, 0.f);
     // Wake up and acknowledge surroundings once the animation is done.
     if (m_sprite->animation_done())
     {

--- a/src/badguy/scrystallo.cpp
+++ b/src/badguy/scrystallo.cpp
@@ -43,11 +43,8 @@ SCrystallo::SCrystallo(const ReaderMapping& reader) :
 void
 SCrystallo::initialize()
 {
-  if (m_roof)
-  {
-    m_physic.set_gravity_modifier(-1.f);
-    FlipLevelTransformer::transform_flip(m_flip);
-  }
+  m_physic.enable_gravity(false);
+  if (m_roof) FlipLevelTransformer::transform_flip(m_flip);
   m_state = SCRYSTALLO_SLEEPING;
   set_action("sleeping", m_dir);
 }
@@ -127,6 +124,7 @@ SCrystallo::active_update(float dt_sec)
         return;
       }
 
+      m_physic.enable_gravity(true);
       m_physic.set_velocity_y(-250.f);
       WalkingBadguy::initialize();
       set_action(m_dir == Direction::LEFT ? "jumping-left" : "jumping-right", -1);
@@ -193,7 +191,6 @@ SCrystallo::on_flip(float height)
 
   if (m_state == SCRYSTALLO_SLEEPING || m_state == SCRYSTALLO_WAKING)
   {
-    m_physic.set_gravity_modifier(-m_physic.get_gravity_modifier());
     FlipLevelTransformer::transform_flip(m_flip);
   }
   else


### PR DESCRIPTION
This adds back the missing jumping sprite actions for crystallo (I accidentally removed them in #2576 ).
It also re-disables gravity for Sleeping Crystallo, which I enabled in the same PR, but apparently, there is a legitimate use case and a reason for why it was disabled before, so I'm re-disabling it.
The gravity will also be disabled for Roof Crystallos created by waking roof-attached Sleeping Crystallos (until they drop).