### PR TITLE
Fix enemy death script running twice if Tux slides into it.

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -645,10 +645,14 @@ BadGuy::kill_fall()
 void
 BadGuy::run_dead_script()
 {
+  if(m_is_active_flag) {
+    m_is_active_flag = false;
+  } else {
+    return;
+  }
+
   if (m_countMe)
     Sector::get().get_level().m_stats.increment_badguys();
-
-  m_countMe = false;
 
   if (m_parent_dispenser != nullptr)
   {
@@ -658,7 +662,6 @@ BadGuy::run_dead_script()
   // Start the dead-script.
   if (!m_dead_script.empty()) {
     Sector::get().run_script(m_dead_script, "dead-script");
-    m_dead_script = "";
   }
 }
 

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -658,6 +658,7 @@ BadGuy::run_dead_script()
   // Start the dead-script.
   if (!m_dead_script.empty()) {
     Sector::get().run_script(m_dead_script, "dead-script");
+    m_dead_script = "";
   }
 }
 

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -647,9 +647,8 @@ BadGuy::run_dead_script()
 {
   if(!m_is_active_flag) {
      return;
-  } else {
-     m_is_active_flag = false;
-  }
+
+  m_is_active_flag = false;
 
   if (m_countMe)
     Sector::get().get_level().m_stats.increment_badguys();

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -645,7 +645,7 @@ BadGuy::kill_fall()
 void
 BadGuy::run_dead_script()
 {
-  if(!m_is_active_flag) {
+  if(!m_is_active_flag)
      return;
 
   m_is_active_flag = false;

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -645,10 +645,10 @@ BadGuy::kill_fall()
 void
 BadGuy::run_dead_script()
 {
-  if(m_is_active_flag) {
-    m_is_active_flag = false;
+  if(!m_is_active_flag) {
+     return;
   } else {
-    return;
+     m_is_active_flag = false;
   }
 
   if (m_countMe)


### PR DESCRIPTION
If you slide into an enemy and kill it the death script triggers twice, once when you first hit him and another when hes falls into the void. This should fix the issue by removing the death script the first time the enemy is hit.