### PR TITLE
Fix broken `load_worldmap` and `set_next_worldmap` scripting functions

### DIFF
--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -37,7 +37,6 @@
 #include "video/viewport.hpp"
 #include "worldmap/tux.hpp"
 #include "worldmap/worldmap.hpp"
-#include "worldmap/worldmap_screen.hpp"
 
 namespace {
 
@@ -226,24 +225,23 @@ void display_text_file(const std::string& filename)
   ScreenManager::current()->push_screen(std::make_unique<TextScrollerScreen>(filename));
 }
 
-void load_worldmap(const std::string& filename)
+void load_worldmap(const std::string& filename, const std::string& sector, const std::string& spawnpoint)
 {
   using namespace worldmap;
 
-  if (!::worldmap::WorldMap::current())
+  if (!WorldMap::current())
   {
     throw std::runtime_error("Can't start Worldmap without active WorldMap");
   }
   else
   {
-    ScreenManager::current()->push_screen(std::make_unique<WorldMapScreen>(
-                                            std::make_unique<::worldmap::WorldMap>(filename, ::worldmap::WorldMap::current()->get_savegame())));
+    WorldMap::current()->change(filename, sector, spawnpoint);
   }
 }
 
-void set_next_worldmap(const std::string& dirname, const std::string& spawnpoint)
+void set_next_worldmap(const std::string& dirname, const std::string& sector, const std::string& spawnpoint)
 {
-  GameManager::current()->set_next_worldmap(dirname, spawnpoint);
+  GameManager::current()->set_next_worldmap(dirname, sector, spawnpoint);
 }
 
 void load_level(const std::string& filename)

--- a/src/scripting/functions.hpp
+++ b/src/scripting/functions.hpp
@@ -64,20 +64,23 @@ bool is_christmas();
 void display_text_file(const std::string& filename);
 
 /**
- * Loads and displays a worldmap (on next screenswitch).
+ * Loads and displays a worldmap (on next screenswitch), using the savegame of the current worldmap.
  * @param string $filename
+ * @param string $sector Forced sector to spawn in the worldmap on. Leave empty to use last sector from savegame.
+ * @param string $spawnpoint Forced spawnpoint to spawn in the worldmap on. Leave empty to use last position from savegame.
  */
-void load_worldmap(const std::string& filename);
+void load_worldmap(const std::string& filename, const std::string& sector, const std::string& spawnpoint);
 
 /**
  * Switches to a different worldmap after unloading the current one, after ""exit_screen()"" is called.
- * @param string $dirname
- * @param string $spawnpoint
+ * @param string $dirname The world directory, where the "worldmap.stwm" file is located.
+ * @param string $sector Forced sector to spawn in the worldmap on. Leave empty to use last sector from savegame.
+ * @param string $spawnpoint Forced spawnpoint to spawn in the worldmap on. Leave empty to use last position from savegame.
  */
-void set_next_worldmap(const std::string& dirname, const std::string& spawnpoint);
+void set_next_worldmap(const std::string& dirname, const std::string& sector, const std::string& spawnpoint);
 
 /**
- * Loads and displays a level (on next screenswitch).
+ * Loads and displays a level (on next screenswitch), using the savegame of the current level.
  * @param string $filename
  */
 void load_level(const std::string& filename);

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -11590,9 +11590,19 @@ static SQInteger load_worldmap_wrapper(HSQUIRRELVM vm)
     sq_throwerror(vm, _SC("Argument 1 not a string"));
     return SQ_ERROR;
   }
+  const SQChar* arg1;
+  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a string"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
 
   try {
-    scripting::load_worldmap(arg0);
+    scripting::load_worldmap(arg0, arg1, arg2);
 
     return 0;
 
@@ -11618,9 +11628,14 @@ static SQInteger set_next_worldmap_wrapper(HSQUIRRELVM vm)
     sq_throwerror(vm, _SC("Argument 2 not a string"));
     return SQ_ERROR;
   }
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
 
   try {
-    scripting::set_next_worldmap(arg0, arg1);
+    scripting::set_next_worldmap(arg0, arg1, arg2);
 
     return 0;
 
@@ -13726,14 +13741,14 @@ void register_supertux_wrapper(HSQUIRRELVM v)
 
   sq_pushstring(v, "load_worldmap", -1);
   sq_newclosure(v, &load_worldmap_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".s");
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".sss");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'load_worldmap'");
   }
 
   sq_pushstring(v, "set_next_worldmap", -1);
   sq_newclosure(v, &set_next_worldmap_wrapper, 0);
