### PR TITLE
Fix SDL gradient overlaps + SDL rendering of sector-wide gradients

### DIFF
--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -309,23 +309,45 @@ SDLPainter::draw_gradient(const GradientRequest& request)
       next_step += rect.w;
     }
 
-    float p = static_cast<float>(i+1) / static_cast<float>(n);
+    float p = static_cast<float>(i) / static_cast<float>(n == 1 ? n : n - 1);
     Uint8 r, g, b, a;
 
-    if ( direction == HORIZONTAL_SECTOR || direction == VERTICAL_SECTOR)
+    if (direction == HORIZONTAL_SECTOR || direction == VERTICAL_SECTOR)
     {
-        float begin_percentage = region.get_left() * -1 / region.get_right();
-        r = static_cast<Uint8>(((1.0f - begin_percentage - p) * top.red + (p + begin_percentage) * bottom.red)  * 255);
-        g = static_cast<Uint8>(((1.0f - begin_percentage - p) * top.green + (p + begin_percentage) * bottom.green) * 255);
-        b = static_cast<Uint8>(((1.0f - begin_percentage - p) * top.blue + (p + begin_percentage) * bottom.blue) * 255);
-        a = static_cast<Uint8>(((1.0f - begin_percentage - p) * top.alpha + (p + begin_percentage) * bottom.alpha) * 255);
+      float begin_percentage, end_percentage;
+      if (direction == HORIZONTAL_SECTOR)
+      {
+        begin_percentage = -region.get_left() / region.get_right();
+        end_percentage = (-region.get_left() + static_cast<float>(SCREEN_WIDTH)) / region.get_right();
+      }
+      else
+      {
+        begin_percentage = -region.get_top() / region.get_bottom();
+        end_percentage = (-region.get_top() + static_cast<float>(SCREEN_HEIGHT)) / region.get_bottom();
+      }
+
+      Color begin, end;
+      begin.red   = top.red   * (1.f - begin_percentage) + bottom.red   * begin_percentage;
+      begin.green = top.green * (1.f - begin_percentage) + bottom.green * begin_percentage;
+      begin.blue  = top.blue  * (1.f - begin_percentage) + bottom.blue  * begin_percentage;
+      begin.alpha = top.alpha * (1.f - begin_percentage) + bottom.alpha * begin_percentage;
+
+      end.red   = top.red   * (1.f - end_percentage) + bottom.red   * end_percentage;
+      end.green = top.green * (1.f - end_percentage) + bottom.green * end_percentage;
+      end.blue  = top.blue  * (1.f - end_percentage) + bottom.blue  * end_percentage;
+      end.alpha = top.alpha * (1.f - end_percentage) + bottom.alpha * end_percentage;
+
+      r = static_cast<Uint8>(((1.0f - p) * begin.red   + p * end.red)   * 255);
+      g = static_cast<Uint8>(((1.0f - p) * begin.green + p * end.green) * 255);
+      b = static_cast<Uint8>(((1.0f - p) * begin.blue  + p * end.blue)  * 255);
+      a = static_cast<Uint8>(((1.0f - p) * begin.alpha + p * end.alpha) * 255);
     }
     else
     {
-        r = static_cast<Uint8>(((1.0f - p) * top.red + p * bottom.red)  * 255);
-        g = static_cast<Uint8>(((1.0f - p) * top.green + p * bottom.green) * 255);
-        b = static_cast<Uint8>(((1.0f - p) * top.blue + p * bottom.blue) * 255);
-        a = static_cast<Uint8>(((1.0f - p) * top.alpha + p * bottom.alpha) * 255);
+      r = static_cast<Uint8>(((1.0f - p) * top.red   + p * bottom.red)   * 255);
+      g = static_cast<Uint8>(((1.0f - p) * top.green + p * bottom.green) * 255);
+      b = static_cast<Uint8>(((1.0f - p) * top.blue  + p * bottom.blue)  * 255);
+      a = static_cast<Uint8>(((1.0f - p) * top.alpha + p * bottom.alpha) * 255);
     }
 
     SDL_SetRenderDrawBlendMode(m_sdl_renderer, blend2sdl(request.blend));

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -326,16 +326,21 @@ SDLPainter::draw_gradient(const GradientRequest& request)
         end_percentage = (-region.get_top() + static_cast<float>(SCREEN_HEIGHT)) / region.get_bottom();
       }
 
-      Color begin, end;
-      begin.red   = top.red   * (1.f - begin_percentage) + bottom.red   * begin_percentage;
-      begin.green = top.green * (1.f - begin_percentage) + bottom.green * begin_percentage;
-      begin.blue  = top.blue  * (1.f - begin_percentage) + bottom.blue  * begin_percentage;
-      begin.alpha = top.alpha * (1.f - begin_percentage) + bottom.alpha * begin_percentage;
+      // This is needed because the limited floating point precision can produce
+      // values just below zero or just above one.
+      begin_percentage = math::clamp(begin_percentage, 0.0f, 1.0f);
+      end_percentage   = math::clamp(end_percentage,   0.0f, 1.0f);
 
