### PR TITLE
Remove boost references in some files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,6 @@ EOF
 
               pkgs.physfs
               pkgs.libpng
-              pkgs.boost
               pkgs.curl
               pkgs.fmt_8
               pkgs.libGL

--- a/guix.scm
+++ b/guix.scm
@@ -37,8 +37,7 @@
              (gnu packages squirrel)
              (gnu packages version-control)
              (gnu packages xiph)
-             (guix-cocfree utils)
-             (guix-cocfree packages boost))
+             (guix-cocfree utils))
 
 (define %source-dir (dirname (current-filename)))
 

--- a/mk/cmake/SuperTux/WarningFlags.cmake
+++ b/mk/cmake/SuperTux/WarningFlags.cmake
@@ -52,11 +52,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
           "-Wint-in-bool-context "
           )
       endif()
-      if(Boost_VERSION LESS 106500)
-        string(CONCAT SUPERTUX2_EXTRA_WARNING_FLAGS
-          "${SUPERTUX2_EXTRA_WARNING_FLAGS} "
-          "-Wno-implicit-fallthrough ")
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       string(CONCAT SUPERTUX2_EXTRA_WARNING_FLAGS
         "${SUPERTUX2_EXTRA_WARNING_FLAGS} "


### PR DESCRIPTION
I noted that this file still referenced boost. On checking it, I found that Boost_VERSION was never defined, always resulting in false.

As a result, I made this PR to remove it.