### PR TITLE
Fix `wait()` segfaulting on the worldmap.

### DIFF
--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -137,7 +137,7 @@ bool check_cutscene()
 
 void wait(HSQUIRRELVM vm, float seconds)
 {
-  auto session = GameSession::current()
+  auto session = GameSession::current();
 
   if(session && session->get_current_level().m_skip_cutscene)
   {

--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -137,7 +137,9 @@ bool check_cutscene()
 
 void wait(HSQUIRRELVM vm, float seconds)
 {
-  if(GameSession::current() != nullptr && GameSession::current()->get_current_level().m_skip_cutscene)
+  auto session = GameSession::current()
+
+  if(session && session->get_current_level().m_skip_cutscene)
   {
     if (auto squirrelenv = static_cast<SquirrelEnvironment*>(sq_getforeignptr(vm)))
     {
@@ -153,18 +155,18 @@ void wait(HSQUIRRELVM vm, float seconds)
       log_warning << "wait(): no VM or environment available\n";
     }
   }
-  else if(GameSession::current() != nullptr && GameSession::current()->get_current_level().m_is_in_cutscene)
+  else if(session && session->get_current_level().m_is_in_cutscene)
   {
     if (auto squirrelenv = static_cast<SquirrelEnvironment*>(sq_getforeignptr(vm)))
     {
       // Wait anyways, to prevent scripts like `while (true) {wait(0.1); ...}` from freezing the game.
       squirrelenv->skippable_wait_for_seconds(vm, seconds);
-      //GameSession::current()->set_scheduler(squirrelenv->get_scheduler());
+      //session->set_scheduler(squirrelenv->get_scheduler());
     }
     else if (auto squirrelvm = static_cast<SquirrelVirtualMachine*>(sq_getsharedforeignptr(vm)))
     {
       squirrelvm->skippable_wait_for_seconds(vm, seconds);
-      //GameSession::current()->set_scheduler(squirrelvm->get_scheduler());
+      //session->set_scheduler(squirrelvm->get_scheduler());
     }
     else
     {

--- a/src/scripting/functions.cpp
+++ b/src/scripting/functions.cpp
@@ -137,7 +137,7 @@ bool check_cutscene()
 
 void wait(HSQUIRRELVM vm, float seconds)
 {
-  if(GameSession::current()->get_current_level().m_skip_cutscene)
+  if(GameSession::current() != nullptr && GameSession::current()->get_current_level().m_skip_cutscene)
   {
     if (auto squirrelenv = static_cast<SquirrelEnvironment*>(sq_getforeignptr(vm)))
     {
@@ -153,7 +153,7 @@ void wait(HSQUIRRELVM vm, float seconds)
       log_warning << "wait(): no VM or environment available\n";
     }
   }
-  else if(GameSession::current()->get_current_level().m_is_in_cutscene)
+  else if(GameSession::current() != nullptr && GameSession::current()->get_current_level().m_is_in_cutscene)
   {
     if (auto squirrelenv = static_cast<SquirrelEnvironment*>(sq_getforeignptr(vm)))
     {


### PR DESCRIPTION
`wait()` checks for the current level in the gamesession to check if it can skip the cutscene/if ones running, but if you run this on the worldmap then it segfaults because there isnt a current gamesession (sometimes, idk why but sometimes there is a gamesession and i dont know why). Basically this makes it where it doesnt check for cutscene specific stuff if it cant find a gamesession.

~~I know it might seem a little strange to have 2 `GameSession::current() != nullptr`s but i tried to make it just 1 and it didnt work.~~