### PR TITLE
Fix missing (or rather, not loading) editor sprite actions

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1081,18 +1081,19 @@ BadGuy::after_editor_set()
       action_set = true;
       break;
     }
-    else if (m_sprite->has_action(direction_str))
-    {
-      set_action(direction_str);
-      action_set = true;
-      break;
-    }
   }
 
   if (!action_set)
   {
+    if (m_sprite->has_action(direction_str))
+    {
+      set_action(direction_str);
+    }
+    else
+    {
     log_warning << "Couldn't find editor sprite action for badguy direction='"
                 << dir_to_string(m_start_dir) << "': " << get_class_name() << "." << std::endl;
+    }
   }
 }
 

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -16,8 +16,6 @@
 
 #include "badguy/badguy.hpp"
 
-#include <list>
-
 #include "audio/sound_manager.hpp"
 #include "badguy/dispenser.hpp"
 #include "editor/editor.hpp"
@@ -1067,8 +1065,9 @@ BadGuy::after_editor_set()
   MovingSprite::after_editor_set();
 
   const std::string direction_str = m_start_dir == Direction::AUTO ? "left" : dir_to_string(m_start_dir);
+  const std::string actions[] = {"editor", "normal", "idle", "flying", "walking", "standing", "swim"};
   bool action_set = false;
