### PR TITLE
Fix bug with throwing snail downwards

### DIFF
--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -411,7 +411,10 @@ Snail::ungrab(MovingObject& object, Direction dir_)
       if (dir_ != Direction::DOWN) {
         m_dir = dir_;
       } else {
-        m_dir = dynamic_cast<Player*>(&object)->m_dir;
+        const Player* player = dynamic_cast<Player*>(&object);
+        if(player) {
+          m_dir = player->m_dir;
+        }
       }
       be_kicked(dynamic_cast<Owl*>(&object) ? false : true);
     }

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -402,13 +402,18 @@ Snail::grab(MovingObject& object, const Vector& pos, Direction dir_)
 void
 Snail::ungrab(MovingObject& object, Direction dir_)
 {
+  auto player = dynamic_cast<Player*> (&object);
   if (!m_frozen)
   {
     if (dir_ == Direction::UP) {
       be_flat();
     }
     else {
-      m_dir = dir_;
+      if (dir_ != Direction::DOWN) {
+        m_dir = dir_;
+      } else {
+        m_dir = player->m_dir;
+      }
       be_kicked(dynamic_cast<Owl*>(&object) ? false : true);
     }
   }

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -402,7 +402,6 @@ Snail::grab(MovingObject& object, const Vector& pos, Direction dir_)
 void
 Snail::ungrab(MovingObject& object, Direction dir_)
 {
-  auto player = dynamic_cast<Player*> (&object);
   if (!m_frozen)
   {
     if (dir_ == Direction::UP) {
@@ -412,7 +411,7 @@ Snail::ungrab(MovingObject& object, Direction dir_)
       if (dir_ != Direction::DOWN) {
         m_dir = dir_;
       } else {
-        m_dir = player->m_dir;
+        m_dir = dynamic_cast<Player*>(&object)->m_dir;
       }
       be_kicked(dynamic_cast<Owl*>(&object) ? false : true);
     }


### PR DESCRIPTION
Fixes #2630, in which snails get put in a glitched state when thrown downwards which would also cause a rather loud and annoying sound. This was caused by the direction of snails actually being set downwards which caused unexpected behavior.