### PR TITLE
Expose `get_filename` to scripting under `worldmap.settings`.

### DIFF
--- a/src/scripting/worldmap_sector.cpp
+++ b/src/scripting/worldmap_sector.cpp
@@ -59,6 +59,13 @@ WorldMapSector::move_to_spawnpoint(const std::string& spawnpoint)
   m_parent->move_to_spawnpoint(spawnpoint);
 }
 
+std::string&
+WorldMapSector::get_filename()
+{
+  SCRIPT_GUARD_WORLDMAP;
+  return worldmap.get_filename();
+}
+
 } // namespace scripting
 
 /* EOF */

--- a/src/scripting/worldmap_sector.cpp
+++ b/src/scripting/worldmap_sector.cpp
@@ -59,8 +59,8 @@ WorldMapSector::move_to_spawnpoint(const std::string& spawnpoint)
   m_parent->move_to_spawnpoint(spawnpoint);
 }
 
-const std::string&
-WorldMapSector::get_filename()
+std::string
+WorldMapSector::get_filename() const
 {
   SCRIPT_GUARD_WORLDMAP;
   return worldmap.get_filename();

--- a/src/scripting/worldmap_sector.cpp
+++ b/src/scripting/worldmap_sector.cpp
@@ -59,7 +59,7 @@ WorldMapSector::move_to_spawnpoint(const std::string& spawnpoint)
   m_parent->move_to_spawnpoint(spawnpoint);
 }
 
-std::string&
+const std::string&
 WorldMapSector::get_filename()
 {
   SCRIPT_GUARD_WORLDMAP;

--- a/src/scripting/worldmap_sector.hpp
+++ b/src/scripting/worldmap_sector.hpp
@@ -87,7 +87,7 @@ public:
   /**
    * Gets the path to the worldmap file. Useful for saving worldmap specific data.
    */
-  const std::string& get_filename();
+  std::string get_filename() const;
 
 };
 

--- a/src/scripting/worldmap_sector.hpp
+++ b/src/scripting/worldmap_sector.hpp
@@ -83,6 +83,12 @@ public:
    * @param string $spawnpoint
    */
   void move_to_spawnpoint(const std::string& spawnpoint);
+
+  /**
+   * Gets the path to the worldmap file. Useful for saving worldmap specific data.
+   */
+  std::string& get_filename();
+
 };
 
 } // namespace scripting

--- a/src/scripting/worldmap_sector.hpp
+++ b/src/scripting/worldmap_sector.hpp
@@ -87,7 +87,7 @@ public:
   /**
    * Gets the path to the worldmap file. Useful for saving worldmap specific data.
    */
-  std::string& get_filename();
+  const std::string& get_filename();
 
 };
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -11512,6 +11512,33 @@ static SQInteger WorldMapSector_move_to_spawnpoint_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger WorldMapSector_get_filename_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'get_filename' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::WorldMapSector* _this = reinterpret_cast<scripting::WorldMapSector*> (data);
+
+
+  try {
+    std::string& return_value = _this->get_filename();
+
+    assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
+    sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));
+    return 1;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'get_filename'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger display_wrapper(HSQUIRRELVM vm)
 {
   return scripting::display(vm);
@@ -15659,6 +15686,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".s");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'move_to_spawnpoint'");
+  }
+
+  sq_pushstring(v, "get_filename", -1);
+  sq_newclosure(v, &WorldMapSector_get_filename_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'get_filename'");
   }
 
   if(SQ_FAILED(sq_createslot(v, -3))) {

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -11523,7 +11523,7 @@ static SQInteger WorldMapSector_get_filename_wrapper(HSQUIRRELVM vm)
 
 
   try {
-    const std::string& return_value = _this->get_filename();
+    std::string return_value = _this->get_filename();
 
     assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
     sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -11523,7 +11523,7 @@ static SQInteger WorldMapSector_get_filename_wrapper(HSQUIRRELVM vm)
 
 
   try {
-    std::string& return_value = _this->get_filename();
+    const std::string& return_value = _this->get_filename();
 
     assert(return_value.size() < static_cast<size_t>(std::numeric_limits<SQInteger>::max()));
     sq_pushstring(vm, return_value.c_str(), static_cast<SQInteger>(return_value.size()));

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -334,7 +334,7 @@ WorldMap::set_sector(const std::string& name, const std::string& spawnpoint,
     m_sector->move_to_spawnpoint(spawnpoint);
 }
 
-std::string&
+const std::string&
 WorldMap::get_filename()
 {
   return m_map_filename;

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -334,8 +334,8 @@ WorldMap::set_sector(const std::string& name, const std::string& spawnpoint,
     m_sector->move_to_spawnpoint(spawnpoint);
 }
 
-const std::string&
-WorldMap::get_filename()
+std::string
+WorldMap::get_filename() const
 {
   return m_map_filename;
 }

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -334,6 +334,12 @@ WorldMap::set_sector(const std::string& name, const std::string& spawnpoint,
     m_sector->move_to_spawnpoint(spawnpoint);
 }
 
+std::string&
+WorldMap::get_filename()
+{
+  return m_map_filename;
+}
+
 } // namespace worldmap
 
 /* EOF */

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -86,6 +86,8 @@ public:
   void set_sector(const std::string& name, const std::string& spawnpoint = "",
                   bool perform_full_setup = true);
 
+  std::string& get_filename();
+
 private:
   void on_escape_press();
 

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -86,7 +86,7 @@ public:
   void set_sector(const std::string& name, const std::string& spawnpoint = "",
                   bool perform_full_setup = true);
 
-  std::string& get_filename();
+  const std::string& get_filename();
 
 private:
   void on_escape_press();

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -86,7 +86,7 @@ public:
   void set_sector(const std::string& name, const std::string& spawnpoint = "",
                   bool perform_full_setup = true);
 
-  const std::string& get_filename();
+  std::string get_filename() const;
 
 private:
   void on_escape_press();


### PR DESCRIPTION
Think of this as a getter for the worldmap selection thing so you can tell which worldmap youre on. :snowsmiley:

Ive been having an issue with using a script to save info in the state table. Because its all saved to the same table it loads stuff where its not supposed to and it would be really helpful if i could get a string unique to each worldmap to save the data in different tables.