### PR TITLE
Make level note translatable

### DIFF
--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -175,7 +175,7 @@ Level::save(Writer& writer)
   writer.write("name", m_name, true);
   writer.write("author", m_author, false);
   if (!m_note.empty()) {
-    writer.write("note", m_note, false);
+    writer.write("note", m_note, true);
   }
   if (!m_contact.empty()) {
     writer.write("contact", m_contact, false);


### PR DESCRIPTION
This fixes an oversight where the level note would not save as translatable.

before:
![image](https://github.com/SuperTux/supertux/assets/14074789/0198da7d-5d0e-4dbe-bdda-f8297b860f94)
now:
![image](https://github.com/SuperTux/supertux/assets/14074789/98eaf1fd-c2cf-4cb0-8928-2df8448f1ba8)
