### PR TITLE
Tuxs action updates regardless of whether Tux is being drawn.

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2083,12 +2083,10 @@ Player::draw(DrawingContext& context)
   */
 
   /* Draw Tux */
-  if (m_safe_timer.started() && size_t(g_game_time * 40) % 2 || (Editor::is_active() || !m_visible))
+  if ((Editor::is_active() || !m_visible) || (m_safe_timer.started() && size_t(g_game_time * 40) % 2))
   {
   }  // don't draw Tux
 
-  else if (m_player_status.bonus[get_id()] == EARTH_BONUS)
-    m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 1);
   else if (m_dying)
     m_sprite->draw(context.color(), get_pos(), Sector::get().get_foremost_layer());
   else

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1860,6 +1860,9 @@ Player::get_action() const
 void
 Player::draw(DrawingContext& context)
 {
+  if(Editor::is_active())
+    return;
+
   if (is_dead() && m_target && Sector::get().get_object_count<Player>([this](const Player& p){ return !p.is_dead() && !p.is_dying() && !p.is_winning() && &p != this; }))
   {
     auto* target = Sector::get().get_object_by_uid<Player>(*m_target);
@@ -2083,7 +2086,7 @@ Player::draw(DrawingContext& context)
   */
 
   /* Draw Tux */
-  if ((Editor::is_active() || !m_visible) || (m_safe_timer.started() && size_t(g_game_time * 40) % 2))
+  if (!m_visible || (m_safe_timer.started() && size_t(g_game_time * 40) % 2))
   {
   }  // don't draw Tux
 

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1860,13 +1860,6 @@ Player::get_action() const
 void
 Player::draw(DrawingContext& context)
 {
-  if (Editor::is_active()) {
-    return;
-  }
-
-  if (!m_visible)
-    return;
-
   if (is_dead() && m_target && Sector::get().get_object_count<Player>([this](const Player& p){ return !p.is_dead() && !p.is_dying() && !p.is_winning() && &p != this; }))
   {
     auto* target = Sector::get().get_object_by_uid<Player>(*m_target);
@@ -2090,19 +2083,16 @@ Player::draw(DrawingContext& context)
   */
 
   /* Draw Tux */
-  if (m_safe_timer.started() && size_t(g_game_time * 40) % 2)
+  if (m_safe_timer.started() && size_t(g_game_time * 40) % 2 || (Editor::is_active() || !m_visible))
   {
   }  // don't draw Tux
 
-  else if (m_player_status.bonus[get_id()] == EARTH_BONUS) {
+  else if (m_player_status.bonus[get_id()] == EARTH_BONUS)
     m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 1);
-  }
-  else {
-    if (m_dying)
-      m_sprite->draw(context.color(), get_pos(), Sector::get().get_foremost_layer());
-    else
-      m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 1);
-  }
+  else if (m_dying)
+    m_sprite->draw(context.color(), get_pos(), Sector::get().get_foremost_layer());
+  else
+    m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 1);
 
   //TODO: Replace recoloring with proper costumes
   Color power_color = (m_player_status.bonus[get_id()] == FIRE_BONUS ? Color(1.f, 0.7f, 0.5f) :
@@ -2112,7 +2102,6 @@ Player::draw(DrawingContext& context)
     Color(1.f, 1.f, 1.f));
 
   m_sprite->set_color(m_stone ? Color(1.f, 1.f, 1.f) : power_color);
-
 }
 
 


### PR DESCRIPTION
Ok hear me out...

Basically it fixes `Tux.get_action()` not giving the correct action when Tux isn't being drawn.

When `Tux.get_visible()` is false Tux's sprite isn't updated at all. This interferes with `Tux.get_action()` because it relies on the sprite updating. What I'm gonna do to fix this is make Tux's sprite update regardless of whether Tux is visible but only draw Tux if `Tux.get_visible()` is true.