### PR TITLE
Fix setting random seed to current time

### DIFF
--- a/src/math/random.cpp
+++ b/src/math/random.cpp
@@ -31,11 +31,8 @@ void
 Random::seed(int v)
 {
   if (v <= 0)
-  {
-    // Use the UNIX timestamp of the current time as a seed.
-    m_generator.seed(static_cast<unsigned int>(std::time(nullptr)));
-    return;
-  }
+    v = static_cast<int>(std::time(nullptr)); // Use the UNIX timestamp of the current time as a seed.
+
   m_generator.seed(v);
 }
 

--- a/src/math/random.cpp
+++ b/src/math/random.cpp
@@ -33,7 +33,7 @@ Random::seed(int v)
   if (v <= 0)
   {
     // Use the UNIX timestamp of the current time as a seed.
-    m_generator.seed(std::time(nullptr));
+    m_generator.seed(static_cast<unsigned int>(std::time(nullptr)));
     return;
   }
   m_generator.seed(v);

--- a/src/math/random.cpp
+++ b/src/math/random.cpp
@@ -16,6 +16,7 @@
 
 #include "math/random.hpp"
 
+#include <ctime>
 #include <limits>
 
 Random graphicsRandom;
@@ -29,6 +30,12 @@ Random::Random() :
 void
 Random::seed(int v)
 {
+  if (v <= 0)
+  {
+    // Use the UNIX timestamp of the current time as a seed.
+    m_generator.seed(std::time(nullptr));
+    return;
+  }
   m_generator.seed(v);
 }
 


### PR DESCRIPTION
Setting the random seed to 0 or lower of a `Random` generator will now set it to the UNIX timestamp of the current time.