### PR TITLE
Worldmap support for adding objects through scripting

### DIFF
--- a/src/scripting/game_object_manager.cpp
+++ b/src/scripting/game_object_manager.cpp
@@ -71,6 +71,14 @@ GameObjectManager::set_music(const std::string& filename)
   music.set_music(filename);
 }
 
+void
+GameObjectManager::add_object(const std::string& class_name, const std::string& name,
+                              int posX, int posY, const std::string& direction,
+                              const std::string& data)
+{
+  m_gom_parent->add_object_scripting(class_name, name, Vector(posX, posY), direction, data);
+}
+
 } // namespace scripting
 
 /* EOF */

--- a/src/scripting/game_object_manager.hpp
+++ b/src/scripting/game_object_manager.hpp
@@ -77,6 +77,20 @@ public:
    * @param string $music Full filename, relative to the "music" folder.
    */
   void set_music(const std::string& music);
+
+  /**
+   * Adds a ""MovingObject"" to the manager.
+     Note: If adding objects to a worldmap sector, ""posX"" and ""posY"" have to be tile positions (sector position / 32).
+   * @param string $class_name GameObject's class.
+   * @param string $name Name of the created object.
+   * @param int $posX X position inside the current sector.
+   * @param int $posY Y position inside the current sector.
+   * @param string $direction Direction.
+   * @param string $data Additional data in S-Expression format (check object definitions in level files).
+   */
+  void add_object(const std::string& class_name, const std::string& name,
+                  int posX, int posY, const std::string& direction,
+                  const std::string& data);
 };
 
 } // namespace scripting

--- a/src/scripting/sector.cpp
+++ b/src/scripting/sector.cpp
@@ -17,14 +17,7 @@
 
 #include "scripting/sector.hpp"
 
-#include "math/easing.hpp"
-#include "object/ambient_light.hpp"
-#include "object/music_object.hpp"
-#include "supertux/game_object_factory.hpp"
-#include "supertux/moving_object.hpp"
 #include "supertux/sector.hpp"
-#include "util/log.hpp"
-#include "video/color.hpp"
 
 namespace scripting {
 
@@ -38,39 +31,6 @@ void
 Sector::set_gravity(float gravity)
 {
   m_parent->set_gravity(gravity);
-}
-
-void
-Sector::add_object(const std::string& class_name, const std::string& name,
-                   int posX, int posY, const std::string& direction,
-                   const std::string& data)
-{
-  if(class_name.empty())
-  {
-    log_fatal << "Object class name cannot be empty" << std::endl;
-    return; 
-  } 
-
-  if(!name.empty() && m_parent->get_object_by_name<GameObject>(name) != nullptr)
-  {
-    log_fatal << "Object with name " << name << " already exists in sector" << std::endl;
-    return; 
-  }
-
-  std::unique_ptr<GameObject> obj =
-    GameObjectFactory::instance().create(class_name, Vector(posX, posY), string_to_dir(direction), data);
-
-  if(dynamic_cast<MovingObject*>(obj.get()) == nullptr)
-  {
-    log_fatal << "Only MovingObject instances can be created via scripting" << std::endl;
-    return; 
-  }
-
-  if(!name.empty())
-  {
-    obj->set_name(name);
-  }
-  m_parent->add_object(std::move(obj));
 }
 
 } // namespace scripting

--- a/src/scripting/sector.hpp
+++ b/src/scripting/sector.hpp
@@ -50,20 +50,6 @@ public:
    * @param float $gravity
    */
   void set_gravity(float gravity);
