### PR TITLE
Properly initialise harmless fish

### DIFF
--- a/src/badguy/fish_harmless.cpp
+++ b/src/badguy/fish_harmless.cpp
@@ -20,12 +20,12 @@ FishHarmless::FishHarmless(const ReaderMapping& reader) :
   FishSwimming(reader, "images/creatures/fish/ice/goldfish.sprite")
 {
   m_countMe = false;
-  set_group(COLGROUP_DISABLED);
 }
 
 void
 FishHarmless::initialize()
 {
+  FishSwimming::initialize();
   set_group(COLGROUP_MOVING_ONLY_STATIC);
 }
 


### PR DESCRIPTION
In #2587 I missed a few things (a forgotten collision group setting in the constructor I left there from testing + I forgot to call the parent's initialize() function). It was merged before I noticed. This PR fixes it.