-  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".ss");
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".sss");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'set_next_worldmap'");
   }

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -34,8 +34,7 @@
 
 GameManager::GameManager() :
   m_savegame(),
-  m_next_worldmap(),
-  m_next_spawnpoint()
+  m_next_worldmap()
 {
 }
 
@@ -98,26 +97,28 @@ GameManager::start_worldmap(const World& world, const std::string& worldmap_file
 bool
 GameManager::load_next_worldmap()
 {
-  if (m_next_worldmap.empty())
-  {
+  if (!m_next_worldmap)
     return false;
-  }
-  std::unique_ptr<World> world = World::from_directory(m_next_worldmap);
-  m_next_worldmap = "";
+
+  const auto next_worldmap = std::move(*m_next_worldmap);
+  m_next_worldmap.reset();
+
+  std::unique_ptr<World> world = World::from_directory(next_worldmap.world);
   if (!world)
   {
-    log_warning << "Can't load world '" << m_next_worldmap << "'" <<  std::endl;
+    log_warning << "Cannot load world '" << next_worldmap.world << "'" <<  std::endl;
     return false;
   }
-  start_worldmap(*world, m_next_spawnpoint); // New world, new savegame.
+
+  start_worldmap(*world, "", next_worldmap.sector, next_worldmap.spawnpoint); // New world, new savegame.
   return true;
 }
 
 void
-GameManager::set_next_worldmap(const std::string& worldmap, const std::string &spawnpoint)
+GameManager::set_next_worldmap(const std::string& world, const std::string& sector,
+                               const std::string& spawnpoint)
 {
-  m_next_worldmap = worldmap;
-  m_next_spawnpoint = spawnpoint;
+  m_next_worldmap.emplace(world, sector, spawnpoint);
 }
 
 /* EOF */

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -17,11 +17,13 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_GAME_MANAGER_HPP
 #define HEADER_SUPERTUX_SUPERTUX_GAME_MANAGER_HPP
 
+#include "util/currenton.hpp"
+
 #include <optional>
 #include <memory>
 #include <string>
+
 #include "math/vector.hpp"
-#include "util/currenton.hpp"
 
 class Savegame;
 class World;
@@ -39,13 +41,26 @@ public:
                    const std::optional<std::pair<std::string, Vector>>& start_pos = std::nullopt);
 
   bool load_next_worldmap();
-  void set_next_worldmap(const std::string& worldmap, const std::string &spawnpoint);
+  void set_next_worldmap(const std::string& world, const std::string& sector = "",
+                         const std::string& spawnpoint = "");
+
+private:
+  struct NextWorldMap
+  {
+    NextWorldMap(const std::string& w, const std::string& s,
+                 const std::string& sp) :
+      world(w), sector(s), spawnpoint(sp)
+    {}
+
+    const std::string world;
+    const std::string sector;
+    const std::string spawnpoint;
+  };
 
 private:
   std::unique_ptr<Savegame> m_savegame;
 
-  std::string m_next_worldmap;
-  std::string m_next_spawnpoint;
+  std::optional<NextWorldMap> m_next_worldmap;
 
 private:
   GameManager(const GameManager&) = delete;


### PR DESCRIPTION
The `load_worldmap` scripting function didn't use the designated `WorldMap::change()` function, but instead immediately tried to destroy the current `WorldMap`, which caused a segmentation fault.

The `set_next_worldmap` function seemingly has been broken since the introduction of worldmap sectors. It was not providing arguments in the proper order (passing provided spawnpoint as worldmap filename). It now supports providing a forced sector, alongside a spawnpoint.