### PR TITLE
Do not unload falling badguys

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -207,7 +207,9 @@ BadGuy::update(float dt_sec)
     }
   }
 
-  if (m_is_active_flag && is_offscreen()) {
+  // Deactivate badguy, if off-screen and not falling down.
+  if (m_is_active_flag && is_offscreen() && m_physic.get_velocity_y() <= 0.f)
+  {
     deactivate();
     set_state(STATE_INACTIVE);
   }


### PR DESCRIPTION
Falling `BadGuy`s (which have Y-velocity bigger than 0), no longer are unloaded.

This allows level designers to have more freedom with height of levels and not worry about badguys not being counted towards the total badguy counter, because they have been unloaded, before dying.