### PR TITLE
Rewrite project license expression in AppData file

### DIFF
--- a/supertux2.appdata.xml
+++ b/supertux2.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>org.supertuxproject.SuperTux</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+ AND CC-BY-SA-2.0</project_license>
+  <project_license>GPL-3.0-or-later AND CC-BY-SA-2.0</project_license>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>


### PR DESCRIPTION
I changed [the value for the "project_license" license tags in supertuxkart2.appdata.xml](https://github.com/SuperTux/supertux/blob/d8734847a860ab726feba580f45d7050bc7747d0/supertux2.appdata.xml#L5), since `GPL-3.0+` is not a valid SPDX license expression (at least not anymore), but `GPL-3.0-or-later` is, according to [the most recent SPDX License List](https://spdx.org/licenses/) as of now (version 3.22, 2023-10-05).

This is why, on Flathub, the SuperTux Flatpak app shows its license as being "Proprietary" when it's really not. See: flathub/org.supertuxproject.SuperTux#20

This does not affect the build system or existing game code, but I nonetheless tried building SuperTux after changing the appdata.xml file to see if everything still works, and it does.

I also opened a PR in the SuperTux Flatpak to address the aforementioned Flathub issue so that the appdata _there_ can still be updated if and/or before _this_ PR gets merged and included in a future SuperTux release: flathub/org.supertuxproject.SuperTux#22