### PR TITLE
Pass reference to the player, who has triggered a script

### DIFF
--- a/src/object/pushbutton.cpp
+++ b/src/object/pushbutton.cpp
@@ -125,7 +125,14 @@ PushButton::collision(GameObject& other, const CollisionHit& hit)
   SoundManager::current()->play(BUTTON_SOUND, get_pos());
 
   // run script
-  Sector::get().run_script(m_script, "PushButton");
+  if (player)
+  {
+    Sector::get().run_script(m_script, "PushButton", *this, {
+        { player->get_name(), "Tux" } // Create trigger reference to the player
+      });
+  }
+  else
+    Sector::get().run_script(m_script, "PushButton", *this, {});
 
   return FORCE_MOVE;
 }

--- a/src/object/scripted_object.cpp
+++ b/src/object/scripted_object.cpp
@@ -71,7 +71,7 @@ ScriptedObject::get_settings()
   result.add_bool(_("Solid"), &solid, "solid", true);
   result.add_bool(_("Physics enabled"), &physic_enabled, "physic-enabled", true);
   result.add_bool(_("Visible"), &visible, "visible", true);
-  result.add_text(_("Hit script"), &hit_script, "hit-script");
+  result.add_script(_("Hit script"), &hit_script, "hit-script");
 
   result.reorder({"z-pos", "visible", "physic-enabled", "solid", "name", "sprite", "script", "button", "x", "y"});
 
@@ -200,7 +200,9 @@ ScriptedObject::collision(GameObject& other, const CollisionHit& )
 {
   auto player = dynamic_cast<Player*> (&other);
   if (player && !hit_script.empty()) {
-    Sector::get().run_script(hit_script, "hit-script");
+    Sector::get().run_script(hit_script, "hit-script", *this, {
+        { player->get_name(), "Tux" } // Create trigger reference to the player
+      });
   }
 
   return FORCE_MOVE;

--- a/src/squirrel/squirrel_environment.hpp
+++ b/src/squirrel/squirrel_environment.hpp
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 
 #include <squirrel.h>
 
@@ -70,6 +71,13 @@ public:
       the script so the script gets destroyed when the SquirrelEnvironment is
       destroyed). */
   void run_script(std::istream& in, const std::string& sourcename);
+
+  /** Pushes a reference to an entry in the environment table, if it exists,
+      to a sub-table in the environment table. */
+  void create_reference(const std::string& name, const std::string& ref_name,
+                        const std::string& ref_table, const std::string& ref_sub_table);
+
+  void modify_table(const std::function<void(SquirrelVM&)>& function);
 
   void update(float dt_sec);
   void wait_for_seconds(HSQUIRRELVM vm, float seconds);

--- a/src/supertux/sector_base.cpp
+++ b/src/supertux/sector_base.cpp
@@ -16,8 +16,6 @@
 
 #include "supertux/sector_base.hpp"
 
-#include "util/log.hpp"
-
 namespace Base {
 
 Sector::Sector(const std::string& type) :
@@ -30,6 +28,29 @@ Sector::Sector(const std::string& type) :
 void
 Sector::run_script(const std::string& script, const std::string& sourcename)
 {
+  m_squirrel_environment->run_script(script, sourcename);
+}
+
+void
+Sector::run_script(const std::string& script, const std::string& sourcename,
+                   const GameObject& object, std::map<std::string, std::string> triggers)
+{
+  if (!object.get_name().empty())
+  {
+    // Delete any existing trigger references
+    m_squirrel_environment->modify_table([&object](SquirrelVM& vm) {
+        try
+        {
+          vm.get_table_entry("triggers");
+          vm.delete_table_entry(object.get_name().c_str());
+        }
+        catch (...) {}
+      });
+
+    for (auto it = triggers.begin(); it != triggers.end(); it++)
+      m_squirrel_environment->create_reference(it->first, it->second, "triggers", object.get_name());
+  }
+
   m_squirrel_environment->run_script(script, sourcename);
 }
 

--- a/src/supertux/sector_base.hpp
+++ b/src/supertux/sector_base.hpp
@@ -19,6 +19,8 @@
 
 #include "supertux/game_object_manager.hpp"
 
+#include <map>
+
 #include "squirrel/squirrel_environment.hpp"
 
 class Level;
@@ -47,6 +49,8 @@ public:
 
   void set_init_script(const std::string& init_script) { m_init_script = init_script; }
   void run_script(const std::string& script, const std::string& sourcename);
+  void run_script(const std::string& script, const std::string& sourcename,
+                  const GameObject& object, std::map<std::string, std::string> triggers);
 
 protected:
   virtual bool before_object_add(GameObject& object) override;

--- a/src/trigger/scripttrigger.cpp
+++ b/src/trigger/scripttrigger.cpp
@@ -17,6 +17,7 @@
 #include "trigger/scripttrigger.hpp"
 
 #include "editor/editor.hpp"
+#include "object/player.hpp"
 #include "supertux/debug.hpp"
 #include "supertux/sector.hpp"
 #include "util/log.hpp"
@@ -58,12 +59,14 @@ ScriptTrigger::get_settings()
 }
 
 void
