### PR TITLE
Improve `DrawingRequest` API

### DIFF
--- a/src/video/bitmap_font.cpp
+++ b/src/video/bitmap_font.cpp
@@ -29,8 +29,8 @@
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
 #include "util/utf8_iterator.hpp"
+#include "video/canvas.hpp"
 #include "video/drawing_request.hpp"
-#include "video/painter.hpp"
 #include "video/surface.hpp"
 #include "video/sdl_surface.hpp"
 

--- a/src/video/compositor.cpp
+++ b/src/video/compositor.cpp
@@ -18,6 +18,7 @@
 #include "video/compositor.hpp"
 
 #include "math/rect.hpp"
+#include "video/drawing_context.hpp"
 #include "video/drawing_request.hpp"
 #include "video/painter.hpp"
 #include "video/renderer.hpp"
@@ -68,12 +69,9 @@ Compositor::render()
     {
       if (!ctx->is_overlay())
       {
-        painter.set_clip_rect(ctx->get_viewport());
         painter.clear(ctx->get_ambient_color());
 
         ctx->light().render(lightmap, Canvas::ALL);
-
-        painter.clear_clip_rect();
       }
     }
     lightmap.end_draw();
@@ -88,9 +86,7 @@ Compositor::render()
 
     for (auto& ctx : m_drawing_contexts)
     {
-      painter.set_clip_rect(ctx->get_viewport());
       ctx->color().render(*back_renderer, Canvas::BELOW_LIGHTMAP);
-      painter.clear_clip_rect();
     }
 
     back_renderer->end_draw();
@@ -105,9 +101,7 @@ Compositor::render()
 
     for (auto& ctx : m_drawing_contexts)
     {
-      painter.set_clip_rect(ctx->get_viewport());
       ctx->color().render(renderer, Canvas::BELOW_LIGHTMAP);
-      painter.clear_clip_rect();
     }
 
     if (use_lightmap)
@@ -115,11 +109,9 @@ Compositor::render()
       const TexturePtr& texture = lightmap.get_texture();
       if (texture)
       {
-        TextureRequest request;
+        DrawingTransform transform(m_video_system.get_viewport());
+        TextureRequest request(transform);
 
-        request.type = TEXTURE;
-        request.flip = 0;
-        request.alpha = 1.0f;
         request.blend = Blend::MOD;
 
         request.srcrects.emplace_back(0.0f, 0.0f,
@@ -138,9 +130,7 @@ Compositor::render()
     // Render overlay elements.
     for (auto& ctx : m_drawing_contexts)
     {
-      painter.set_clip_rect(ctx->get_viewport());
       ctx->color().render(renderer, Canvas::ABOVE_LIGHTMAP);
-      painter.clear_clip_rect();
     }
 
     renderer.end_draw();

--- a/src/video/drawing_context.cpp
+++ b/src/video/drawing_context.cpp
@@ -30,11 +30,8 @@ DrawingContext::DrawingContext(VideoSystem& video_system_, obstack& obst, bool o
   m_video_system(video_system_),
   m_obst(obst),
   m_overlay(overlay),
-  m_viewport(0, 0,
-             m_video_system.get_viewport().get_screen_width(),
-             m_video_system.get_viewport().get_screen_height()),
   m_ambient_color(Color::WHITE),
-  m_transform_stack(1),
+  m_transform_stack({ DrawingTransform(m_video_system.get_viewport()) }),
   m_colormap_canvas(*this, m_obst),
   m_lightmap_canvas(*this, m_obst)
 {
@@ -56,8 +53,8 @@ DrawingContext::get_cliprect() const
 {
   return Rectf(get_translation().x,
                get_translation().y,
-               get_translation().x + static_cast<float>(m_viewport.get_width()) / transform().scale,
-               get_translation().y + static_cast<float>(m_viewport.get_height()) / transform().scale);
+               get_translation().x + static_cast<float>(transform().viewport.get_width()) / transform().scale,
+               get_translation().y + static_cast<float>(transform().viewport.get_height()) / transform().scale);
 }
 
 void
@@ -111,22 +108,22 @@ DrawingContext::pop_transform()
   assert(!m_transform_stack.empty());
 }
 
-const Rect
+const Rect&
 DrawingContext::get_viewport() const
 {
-  return m_viewport;
+  return transform().viewport;
 }
 
 float
 DrawingContext::get_width() const
 {
-  return static_cast<float>(m_viewport.get_width()) / transform().scale;
+  return static_cast<float>(transform().viewport.get_width()) / transform().scale;
 }
 
 float
 DrawingContext::get_height() const
 {
-  return static_cast<float>(m_viewport.get_height()) / transform().scale;
+  return static_cast<float>(transform().viewport.get_height()) / transform().scale;
 }
 
 Vector

--- a/src/video/drawing_context.hpp
+++ b/src/video/drawing_context.hpp
@@ -94,10 +94,10 @@ public:
 
   void set_viewport(const Rect& viewport)
   {
-    m_viewport = viewport;
+    transform().viewport = viewport;
   }
 
-  const Rect get_viewport() const;
+  const Rect& get_viewport() const;
 
   float get_width() const;
   float get_height() const;
@@ -122,7 +122,6 @@ private:
       rendered. */
   bool m_overlay;
 
-  Rect m_viewport;
   Color m_ambient_color;
   std::vector<DrawingTransform> m_transform_stack;
 

--- a/src/video/drawing_transform.hpp
+++ b/src/video/drawing_transform.hpp
@@ -19,17 +19,21 @@
 
 #include "math/vector.hpp"
 #include "video/texture.hpp"
+#include "video/viewport.hpp"
 
 class DrawingTransform final
 {
 public:
   Vector translation;
+  Rect viewport;
   Flip flip;
   float alpha;
   float scale;
 
-  DrawingTransform() :
+  DrawingTransform(const Viewport& viewport) :
     translation(0.0f, 0.0f),
+    viewport(0, 0,
+             viewport.get_screen_width(), viewport.get_screen_height()),
     flip(NO_FLIP),
     alpha(1.0f),
     scale(1.0f)


### PR DESCRIPTION
1. `DrawingRequest` no longer preserves a variable indicating its type, but rather utilizes a `virtual` function for this purpose.
2. `DrawingRequest` now initializes some of its variables from the current `DrawingTransform`.
2. The viewport rectangle is now stored in `DrawingTransform`, instead of `DrawingContext`. bb18239df3d1ed34840e78fc074200ecbb07ee15 has added per-request viewport cropping. Utilizing it now is more convenient, because the old viewport wouldn't have to be stored in a separate variable in a draw function, so it could be restored later. A new transform could be pushed and popped instead.