-      end.red   = top.red   * (1.f - end_percentage) + bottom.red   * end_percentage;
-      end.green = top.green * (1.f - end_percentage) + bottom.green * end_percentage;
-      end.blue  = top.blue  * (1.f - end_percentage) + bottom.blue  * end_percentage;
-      end.alpha = top.alpha * (1.f - end_percentage) + bottom.alpha * end_percentage;
+      Color begin, end;
+      begin.red   = top.red   * (1.0f - begin_percentage) + bottom.red   * begin_percentage;
+      begin.green = top.green * (1.0f - begin_percentage) + bottom.green * begin_percentage;
+      begin.blue  = top.blue  * (1.0f - begin_percentage) + bottom.blue  * begin_percentage;
+      begin.alpha = top.alpha * (1.0f - begin_percentage) + bottom.alpha * begin_percentage;
+
+      end.red   = top.red   * (1.0f - end_percentage) + bottom.red   * end_percentage;
+      end.green = top.green * (1.0f - end_percentage) + bottom.green * end_percentage;
+      end.blue  = top.blue  * (1.0f - end_percentage) + bottom.blue  * end_percentage;
+      end.alpha = top.alpha * (1.0f - end_percentage) + bottom.alpha * end_percentage;
 
       r = static_cast<Uint8>(((1.0f - p) * begin.red   + p * end.red)   * 255);
       g = static_cast<Uint8>(((1.0f - p) * begin.green + p * end.green) * 255);

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -275,6 +275,9 @@ SDLPainter::draw_gradient(const GradientRequest& request)
                                     std::max(fabsf(top.blue - bottom.blue),
                                              fabsf(top.alpha - bottom.alpha))) * 255);
   n = std::max(n, 1);
+
+  int next_step = (direction == VERTICAL || direction == VERTICAL_SECTOR) ?
+                  static_cast<int>(region.get_top()) : static_cast<int>(region.get_left());
   for (int i = 0; i < n; ++i)
   {
     SDL_Rect rect;
@@ -282,16 +285,24 @@ SDLPainter::draw_gradient(const GradientRequest& request)
     if (direction == VERTICAL || direction == VERTICAL_SECTOR)
     {
       rect.x = static_cast<int>(region.get_left());
-      rect.y = static_cast<int>(region.get_top() + (region.get_bottom() - region.get_top()) * static_cast<float>(i) / static_cast<float>(n));
+      rect.y = next_step;
       rect.w = static_cast<int>(region.get_right() - region.get_left());
       rect.h = static_cast<int>(ceilf((region.get_bottom() - region.get_top()) / static_cast<float>(n)));
+
+      if (next_step > static_cast<int>(region.get_top() + (region.get_bottom() - region.get_top()) * static_cast<float>(i) / static_cast<float>(n)))
+        --rect.h;
+      next_step += rect.h;
     }
     else
     {
-      rect.x = static_cast<int>(region.get_left() + (region.get_right() - region.get_left()) * static_cast<float>(i) / static_cast<float>(n));
+      rect.x = next_step;
       rect.y = static_cast<int>(region.get_top());
       rect.w = static_cast<int>(ceilf((region.get_right() - region.get_left()) / static_cast<float>(n)));
       rect.h = static_cast<int>(region.get_bottom() - region.get_top());
+
+      if (next_step > static_cast<int>(region.get_left() + (region.get_right() - region.get_left()) * static_cast<float>(i) / static_cast<float>(n)))
+        --rect.w;
+      next_step += rect.w;
     }
 
     float p = static_cast<float>(i+1) / static_cast<float>(n);

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -289,8 +289,10 @@ SDLPainter::draw_gradient(const GradientRequest& request)
       rect.w = static_cast<int>(region.get_right() - region.get_left());
       rect.h = static_cast<int>(ceilf((region.get_bottom() - region.get_top()) / static_cast<float>(n)));
 
+      // Account for the build-up of rounding errors due to floating point precision.
       if (next_step > static_cast<int>(region.get_top() + (region.get_bottom() - region.get_top()) * static_cast<float>(i) / static_cast<float>(n)))
         --rect.h;
+
       next_step += rect.h;
     }
     else
@@ -300,8 +302,10 @@ SDLPainter::draw_gradient(const GradientRequest& request)
       rect.w = static_cast<int>(ceilf((region.get_right() - region.get_left()) / static_cast<float>(n)));
       rect.h = static_cast<int>(region.get_bottom() - region.get_top());
 
+      // Account for the build-up of rounding errors due to floating point precision.
       if (next_step > static_cast<int>(region.get_left() + (region.get_right() - region.get_left()) * static_cast<float>(i) / static_cast<float>(n)))
         --rect.w;
+
       next_step += rect.w;
     }
 


### PR DESCRIPTION
This was discovered by FrostC.
Due to the conversion from floating point to integer values, there was a "build-up" of rounding errors when splitting gradients to single-colour rectangles for rendering, which caused that some of the rectangles would overlap by one pixel. This PR adds a check that ensures that the next step always starts at previous step + previous height/width (both of those are already integers), plus it always shortens the height/width by one when the rounding error exceeds one (checks the actual position of the rectangle calculated by adding the width/height of the previous one to its starting position against the position calculated directly using the floats), so the gradient isn't stretched. This is the point at which the overlap would previously occur.
This bug was introduced in #2549 . I didn't notice it because the overlap can only be seen when the overlapping rectangles change the rendering outcome, i.e. when using the Additive blend mode.

before:
![image](https://github.com/SuperTux/supertux/assets/14074789/f4edb1cf-4bfe-42dc-96d5-9b9fe85d350c)
now:
![image](https://github.com/SuperTux/supertux/assets/14074789/7beaadd2-ee7d-4fff-8bf1-06340754d0d0)

**EDIT:**
While testing this PR, I found another bug. This one would cause sector-wide gradients (VERTICAL_SECTOR and HORIZONTAL_SECTOR) to render incorrectly, so I also fixed that (see the video in the fourth comment).