### PR TITLE
Fix saving of gradient direction

### DIFF
--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -139,7 +139,7 @@ Gradient::get_settings()
   result.add_enum(_("Direction"), reinterpret_cast<int*>(&m_gradient_direction),
                   {_("Vertical"), _("Horizontal"), _("Vertical (whole sector)"), _("Horizontal (whole sector)")},
                   {"vertical", "horizontal", "vertical_sector", "horizontal_sector"},
-                  static_cast<int>(VERTICAL));
+                  static_cast<int>(VERTICAL), "direction");
 
   result.add_enum(_("Draw target"), reinterpret_cast<int*>(&m_target),
                   {_("Normal"), _("Lightmap")},


### PR DESCRIPTION
This bug prevented all gradients with a direction other than VERTICAL (i.e. HORIZONTAL, VERTICAL_SECTOR and HORIZONTAL_SECTOR) from saving, this fixes it.

*note*: I made this a separate PR since it's unrelated to SDL or rendering in general, it's a bug with the level editor.