### PR TITLE
Focus on first available deprecated tile

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -380,12 +380,21 @@ Editor::scroll(const Vector& velocity)
 {
   if (!m_levelloaded) return;
 
-  Rectf bounds(0.0f,
-               0.0f,
-               std::max(0.0f, m_sector->get_editor_width() - static_cast<float>(SCREEN_WIDTH - 128)),
-               std::max(0.0f, m_sector->get_editor_height() - static_cast<float>(SCREEN_HEIGHT - 32)));
   Camera& camera = m_sector->get_camera();
-  Vector pos = camera.get_translation() + velocity;
+  camera.set_translation(camera.get_translation() + velocity);
+  keep_camera_in_bounds();
+}
+
+void
+Editor::keep_camera_in_bounds()
+{
+  const Rectf bounds(0.0f,
+                     0.0f,
+                     std::max(0.0f, m_sector->get_editor_width() - static_cast<float>(SCREEN_WIDTH - 128)),
+                     std::max(0.0f, m_sector->get_editor_height() - static_cast<float>(SCREEN_HEIGHT - 32)));
+
+  Camera& camera = m_sector->get_camera();
+  Vector pos = camera.get_translation();
   pos = Vector(math::clamp(pos.x, bounds.get_left(), bounds.get_right()),
                math::clamp(pos.y, bounds.get_top(), bounds.get_bottom()));
   camera.set_translation(pos);
@@ -648,18 +657,31 @@ Editor::check_unsaved_changes(const std::function<void ()>& action)
 }
 
 void
-Editor::check_deprecated_tiles()
+Editor::check_deprecated_tiles(bool focus)
 {
   // Check for any deprecated tiles, used throughout the entire level
   m_has_deprecated_tiles = false;
-  for (size_t sector_num = 0; sector_num < m_level->get_sector_count(); sector_num++)
+  for (const auto& sector : m_level->get_sectors())
   {
-    for (auto& tilemap : m_level->get_sector(sector_num)->get_objects_by_type<TileMap>())
+    for (auto& tilemap : sector->get_objects_by_type<TileMap>())
     {
+      int pos = -1;
       for (const uint32_t& tile_id : tilemap.get_tiles())
       {
+        pos++;
         if (m_tileset->get(tile_id).is_deprecated())
         {
+          // Focus on deprecated tile
+          if (focus)
+          {
+            set_sector(sector.get());
+            m_layers_widget->set_selected_tilemap(&tilemap);
+
+            const int width = tilemap.get_width();
+            m_sector->get_camera().set_translation_centered(Vector(pos % width, pos / width) * 32.f);
+            keep_camera_in_bounds();
+          }
+
           m_has_deprecated_tiles = true;
           return;
         }

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -120,7 +120,7 @@ public:
   /** Convert tiles on every tilemap in the level, according to a tile conversion file. */
   void convert_tiles_by_file(const std::string& file);
 
-  void check_deprecated_tiles();
+  void check_deprecated_tiles(bool focus = false);
   bool has_deprecated_tiles() const { return m_has_deprecated_tiles; }
 
   /** Checks whether the level can be saved and does not contain
@@ -180,6 +180,8 @@ private:
   void save_level(const std::string& filename = "", bool switch_file = false);
   void test_level(const std::optional<std::pair<std::string, Vector>>& test_pos);
   void update_keyboard(const Controller& controller);
+
+  void keep_camera_in_bounds();
 
   void post_undo_redo_actions();
 

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -69,9 +69,9 @@ public:
   bool has_mouse_focus() const;
 
   TileMap* get_selected_tilemap() const;
+  void set_selected_tilemap(TileMap* tilemap);
 
 private:
-  void set_selected_tilemap(TileMap* tilemap);
   Vector get_layer_coords(const int pos) const;
   int get_layer_pos(const Vector& coords) const;
   void update_tip();

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -293,6 +293,12 @@ Camera::get_translation() const
   return m_translation + ((screen_size * (get_current_scale() - 1.f)) / 2.f);
 }
 
+void
+Camera::set_translation_centered(const Vector& translation)
+{
+  m_translation = translation - m_screen_size.as_vector() / 2;
+}
+
 Rectf
 Camera::get_rect() const
 {

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -87,6 +87,7 @@ public:
   /** return camera position */
   const Vector get_translation() const;
   void set_translation(const Vector& translation) { m_translation = translation; }
+  void set_translation_centered(const Vector& translation);
 
   /** shake camera in a direction 1 time */
   void shake(float duration, float x, float y);

--- a/src/supertux/menu/editor_menu.cpp
+++ b/src/supertux/menu/editor_menu.cpp
@@ -226,7 +226,7 @@ EditorMenu::menu_action(MenuItem& item)
       break;
 
     case MNID_CHECKDEPRECATEDTILES:
-      editor->check_deprecated_tiles();
+      editor->check_deprecated_tiles(true);
       if (editor->has_deprecated_tiles())
       {
         const std::string present_message = _("Deprecated tiles are still present in the level.");


### PR DESCRIPTION
When checking for deprecated tiles in the editor, using the option from the main editor menu, the camera will now centrally focus on the first found deprecated tile in the level, setting the respective sector and tilemap.