### PR TITLE
Cloning paths in editor, fix various undo/redo issues

### DIFF
--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -16,10 +16,6 @@
 
 #include "editor/overlay_widget.hpp"
 
-#include "util/reader_document.hpp"
-#include "util/reader_mapping.hpp"
-#include "util/writer.hpp"
-
 #include "editor/editor.hpp"
 #include "editor/node_marker.hpp"
 #include "editor/object_menu.hpp"
@@ -730,29 +726,19 @@ EditorOverlayWidget::clone_object()
       return;
     }
 
-    auto* pm = dynamic_cast<MarkerObject*>(m_hovered_object.get());
-    if (!pm)
-    {
-      m_obj_mouse_desync = m_sector_pos - m_hovered_object->get_pos();
+    if (dynamic_cast<MarkerObject*>(m_hovered_object.get()))
+      return;
 
-      // clone the current object by means of saving and loading it
-      auto game_object_uptr = [this]{
-        std::stringstream stream;
-        Writer writer(stream);
-        writer.start_list(m_hovered_object->get_class_name());
-        m_hovered_object->save(writer);
-        writer.end_list(m_hovered_object->get_class_name());
+    m_obj_mouse_desync = m_sector_pos - m_hovered_object->get_pos();
 
-        auto doc = ReaderDocument::from_stream(stream);
-        auto object_sx = doc.get_root();
-        return GameObjectFactory::instance().create(object_sx.get_name(), object_sx.get_mapping());
-      }();
+    auto obj = GameObjectFactory::instance().create(m_hovered_object->get_class_name(), m_hovered_object->save());
 
-      GameObject& game_object = m_editor.get_sector()->add_object(std::move(game_object_uptr));
+    auto* path_object = dynamic_cast<PathObject*>(obj.get());
+    if (path_object)
+      path_object->editor_clone_path(dynamic_cast<PathObject*>(m_hovered_object.get())->get_path_gameobject());
 
-      m_dragged_object = dynamic_cast<MovingObject*>(&game_object);
-      m_dragged_object->after_editor_set();
-    }
+    m_dragged_object = static_cast<MovingObject*>(&m_editor.get_sector()->add_object(std::move(obj)));
+    m_dragged_object->after_editor_set();
   }
   else
   {

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -286,6 +286,20 @@ Camera::after_editor_set()
   }
 }
 
+void
+Camera::save_state()
+{
+  GameObject::save_state();
+  PathObject::save_state();
+}
+
+void
+Camera::check_state()
+{
+  GameObject::check_state();
+  PathObject::check_state();
+}
+
 const Vector
 Camera::get_translation() const
 {

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -73,6 +73,9 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
 
+  void save_state() override;
+  void check_state() override;
+
   virtual const std::string get_icon_path() const override { return "images/engine/editor/camera.png"; }
   /** @} */
 

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -141,6 +141,20 @@ Coin::editor_update()
 }
 
 void
+Coin::save_state()
+{
+  MovingSprite::save_state();
+  PathObject::save_state();
+}
+
+void
+Coin::check_state()
+{
+  MovingSprite::check_state();
+  PathObject::check_state();
+}
+
+void
 Coin::collect()
 {
   static Timer sound_timer;

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -51,6 +51,9 @@ public:
   virtual void after_editor_set() override;
   virtual void editor_update() override;
 
+  void save_state() override;
+  void check_state() override;
+
   virtual void move_to(const Vector& pos) override;
 
   virtual void on_flip(float height) override;

--- a/src/object/path_gameobject.cpp
+++ b/src/object/path_gameobject.cpp
@@ -98,9 +98,8 @@ PathGameObject::PathGameObject(const ReaderMapping& mapping, bool backward_compa
     m_node_sprite = SpriteManager::current()->create("images/objects/path/node.sprite");
   }
 
-  if (m_name.empty()) {
-    set_name(make_unique_name("path", this));
-  }
+  if (m_name.empty())
+    regenerate_name();
 }
 
 PathGameObject::~PathGameObject()
@@ -230,6 +229,12 @@ void
 PathGameObject::on_flip(float height)
 {
   m_path->on_flip(height);
+}
+
+void
+PathGameObject::regenerate_name()
+{
+  set_name(make_unique_name("path", this));
 }
 
 /* EOF */

