### PR TITLE
Prioritize players in `GameObject` list

### DIFF
--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -79,6 +79,7 @@ public:
   virtual void on_flip(float height) override;
   virtual bool is_saveable() const override { return false; }
   virtual bool is_singleton() const override { return false; }
+  virtual bool priority_in_list() const override { return true; }
   virtual void remove_me() override;
 
   int get_id() const { return m_id; }

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -79,7 +79,7 @@ public:
   virtual void on_flip(float height) override;
   virtual bool is_saveable() const override { return false; }
   virtual bool is_singleton() const override { return false; }
-  virtual bool priority_in_list() const override { return true; }
+  virtual bool has_object_manager_priority() const override { return true; }
   virtual void remove_me() override;
 
   int get_id() const { return m_id; }

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -110,6 +110,9 @@ public:
       If false, load_state() and save_state() calls would not do anything. */
   virtual bool track_state() const { return true; }
 
+  /** Indicates if the object should be added at the beginning of the object list. */
+  virtual bool priority_in_list() const { return false; }
+
   /** Indicates if get_settings() is implemented. If true the editor
       will display Tip and ObjectMenu. */
   virtual bool has_settings() const { return is_saveable(); }

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -111,7 +111,7 @@ public:
   virtual bool track_state() const { return true; }
 
   /** Indicates if the object should be added at the beginning of the object list. */
-  virtual bool priority_in_list() const { return false; }
+  virtual bool has_object_manager_priority() const { return false; }
 
   /** Indicates if get_settings() is implemented. If true the editor
       will display Tip and ObjectMenu. */

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -243,7 +243,11 @@ GameObjectManager::flush_game_objects()
         {
           if (!m_initialized) object->m_track_undo = false;
           this_before_object_add(*object);
-          m_gameobjects.push_back(std::move(object));
+
+          if (object->priority_in_list())
+            m_gameobjects.insert(m_gameobjects.begin(), std::move(object));
+          else
+            m_gameobjects.push_back(std::move(object));
         }
       }
     }

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -244,7 +244,7 @@ GameObjectManager::flush_game_objects()
           if (!m_initialized) object->m_track_undo = false;
           this_before_object_add(*object);
 
-          if (object->priority_in_list())
+          if (object->has_object_manager_priority())
             m_gameobjects.insert(m_gameobjects.begin(), std::move(object));
           else
             m_gameobjects.push_back(std::move(object));


### PR DESCRIPTION
Players are now prioritized in a `GameObjectManager`'s `GameObject` list, allowing for them to be updated first for input processing.

Fixes #2679.