-  const std::list<std::string> actions = {"editor", "normal", "idle", "flying", "walking", "standing", "swim"};
+
   for (const auto& action_str : actions)
   {
     const std::string test_action = action_str + "-" + direction_str;

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -16,6 +16,8 @@
 
 #include "badguy/badguy.hpp"
 
+#include <list>
+
 #include "audio/sound_manager.hpp"
 #include "badguy/dispenser.hpp"
 #include "editor/editor.hpp"
@@ -1066,7 +1068,8 @@ BadGuy::after_editor_set()
 
   const std::string direction_str = m_start_dir == Direction::AUTO ? "left" : dir_to_string(m_start_dir);
   bool action_set = false;
-  for (std::string action_str : {"editor", "normal", "idle", "flying", "walking", "standing", "swim"})
+  const std::list<std::string> actions = {"editor", "normal", "idle", "flying", "walking", "standing", "swim"};
+  for (const auto& action_str : actions)
   {
     const std::string test_action = action_str + "-" + direction_str;
     if (m_sprite->has_action(test_action))

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1064,7 +1064,7 @@ BadGuy::after_editor_set()
 {
   MovingSprite::after_editor_set();
 
-  if (m_dir == Direction::AUTO)
+  if (m_start_dir == Direction::AUTO)
   {
     if (m_sprite->has_action("editor-left")) {
       set_action("editor-left");
@@ -1086,6 +1086,8 @@ BadGuy::after_editor_set()
       set_action("flying");
     } else if (m_sprite->has_action("standing-left")) {
       set_action("standing-left");
+    } else if (m_sprite->has_action("swim-left")) {
+      set_action("swim-left");
     } else {
       log_warning << "couldn't find editor sprite for badguy direction='auto': " << get_class_name() << std::endl;
     }
@@ -1106,6 +1108,8 @@ BadGuy::after_editor_set()
       set_action("standing-" + action_str);
     } else if (m_sprite->has_action("walking-" + action_str)) {
       set_action("walking-" + action_str);
+    } else if (m_sprite->has_action("swim-" + action_str)) {
+      set_action("swim-" + action_str);
     } else if (m_sprite->has_action("left")) {
       set_action("left");
     } else if (m_sprite->has_action("normal")) {

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1093,8 +1093,8 @@ BadGuy::after_editor_set()
     }
     else
     {
-    log_warning << "Couldn't find editor sprite action for badguy direction='"
-                << dir_to_string(m_start_dir) << "': " << get_class_name() << "." << std::endl;
+      log_warning << "Couldn't find editor sprite action for badguy direction='"
+                  << dir_to_string(m_start_dir) << "': " << get_class_name() << "." << std::endl;
     }
   }
 }

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1064,64 +1064,35 @@ BadGuy::after_editor_set()
 {
   MovingSprite::after_editor_set();
 
-  if (m_start_dir == Direction::AUTO)
+  const std::string direction_str = m_start_dir == Direction::AUTO ? "left" : dir_to_string(m_start_dir);
+  bool action_set = false;
+  for (std::string action_str : {"editor", "normal", "idle", "flying", "walking", "standing", "swim"})
   {
-    if (m_sprite->has_action("editor-left")) {
-      set_action("editor-left");
-    } else if (m_sprite->has_action("editor-right")) {
-      set_action("editor-right");
-    } else if (m_sprite->has_action("left")) {
-      set_action("left");
-    } else if (m_sprite->has_action("normal")) {
-      set_action("normal");
-    } else if (m_sprite->has_action("idle")) {
-      set_action("idle");
-    } else if (m_sprite->has_action("idle-left")) {
-      set_action("idle-left");
-    } else if (m_sprite->has_action("flying-left")) {
-      set_action("flying-left");
-    } else if (m_sprite->has_action("walking-left")) {
-      set_action("walking-left");
-    } else if (m_sprite->has_action("flying")) {
-      set_action("flying");
-    } else if (m_sprite->has_action("standing-left")) {
-      set_action("standing-left");
-    } else if (m_sprite->has_action("swim-left")) {
-      set_action("swim-left");
-    } else {
-      log_warning << "couldn't find editor sprite for badguy direction='auto': " << get_class_name() << std::endl;
+    const std::string test_action = action_str + "-" + direction_str;
+    if (m_sprite->has_action(test_action))
+    {
+      set_action(test_action);
+      action_set = true;
+      break;
+    }
+    else if (m_sprite->has_action(action_str))
+    {
+      set_action(action_str);
+      action_set = true;
+      break;
+    }
+    else if (m_sprite->has_action(direction_str))
+    {
+      set_action(direction_str);
+      action_set = true;
+      break;
     }
   }
-  else
-  {
-    std::string action_str = dir_to_string(m_start_dir);
 
-    if (m_sprite->has_action("editor-" + action_str)) {
-      set_action("editor-" + action_str);
-    } else if (m_sprite->has_action(action_str)) {
-      set_action(action_str);
-    } else if (m_sprite->has_action("idle-" + action_str)) {
-      set_action("idle-" + action_str);
-    } else if (m_sprite->has_action("flying-" + action_str)) {
-      set_action("flying-" + action_str);
-    } else if (m_sprite->has_action("standing-" + action_str)) {
-      set_action("standing-" + action_str);
-    } else if (m_sprite->has_action("walking-" + action_str)) {
-      set_action("walking-" + action_str);
-    } else if (m_sprite->has_action("swim-" + action_str)) {
-      set_action("swim-" + action_str);
-    } else if (m_sprite->has_action("left")) {
-      set_action("left");
-    } else if (m_sprite->has_action("normal")) {
-      set_action("normal");
-    } else if (m_sprite->has_action("idle")) {
-      set_action("idle");
-    } else if (m_sprite->has_action("flying")) {
-      set_action("flying");
-    } else {
-      log_warning << "couldn't find editor sprite for badguy direction='" << action_str << "': "
-                  << get_class_name() << std::endl;
-    }
+  if (!action_set)
+  {
+    log_warning << "Couldn't find editor sprite action for badguy direction='"
+                << dir_to_string(m_start_dir) << "': " << get_class_name() << "." << std::endl;
   }
 }
 

--- a/src/badguy/sspiky.cpp
+++ b/src/badguy/sspiky.cpp
@@ -112,4 +112,12 @@ SSpiky::is_flammable() const
   return state != SSPIKY_SLEEPING;
 }
 
+void
+SSpiky::after_editor_set()
+{
+  WalkingBadguy::after_editor_set();
+  if (m_start_dir == Direction::AUTO)
+    set_action("sleeping-left");
+}
+
 /* EOF */

--- a/src/badguy/sspiky.hpp
+++ b/src/badguy/sspiky.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Sleeping Spiky"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual void after_editor_set() override;
 
 protected:
   enum SSpikyState {


### PR DESCRIPTION
Right now, some badguys in the editor show the wrong sprite action (mostly for `Direction::AUTO`, but fish with "`swim`" actions for all directions). There was also a bug that the editor checked `m_dir` instead of `m_start_dir` for the badguys with `Direction::AUTO`. (`m_dir` is the current direction when the level is running, `m_start_dir` is the direction saved in the `.stl` level file that the enemy starts in).
Some would show facing in the wrong direction, some would show the wrong sprite action (eg. woken up sleeping spiky instead of sleeping, burning toads, etc.)

This PR fixes that.