### PR TITLE
Undo tracking for multiple objects, no stack clear on save

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -256,7 +256,8 @@ Editor::update(float dt_sec, const Controller& controller)
 
     // Now that all widgets have been updated, which should have relinquished
     // pointers to objects marked for deletion, we can actually delete them.
-    m_sector->flush_game_objects();
+    for (auto& sector : m_level->get_sectors())
+      sector->flush_game_objects();
 
     update_keyboard(controller);
   }
@@ -702,7 +703,6 @@ Editor::convert_tiles_by_file(const std::string& file)
 
   for (const auto& sector : m_level->get_sectors())
   {
-    sector->start_change_stack();
     for (auto& tilemap : sector->get_objects_by_type<TileMap>())
     {
       tilemap.save_state();
@@ -725,7 +725,6 @@ Editor::convert_tiles_by_file(const std::string& file)
       }
       tilemap.check_state();
     }
-    sector->end_change_stack();
   }
 }
 

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -289,7 +289,7 @@ Editor::save_level(const std::string& filename, bool switch_file)
 
   for (const auto& sector : m_level->m_sectors)
   {
-    sector->clear_undo_stack();
+    sector->on_editor_save();
   }
   m_level->save(m_world ? FileSystem::join(m_world->get_basedir(), file) : file);
   m_time_since_last_save = 0.f;
@@ -702,6 +702,7 @@ Editor::convert_tiles_by_file(const std::string& file)
 
   for (const auto& sector : m_level->get_sectors())
   {
+    sector->start_change_stack();
     for (auto& tilemap : sector->get_objects_by_type<TileMap>())
     {
       tilemap.save_state();
@@ -724,6 +725,7 @@ Editor::convert_tiles_by_file(const std::string& file)
       }
       tilemap.check_state();
     }
+    sector->end_change_stack();
   }
 }
 

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -373,12 +373,16 @@ GameObjectManager::redo()
 void
 GameObjectManager::start_change_stack()
 {
-  m_pending_change_stack = { m_change_uid_generator.next(), {} };
+  if (m_undo_tracking)
+    m_pending_change_stack = { m_change_uid_generator.next(), {} };
 }
 
 void
 GameObjectManager::end_change_stack()
 {
+  if (!m_undo_tracking)
+    return;
+
   assert(m_pending_change_stack);
 
   if (!m_pending_change_stack->objects.empty())

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -253,7 +253,7 @@ GameObjectManager::flush_game_objects()
   }
   update_tilemaps();
 
-  // If object changes have been performed this frame, push them to the undo stack.
+  // If object changes have been performed since last flush, push them to the undo stack.
   if (m_undo_tracking && !m_pending_change_stack.empty())
   {
     m_undo_stack.push_back({ m_change_uid_generator.next(), std::move(m_pending_change_stack) });

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -24,7 +24,6 @@
 #include <typeindex>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 
 #include "supertux/game_object.hpp"
 #include "util/uid_generator.hpp"

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -211,11 +211,6 @@ public:
   void undo();
   void redo();
 
-  /** Start/stop adding object changes to a change stack.
-      Used for tracking multiple object changes at once. */
-  void start_change_stack();
-  void end_change_stack();
-
   /** Save object change in the undo stack with given data.
       Used to save an object's previous state before a change had occurred. */
   void save_object_change(GameObject& object, const std::string& data);
@@ -262,9 +257,6 @@ private:
     std::vector<ObjectChange> objects;
   };
 
-  /** Push an object change to either the undo stack, or a pending change stack. */
-  void push_to_undo_stack(ObjectChange change);
-
   /** Create object from object change. */
   void create_object_from_change(const ObjectChange& change);
 
@@ -290,7 +282,7 @@ private:
   int m_undo_stack_size;
   std::vector<ObjectChanges> m_undo_stack;
   std::vector<ObjectChanges> m_redo_stack;
-  std::optional<ObjectChanges> m_pending_change_stack; // If set, add any object changes to this stack
+  std::vector<ObjectChange> m_pending_change_stack; // Before a flush, any changes go here
   UID m_last_saved_change;
 
   std::vector<std::unique_ptr<GameObject>> m_gameobjects;

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -587,21 +587,38 @@ Sector::resize_sector(const Size& old_size, const Size& new_size, const Size& re
   bool is_offset = resize_offset.width || resize_offset.height;
   Vector obj_shift = Vector(static_cast<float>(resize_offset.width) * 32.0f,
                             static_cast<float>(resize_offset.height) * 32.0f);
-  for (const auto& object : get_objects()) {
+
+  start_change_stack();
+  for (const auto& object : get_objects())
+  {
     auto tilemap = dynamic_cast<TileMap*>(object.get());
-    if (tilemap) {
-      if (tilemap->get_size() == old_size) {
+    if (tilemap)
+    {
+      if (tilemap->get_size() == old_size)
+      {
+        tilemap->save_state();
         tilemap->resize(new_size, resize_offset);
-      } else if (is_offset) {
-        tilemap->move_by(obj_shift);
+        tilemap->check_state();
       }
-    } else if (is_offset) {
+      else if (is_offset)
+      {
+        tilemap->save_state();
+        tilemap->move_by(obj_shift);
+        tilemap->check_state();
+      }
+    }
+    else if (is_offset)
+    {
       auto moving_object = dynamic_cast<MovingObject*>(object.get());
-      if (moving_object) {
+      if (moving_object)
+      {
+        moving_object->save_state();
         moving_object->move_to(moving_object->get_pos() + obj_shift);
+        moving_object->check_state();
       }
     }
   }
+  end_change_stack();
 }
 
 void

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -588,7 +588,6 @@ Sector::resize_sector(const Size& old_size, const Size& new_size, const Size& re
   Vector obj_shift = Vector(static_cast<float>(resize_offset.width) * 32.0f,
                             static_cast<float>(resize_offset.height) * 32.0f);
 
-  start_change_stack();
   for (const auto& object : get_objects())
   {
     auto tilemap = dynamic_cast<TileMap*>(object.get());
@@ -618,7 +617,6 @@ Sector::resize_sector(const Size& old_size, const Size& new_size, const Size& re
       }
     }
   }
-  end_change_stack();
 }
 
 void


### PR DESCRIPTION
The undo/redo stack system of `GameObjectManager` now allows for tracking multiple objects, via object change stacks. This has been applied both to the sector resizing and tile conversion features.

Additionally, the stacks are no longer cleared on level save. Instead, the unique ID of the last change in the undo stack is saved, and if it's equal to the unique ID of the last change in the undo stack, it indicates that no changes have been performed in a sector since the last save.