### PR TITLE
Fix loading of blend mode and draw target of horizontal gradients + always save colours as top and bottom

### DIFF
--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -110,8 +110,8 @@ Gradient::get_settings()
 {
   ObjectSettings result = GameObject::get_settings();
 
-  result.add_rgba(_("Top/Left Colour"), &m_gradient_top, "top_color");
-  result.add_rgba(_("Bottom/Right Colour"), &m_gradient_bottom, "bottom_color");
+  result.add_rgba(_("Primary Colour"), &m_gradient_top, "top_color");
+  result.add_rgba(_("Secondary Colour"), &m_gradient_bottom, "bottom_color");
 
   result.add_int(_("Z-pos"), &m_layer, "z-pos", LAYER_BACKGROUND0);
 

--- a/src/object/gradient.cpp
+++ b/src/object/gradient.cpp
@@ -88,22 +88,6 @@ Gradient::Gradient(const ReaderMapping& reader) :
   {
     m_gradient_direction = VERTICAL;
   }
-  if (m_gradient_direction == HORIZONTAL || m_gradient_direction == HORIZONTAL_SECTOR)
-  {
-    if (!reader.get("left_color", bkgd_top_color) ||
-       !reader.get("right_color", bkgd_bottom_color))
-    {
-      log_warning <<
-        "Horizontal gradients should use left_color and right_color, respectively. "
-        "Trying to parse top and bottom color instead" << std::endl;
-    }
-    else
-    {
-      m_gradient_top = Color(bkgd_top_color);
-      m_gradient_bottom = Color(bkgd_bottom_color);
-      return;
-    }
-  }
 
   if (reader.get("top_color", bkgd_top_color)) {
     m_gradient_top = Color(bkgd_top_color);
@@ -126,13 +110,8 @@ Gradient::get_settings()
 {
   ObjectSettings result = GameObject::get_settings();
 
-  if (m_gradient_direction == HORIZONTAL || m_gradient_direction == HORIZONTAL_SECTOR) {
-    result.add_rgba(_("Left Colour"), &m_gradient_top, "left_color");
-    result.add_rgba(_("Right Colour"), &m_gradient_bottom, "right_color");
-  } else {
-    result.add_rgba(_("Top Colour"), &m_gradient_top, "top_color");
-    result.add_rgba(_("Bottom Colour"), &m_gradient_bottom, "bottom_color");
-  }
+  result.add_rgba(_("Top/Left Colour"), &m_gradient_top, "top_color");
+  result.add_rgba(_("Bottom/Right Colour"), &m_gradient_bottom, "bottom_color");
 
   result.add_int(_("Z-pos"), &m_layer, "z-pos", LAYER_BACKGROUND0);
 


### PR DESCRIPTION
This fixes the problem in the editor that would not update left/right <-> top/bottom until after reloading the gradient settings. It also fixes the HORIZONTAL and HORIZONTAL_SECTOR gradient's blend mode and draw target loading.

The `left_color` and `right_color` entries in the *.stl files are replaced by just `top_color` and `bottom_color`, even for horizontal gradients, since changing one type to the other wouldn't update those entries, and since the colours are handled this way in the code. Functionally, there's zero difference, except simplifying the code and fixing a lot of issues with saving and loading of gradient properties.

I'm not worried about retro-compatibility since until about 2 days ago, a bug prevented any gradients other than vertical from saving at all, so the `left_color` and `right_color` entries were never used, unless using an external editor.