-ScriptTrigger::event(Player& , EventType type)
+ScriptTrigger::event(Player& player, EventType type)
 {
   if (type != triggerevent || (oneshot && runcount >= 1))
     return;
 
-  Sector::get().run_script(script, "ScriptTrigger");
+  Sector::get().run_script(script, "ScriptTrigger", *this, {
+      { player.get_name(), "Tux" } // Create trigger reference to the player
+    });
   runcount++;
 }
 

--- a/src/trigger/switch.cpp
+++ b/src/trigger/switch.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 
 #include "audio/sound_manager.hpp"
+#include "object/player.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/sector.hpp"
 #include "util/log.hpp"
@@ -33,6 +34,7 @@ Switch::Switch(const ReaderMapping& reader) :
   m_script(),
   m_off_script(),
   m_state(OFF),
+  m_player_name(),
   m_bistable(),
   m_dir(Direction::NONE)
 {
@@ -78,9 +80,13 @@ Switch::update(float )
       break;
     case TURN_ON:
       if (m_sprite->animation_done()) {
+        assert(!m_player_name.empty());
+
         std::ostringstream location;
         location << "switch" << m_col.m_bbox.p1();
-        Sector::get().run_script(m_script, location.str());
+        Sector::get().run_script(m_script, location.str(), *this, {
+            { m_player_name, "Tux" } // Create trigger reference to the player
+          });
 
         set_action("on", m_dir, 1);
         m_state = ON;
@@ -95,9 +101,13 @@ Switch::update(float )
     case TURN_OFF:
       if (m_sprite->animation_done()) {
         if (m_bistable) {
+          assert(!m_player_name.empty());
+
           std::ostringstream location;
           location << "switch" << m_col.m_bbox.p1();
-          Sector::get().run_script(m_off_script, location.str());
+          Sector::get().run_script(m_off_script, location.str(), *this, {
+              { m_player_name, "Tux" } // Create trigger reference to the player
+            });
         }
 
         set_action("off", m_dir);
@@ -108,7 +118,7 @@ Switch::update(float )
 }
 
 void
-Switch::event(Player& , EventType type)
+Switch::event(Player& player, EventType type)
 {
   if (type != EVENT_ACTIVATE) return;
 
@@ -117,6 +127,7 @@ Switch::event(Player& , EventType type)
       set_action("turnon", m_dir, 1);
       SoundManager::current()->play(SWITCH_SOUND, get_pos());
       m_state = TURN_ON;
+      m_player_name = player.get_name();
       break;
     case TURN_ON:
       break;
@@ -125,6 +136,7 @@ Switch::event(Player& , EventType type)
         set_action("turnoff", m_dir, 1);
         SoundManager::current()->play(SWITCH_SOUND, get_pos());
         m_state = TURN_OFF;
+        m_player_name = player.get_name();
       }
       break;
     case TURN_OFF:

--- a/src/trigger/switch.hpp
+++ b/src/trigger/switch.hpp
@@ -50,6 +50,7 @@ private:
   std::string m_script;
   std::string m_off_script;
   SwitchState m_state;
+  std::string m_player_name;
   bool m_bistable;
   Direction m_dir;
 


### PR DESCRIPTION
Previously, there was no way to know which player executed a script.

Squirrel weak references to entries under a `SquirrelEnvironment` table in `sector.triggers.{trigger_object}.{name_of_reference}` are now supported. For example, a reference to the player who has triggered a script trigger, can be found under `sector.triggers.{script_trigger_name}.Tux`. The object must have a name to support trigger info. Before running a script of an object, the `triggers` table of that object is deleted.

References to the player who has activated a script are supported in `PushButton`, `ScriptedObject` hit script, `ScriptTrigger` and `Switch`.

An idea for the future would be to provide such player references from `BadGuy` death scripts as well.