### PR TITLE
Unisolid hitboxes for objects

### DIFF
--- a/src/collision/collision_object.cpp
+++ b/src/collision/collision_object.cpp
@@ -27,6 +27,7 @@ CollisionObject::CollisionObject(CollisionGroup group, CollisionListener& listen
   m_group(group),
   m_movement(0.0f, 0.0f),
   m_dest(),
+  m_unisolid(false),
   m_objects_hit_bottom(),
   m_ground_movement_manager(nullptr)
 {

--- a/src/collision/collision_object.hpp
+++ b/src/collision/collision_object.hpp
@@ -63,6 +63,9 @@ public:
 
   void clear_bottom_collision_list();
 
+  bool is_unisolid() const { return m_unisolid; }
+  void set_unisolid(bool unisolid) { m_unisolid = unisolid; }
+
   /** returns the bounding box of the Object */
   const Rectf& get_bbox() const
   {
@@ -154,6 +157,12 @@ private:
       This field holds the currently anticipated destination of the object
       during collision detection */
   Rectf m_dest;
+
+  /** Determines whether the object is unisolid.
+
+      Only bottom constraints to the top of the bounding box would be applied for objects,
+      colliding with unisolid objects. */
+  bool m_unisolid;
 
   /** Objects that were touching the top of this object at the last frame,
       if this object was static or moving static. */

--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -136,7 +136,7 @@ collision::Constraints check_collisions(const Vector& obj_movement, const Rectf&
 
   bool shiftout = false;
 
-  if (other_object && !other_object->is_unisolid())
+  if (!other_object || !other_object->is_unisolid())
   {
     if (fabsf(obj_movement.y) > fabsf(obj_movement.x)) {
       if (ileft < SHIFT_DELTA) {

--- a/src/object/conveyor_belt.cpp
+++ b/src/object/conveyor_belt.cpp
@@ -117,6 +117,8 @@ ConveyorBelt::draw(DrawingContext &context)
 void
 ConveyorBelt::update_hitbox()
 {
+  MovingSprite::update_hitbox();
+
   m_col.m_bbox.set_size(m_sprite->get_current_hitbox_width() * static_cast<float>(m_length),
                         m_sprite->get_current_hitbox_height());
 }

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -127,6 +127,7 @@ void
 MovingSprite::update_hitbox()
 {
   m_col.set_size(m_sprite->get_current_hitbox_width(), m_sprite->get_current_hitbox_height());
+  m_col.set_unisolid(m_sprite->is_current_hitbox_unisolid());
 }
 
 void

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -192,6 +192,12 @@ Sprite::get_height() const
   return static_cast<int>(m_action->surfaces[m_frameidx]->get_height());
 }
 
+bool
+Sprite::is_current_hitbox_unisolid() const
+{
+  return m_action->hitbox_unisolid;
+}
+
 float
 Sprite::get_current_hitbox_x_offset() const
 {

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -89,6 +89,8 @@ public:
   int get_width() const;
   int get_height() const;
 
+  /** Return the "unisolid" property for the current action's hitbox. */
+  bool is_current_hitbox_unisolid() const;
   /** return x-offset of current action's hitbox, relative to start of image */
   float get_current_hitbox_x_offset() const;
   /** return y-offset of current action's hitbox, relative to start of image */

--- a/src/sprite/sprite_data.cpp
+++ b/src/sprite/sprite_data.cpp
@@ -35,6 +35,7 @@ SpriteData::Action::Action() :
   y_offset(0),
   hitbox_w(0),
   hitbox_h(0),
+  hitbox_unisolid(false),
   fps(10),
   loops(-1),
   loop_frame(1),
@@ -127,6 +128,7 @@ SpriteData::parse_action(const ReaderMapping& mapping)
         throw std::runtime_error("hitbox should specify 2/4 coordinates");
     }
   }
+  mapping.get("unisolid", action->hitbox_unisolid);
   mapping.get("fps", action->fps);
   if (mapping.get("loops", action->loops))
   {

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -62,6 +62,9 @@ private:
     /** Hitbox height */
     float hitbox_h;
 
+    /** Whether the hitbox is unisolid */
+    bool hitbox_unisolid;
+
     /** Frames per second */
     float fps;
 


### PR DESCRIPTION
`CollisionObject` now contains a unisolid property. If it's `true`, only bottom constraints to the top of the bounding box would be applied to objects, colliding with that object.

The property is also settable from sprite file actions with the name `unisolid`. Default is `false`.

Fixes #2644.