### PR TITLE
Use only default keybinds, when navigating menus

### DIFF
--- a/src/control/keyboard_manager.cpp
+++ b/src/control/keyboard_manager.cpp
@@ -219,15 +219,7 @@ KeyboardManager::process_menu_key_event(const SDL_KeyboardEvent& event)
       control = Control::REMOVE;
       break;
     default:
-      if (m_keyboard_config.m_keymap.count(event.keysym.sym) == 0)
-        return;
-
-      // Forbid events from players other than the first in menus
-      if (m_keyboard_config.m_keymap[event.keysym.sym].player != 0)
-        return;
-
-      control = m_keyboard_config.m_keymap[event.keysym.sym].control;
-      break;
+      return;
   }
 
   // Keep empty because this is in the menu; only the first player may navigate


### PR DESCRIPTION
Previously, the game would allow using custom key binds as a fallback to the default navigation key binds, when navigating menus. This however causes some issues, for example, `ItemTextField` being unselected, if a custom key bind has been pressed, when typing.

I believe this feature is redundant, and since the game already aims to use default keys for menu navigation, it would likely be better off without the custom key bind fallback.

I am leaving this open for discussion, in case there are any objections.

Fixes #2577.