--- a/src/object/path_gameobject.hpp
+++ b/src/object/path_gameobject.hpp
@@ -58,6 +58,8 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
+  void regenerate_name();
+
   Path& get_path() { return *m_path; }
 
   void copy_into(PathGameObject& other);

--- a/src/object/path_object.cpp
+++ b/src/object/path_object.cpp
@@ -132,9 +132,9 @@ PathObject::editor_clone_path(PathGameObject* path_object)
     return;
 
   auto new_path_obj = GameObjectFactory::instance().create(path_object->get_class_name(), path_object->save());
-  auto* new_path = static_cast<PathGameObject*>(&Editor::current()->get_sector()->add_object(std::move(new_path_obj)));
-  new_path->regenerate_name();
-  m_path_uid = new_path->get_uid();
+  auto& new_path = static_cast<PathGameObject&>(Editor::current()->get_sector()->add_object(std::move(new_path_obj)));
+  new_path.regenerate_name();
+  m_path_uid = new_path.get_uid();
 }
 
 void

--- a/src/object/path_object.hpp
+++ b/src/object/path_object.hpp
@@ -41,10 +41,15 @@ public:
   Path* get_path() const;
   PathWalker* get_walker() const { return m_walker.get(); }
 
+  void editor_clone_path(PathGameObject* path_object);
+
   std::string get_path_ref() const;
   void editor_set_path_by_ref(const std::string& new_ref);
 
 protected:
+  void save_state() const;
+  void check_state() const;
+
   void on_flip();
 
   PathWalker::Handle m_path_handle;

--- a/src/object/platform.cpp
+++ b/src/object/platform.cpp
@@ -196,20 +196,14 @@ void
 Platform::save_state()
 {
   MovingSprite::save_state();
-
-  PathGameObject* path_object = get_path_gameobject();
-  if (path_object)
-    path_object->save_state();
+  PathObject::save_state();
 }
 
 void
 Platform::check_state()
 {
   MovingSprite::check_state();
-
-  PathGameObject* path_object = get_path_gameobject();
-  if (path_object)
-    path_object->check_state();
+  PathObject::check_state();
 }
 
 /* EOF */

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -327,6 +327,20 @@ TileMap::after_editor_set()
 }
 
 void
+TileMap::save_state()
+{
+  GameObject::save_state();
+  PathObject::save_state();
+}
+
+void
+TileMap::check_state()
+{
+  GameObject::check_state();
+  PathObject::check_state();
+}
+
+void
 TileMap::update(float dt_sec)
 {
   // handle tilemap fading

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -61,6 +61,9 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
 
+  void save_state() override;
+  void check_state() override;
+
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -64,7 +64,10 @@ GameObjectManager::request_name_resolve(const std::string& name, std::function<v
 void
 GameObjectManager::process_resolve_requests()
 {
-  assert(m_gameobjects_new.empty());
+  // FIXME: Why is this assertion needed?
+  // Removed to allow for resolving name requests in Sector before object creation,
+  // despite there being queued objects.
+  //assert(m_gameobjects_new.empty());
 
   for (const auto& request : m_name_resolve_requests)
   {
@@ -85,7 +88,11 @@ GameObjectManager::process_resolve_requests()
 void
 GameObjectManager::try_process_resolve_requests()
 {
-  assert(m_gameobjects_new.empty());
+  // FIXME: Why is this assertion needed?
+  // Removed to allow for resolving name requests in Sector before object creation,
+  // despite there being queued objects.
+  //assert(m_gameobjects_new.empty());
+
   std::vector<GameObjectManager::NameResolveRequest> new_list;
 
   for (const auto& request : m_name_resolve_requests)
@@ -256,6 +263,9 @@ GameObjectManager::flush_game_objects()
     }
   }
   update_tilemaps();
+
+  // A resolve request may depend on an object being added.
+  try_process_resolve_requests();
 
   // If object changes have been performed since last flush, push them to the undo stack.
   if (m_undo_tracking && !m_pending_change_stack.empty())

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -385,7 +385,7 @@ Sector::before_object_add(GameObject& object)
   }
 
   if (m_fully_constructed) {
-    process_resolve_requests();
+    try_process_resolve_requests();
     object.finish_construction();
   }
 


### PR DESCRIPTION
Cloning path objects in the editor now clones their path as well. This allows for more robust manipulation of path objects.

Additionally, various undo/redo issues, related to path objects, have also been fixed.

Depends on #2713.