### PR TITLE
Avoid drawing unnecessary things when we're about to quit

### DIFF
--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -279,11 +279,7 @@ ScreenManager::draw(Compositor& compositor, FPS_Stats& fps_statistics)
 
   // draw effects and hud
   auto& context = compositor.make_context(true);
-
-  if(m_running)
-  {
-    m_menu_manager->draw(context);
-  }
+  m_menu_manager->draw(context);
 
   if (m_screen_fade) {
     m_screen_fade->draw(context);

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -102,6 +102,7 @@ private:
 
   std::unique_ptr<ScreenFade> m_screen_fade;
   std::vector<std::unique_ptr<Screen> > m_screen_stack;
+  bool m_running;
 };
 
 #endif


### PR DESCRIPTION
Also, don't update integrations for every tick, that's way too often and wastes CPU cycles.