### PR TITLE
Adjust darttrap's hitbox to spawn darts at the correct position

### DIFF
--- a/data/images/creatures/darttrap/darttrap.sprite
+++ b/data/images/creatures/darttrap/darttrap.sprite
@@ -1,75 +1,79 @@
 (supertux-sprite
   (action
-    (hitbox -13 2 32 38)
+    (hitbox -8 2 32 63)
     (name "idle-left")
     (loops 1)
     (fps 10)
     (images "empty_left-0.png"
-			"empty_left-1.png"
-			"empty_left-2.png"
-			"empty_left-3.png"
-			"empty_left-4.png")
+            "empty_left-1.png"
+            "empty_left-2.png"
+            "empty_left-3.png"
+            "empty_left-4.png"
+    )
   )
   (action
-    (hitbox 2 19 38 32)
+    (hitbox 2 14 63 32)
     (name "idle-down")
     (loops 1)
     (fps 10)
     (images "empty_down-0.png"
-			"empty_down-1.png"
-			"empty_down-2.png"
-			"empty_down-3.png"
-			"empty_down-4.png")
+      "empty_down-1.png"
+      "empty_down-2.png"
+      "empty_down-3.png"
+      "empty_down-4.png"
+    )
   )
   (action
-    (hitbox 19 2 32 38)
+    (hitbox 14 2 32 63)
     (name "idle-right")
     (loops 1)
-	(fps 10)
+    (fps 10)
     (mirror-action "idle-left")
   )
   (action
-    (hitbox 2 -13 38 32)
+    (hitbox 2 -8 63 32)
     (name "idle-up")
-	(loops 1)
-	(fps 10)
+    (loops 1)
+    (fps 10)
     (flip-action "idle-down")
   )
 
   (action
-    (hitbox -13 2 32 38)
+    (hitbox -8 2 32 63)
     (name "loading-left")
     (loops 1)
-	(fps 10)
+    (fps 10)
     (images "empty_left-4.png"
-			"charge_left-0.png"
-			"charge_left-1.png"
-			"charge_left-2.png"
-			"charge_left-3.png")
+      "charge_left-0.png"
+      "charge_left-1.png"
+      "charge_left-2.png"
+      "charge_left-3.png"
+    )
   )
   (action
-    (hitbox 2 19 38 32)
+    (hitbox 2 14 63 32)
     (name "loading-down")
     (loops 1)
-	(fps 10)
+    (fps 10)
     (images "empty_down-4.png"
-			"charge_down-0.png"
-			"charge_down-1.png"
-			"charge_down-2.png"
-			"charge_down-3.png")
+      "charge_down-0.png"
+      "charge_down-1.png"
+      "charge_down-2.png"
+      "charge_down-3.png"
+    )
   )
   (action
-    (hitbox 19 2 32 38)
+    (hitbox 14 2 32 63)
     (name "loading-right")
     (loops 1)
-	(fps 10)
+    (fps 10)
     (mirror-action "loading-left")
   )
   (action
-    (hitbox 2 -13 38 32)
+    (hitbox 2 -8 63 32)
     (name "loading-up")
-	(loops 1)
-	(fps 10)
+    (loops 1)
+    (fps 10)
     (flip-action "loading-down")
   )
 )


### PR DESCRIPTION
+replace tabs with spaces in darttrap.sprite

[before vs. now]
![horizontal_before](https://github.com/SuperTux/supertux/assets/14074789/6101b81c-0487-4bd3-a391-50cec0529045)![horizontal_after](https://github.com/SuperTux/supertux/assets/14074789/46b7bbd4-f9a7-4b42-a5de-e3ff6698eb60)
![vertical_before](https://github.com/SuperTux/supertux/assets/14074789/1e7b5cb8-b58b-4b70-9ff1-735316ab09c2)![vertical_after](https://github.com/SuperTux/supertux/assets/14074789/0ed1303f-2cc8-40b8-8d00-ee6a8d011f1c)