-
-  /**
-   * Adds a MovingObject to the game.
-   * 
-   * @param string $class_name GameObject's class.
-   * @param string $name Name of the created object.
-   * @param int $posX X position inside the current sector.
-   * @param int $posY Y position inside the current sector.
-   * @param string $direction Direction.
-   * @param string $data Additional data.
-   */
-  void add_object(const std::string& class_name, const std::string& name,
-                  int posX, int posY, const std::string& direction,
-                  const std::string& data);
 };
 
 } // namespace scripting

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -5797,6 +5797,61 @@ static SQInteger GameObjectManager_set_music_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger GameObjectManager_add_object_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'add_object' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::GameObjectManager* _this = reinterpret_cast<scripting::GameObjectManager*> (data);
+
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg1;
+  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a string"));
+    return SQ_ERROR;
+  }
+  SQInteger arg2;
+  if(SQ_FAILED(sq_getinteger(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not an integer"));
+    return SQ_ERROR;
+  }
+  SQInteger arg3;
+  if(SQ_FAILED(sq_getinteger(vm, 5, &arg3))) {
+    sq_throwerror(vm, _SC("Argument 4 not an integer"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg4;
+  if(SQ_FAILED(sq_getstring(vm, 6, &arg4))) {
+    sq_throwerror(vm, _SC("Argument 5 not a string"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg5;
+  if(SQ_FAILED(sq_getstring(vm, 7, &arg5))) {
+    sq_throwerror(vm, _SC("Argument 6 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->add_object(arg0, arg1, static_cast<int> (arg2), static_cast<int> (arg3), arg4, arg5);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'add_object'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Gradient_release_hook(SQUserPointer ptr, SQInteger )
 {
   scripting::Gradient* _this = reinterpret_cast<scripting::Gradient*> (ptr);
@@ -8331,61 +8386,6 @@ static SQInteger Sector_set_gravity_wrapper(HSQUIRRELVM vm)
     return SQ_ERROR;
   } catch(...) {
     sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_gravity'"));
-    return SQ_ERROR;
-  }
-
-}
-
-static SQInteger Sector_add_object_wrapper(HSQUIRRELVM vm)
-{
-  SQUserPointer data;
-  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
-    sq_throwerror(vm, _SC("'add_object' called without instance"));
-    return SQ_ERROR;
-  }
-  scripting::Sector* _this = reinterpret_cast<scripting::Sector*> (data);
-
-  const SQChar* arg0;
-  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
-    sq_throwerror(vm, _SC("Argument 1 not a string"));
-    return SQ_ERROR;
-  }
-  const SQChar* arg1;
-  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
-    sq_throwerror(vm, _SC("Argument 2 not a string"));
-    return SQ_ERROR;
-  }
-  SQInteger arg2;
-  if(SQ_FAILED(sq_getinteger(vm, 4, &arg2))) {
-    sq_throwerror(vm, _SC("Argument 3 not an integer"));
-    return SQ_ERROR;
-  }
-  SQInteger arg3;
-  if(SQ_FAILED(sq_getinteger(vm, 5, &arg3))) {
-    sq_throwerror(vm, _SC("Argument 4 not an integer"));
-    return SQ_ERROR;
-  }
-  const SQChar* arg4;
-  if(SQ_FAILED(sq_getstring(vm, 6, &arg4))) {
-    sq_throwerror(vm, _SC("Argument 5 not a string"));
-    return SQ_ERROR;
-  }
-  const SQChar* arg5;
-  if(SQ_FAILED(sq_getstring(vm, 7, &arg5))) {
-    sq_throwerror(vm, _SC("Argument 6 not a string"));
-    return SQ_ERROR;
-  }
-
-  try {
-    _this->add_object(arg0, arg1, static_cast<int> (arg2), static_cast<int> (arg3), arg4, arg5);
-
-    return 0;
-
-  } catch(std::exception& e) {
-    sq_throwerror(vm, e.what());
-    return SQ_ERROR;
-  } catch(...) {
-    sq_throwerror(vm, _SC("Unexpected exception while executing function 'add_object'"));
     return SQ_ERROR;
   }
 
@@ -15345,6 +15345,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
     throw SquirrelError(v, "Couldn't register function 'set_music'");
   }
 
+  sq_pushstring(v, "add_object", -1);
+  sq_newclosure(v, &GameObjectManager_add_object_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".ssb|nb|nss");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'add_object'");
+  }
+
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register class 'GameObjectManager'");
   }
@@ -15363,13 +15370,6 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".b|n");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_gravity'");
-  }
-
-  sq_pushstring(v, "add_object", -1);
-  sq_newclosure(v, &Sector_add_object_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".ssb|nb|nss");
-  if(SQ_FAILED(sq_createslot(v, -3))) {
-    throw SquirrelError(v, "Couldn't register function 'add_object'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -306,7 +306,7 @@ GameObjectFactory::init_factories()
   add_factory<worldmap::SpecialTile>("special-tile", OBJ_PARAM_WORLDMAP);
   add_factory<worldmap::SpriteChange>("sprite-change", OBJ_PARAM_WORLDMAP);
   add_factory<worldmap::Teleporter>("teleporter", OBJ_PARAM_WORLDMAP);
-  add_factory<worldmap::SpawnPointObject>("worldmap-spawnpoint", OBJ_PARAM_WORLDMAP);
+  add_factory<worldmap::SpawnPointObject>("worldmap-spawnpoint");
 
   add_factory("tilemap", {
     [](const ReaderMapping& reader) {

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -23,6 +23,7 @@
 #include "editor/editor.hpp"
 #include "object/tilemap.hpp"
 #include "supertux/game_object_factory.hpp"
+#include "supertux/moving_object.hpp"
 
 bool GameObjectManager::s_draw_solids_only = false;
 
@@ -135,6 +136,32 @@ GameObjectManager::add_object(std::unique_ptr<GameObject> object)
   GameObject& tmp = *object;
   m_gameobjects_new.push_back(std::move(object));
   return tmp;
+}
+
+MovingObject&
+GameObjectManager::add_object_scripting(const std::string& class_name, const std::string& name,
+                                        const Vector& pos, const std::string& direction,
+                                        const std::string& data)
+{
+  if (class_name.empty())
+    throw std::runtime_error("Object class name cannot be empty.");
+
+  if (!name.empty() && get_object_by_name<GameObject>(name))
+    throw std::runtime_error("Object with name '" + name + "' already exists.");
+
+  auto obj = GameObjectFactory::instance().create(class_name, pos,
+                                                  direction.empty() ? Direction::AUTO : string_to_dir(direction),
+                                                  data);
+
+  auto moving_object = dynamic_cast<MovingObject*>(obj.get());
+  if (!moving_object)
+    throw std::runtime_error("Only MovingObject instances can be created via scripting.");
+
+  if (!name.empty())
+    obj->set_name(name);
+
+  add_object(std::move(obj));
+  return *moving_object;
 }
 
 void

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -29,6 +29,7 @@
 #include "util/uid_generator.hpp"
 
 class DrawingContext;
+class MovingObject;
 class TileMap;
 
 template<class T> class GameObjectRange;
@@ -61,6 +62,11 @@ public:
     add_object(std::move(obj));
     return obj_ref;
   }
+
+  /** Add a MovingObject from scripting. */
+  virtual MovingObject& add_object_scripting(const std::string& class_name, const std::string& name,
+                                             const Vector& pos, const std::string& direction,
+                                             const std::string& data);
 
   void update(float dt_sec);
   void draw(DrawingContext& context);

--- a/src/supertux/sector_base.cpp
+++ b/src/supertux/sector_base.cpp
@@ -33,6 +33,19 @@ Sector::run_script(const std::string& script, const std::string& sourcename)
   m_squirrel_environment->run_script(script, sourcename);
 }
 
+bool
+Sector::before_object_add(GameObject& object)
+{
+  m_squirrel_environment->try_expose(object);
+  return true;
+}
+
+void
+Sector::before_object_remove(GameObject& object)
+{
+  m_squirrel_environment->try_unexpose(object);
+}
+
 } // namespace Base
 
 /* EOF */

--- a/src/supertux/sector_base.hpp
+++ b/src/supertux/sector_base.hpp
@@ -49,6 +49,10 @@ public:
   void run_script(const std::string& script, const std::string& sourcename);
 
 protected:
+  virtual bool before_object_add(GameObject& object) override;
+  virtual void before_object_remove(GameObject& object) override;
+
+protected:
   std::string m_name;
   std::string m_init_script;
 

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -30,6 +30,7 @@
 #include "supertux/debug.hpp"
 #include "supertux/fadetoblack.hpp"
 #include "supertux/game_manager.hpp"
+#include "supertux/game_object_factory.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/level.hpp"
@@ -353,6 +354,26 @@ WorldMapSector::update(float dt_sec)
       // tux->set_direction(input_direction);
     }
   }
+
+  flush_game_objects();
+}
+
+
+MovingObject&
+WorldMapSector::add_object_scripting(const std::string& class_name, const std::string& name,
+                                     const Vector& pos, const std::string& direction,
+                                     const std::string& data)
+{
+  if (!GameObjectFactory::instance().has_params(class_name, ObjectFactory::OBJ_PARAM_WORLDMAP))
+    throw std::runtime_error("Object '" + class_name + "' cannot be added to a worldmap sector.");
+
+  auto& obj = GameObjectManager::add_object_scripting(class_name, name, pos, direction, data);
+
+  // Set position of non-WorldMapObjects from provided tile position.
+  if (!dynamic_cast<WorldMapObject*>(&obj))
+    obj.set_pos(obj.get_pos() * 32.f);
+
+  return obj;
 }
 
 
@@ -558,20 +579,6 @@ WorldMapSector::set_initial_fade_tilemap(const std::string& tilemap_name, int di
 {
   m_initial_fade_tilemap = tilemap_name;
   m_fade_direction = direction;
-}
-
-
-bool
-WorldMapSector::before_object_add(GameObject& object)
-{
-  m_squirrel_environment->try_expose(object);
-  return true;
-}
-
-void
-WorldMapSector::before_object_remove(GameObject& object)
-{
-  m_squirrel_environment->try_unexpose(object);
 }
 
 

--- a/src/worldmap/worldmap_sector.hpp
+++ b/src/worldmap/worldmap_sector.hpp
@@ -51,6 +51,10 @@ public:
   void draw(DrawingContext& context) override;
   void update(float dt_sec) override;
 
+  MovingObject& add_object_scripting(const std::string& class_name, const std::string& name,
+                                     const Vector& pos, const std::string& direction,
+                                     const std::string& data) override;
+
   Vector get_next_tile(const Vector& pos, const Direction& direction) const;
 
   /** gets a bitfield of Tile::WORLDMAP_NORTH | Tile::WORLDMAP_WEST |
@@ -115,9 +119,6 @@ public:
 
 protected:
   void draw_status(DrawingContext& context);
-
-  bool before_object_add(GameObject& object) override;
-  void before_object_remove(GameObject& object) override;
 
 private:
   WorldMap& m_parent;


### PR DESCRIPTION
The `add_object` scripting function was moved to the `GameObjectManager` scripting class. It calls `add_object_scripting` on the parent `GameObjectManager`, which is virtual, so `WorldMapSector` can add additional checks for its implementation.

The function always accepts tile positions (sector position / 32), when adding objects to `WorldMapSector`s, no matter if the object being added isn't a `WorldMapObject`.