### PR TITLE
Rename `Rectf::contains(const Rectf&)` to `Rectf::overlaps(const Rectf&)`

### DIFF
--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -257,7 +257,7 @@ Crusher::update(float dt_sec)
     brickbox.set_right((m_sideways && m_physic.get_velocity_x() > 0.f) ?
       get_bbox().get_right() + 9.f : get_bbox().get_right() - 1.f);
 
-    if (brickbox.contains(brick.get_bbox()))
+    if (brickbox.overlaps(brick.get_bbox()))
     {
       if (brick.get_class_name() != "heavy-brick")
       {

--- a/src/collision/collision.cpp
+++ b/src/collision/collision.cpp
@@ -37,16 +37,6 @@ void Constraints::merge_constraints(const Constraints& other)
   hit.crush |= other.hit.crush;
 }
 
-bool intersects(const Rectf& r1, const Rectf& r2)
-{
-  if (r1.get_right() < r2.get_left() || r1.get_left() > r2.get_right())
-    return false;
-  if (r1.get_bottom() < r2.get_top() || r1.get_top() > r2.get_bottom())
-    return false;
-
-  return true;
-}
-
 //---------------------------------------------------------------------------
 
 namespace {
@@ -72,7 +62,7 @@ bool rectangle_aatriangle(Constraints* constraints, const Rectf& rect,
                           const AATriangle& triangle,
                           bool& hits_rectangle_bottom)
 {
-  if (!intersects(rect, triangle.bbox))
+  if (!rect.overlaps(triangle.bbox))
     return false;
 
   Vector normal(0.0f, 0.0f);

--- a/src/collision/collision.hpp
+++ b/src/collision/collision.hpp
@@ -102,9 +102,6 @@ private:
   float position_bottom;
 };
 
-/** checks if 2 rectangle intersect each other */
-bool intersects(const Rectf& r1, const Rectf& r2);
-
 /** does collision detection between a rectangle and an axis aligned triangle
  * Returns true in case of a collision and fills in the hit structure then.
  */

--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -118,7 +118,7 @@ collision::Constraints check_collisions(const Vector& obj_movement, const Rectf&
   // adjacent or at least extremely close.
   const Rectf grown_other_obj_rect = other_obj_rect.grown(EPSILON);
 
-  if (!collision::intersects(moving_obj_rect, grown_other_obj_rect))
+  if (!moving_obj_rect.overlaps(grown_other_obj_rect))
     return constraints;
   
   const CollisionHit dummy;
@@ -357,7 +357,7 @@ CollisionSystem::collision_object(CollisionObject* object1, CollisionObject* obj
   const Rectf& r2 = object2->m_dest;
 
   CollisionHit hit;
-  if (intersects(object1->m_dest, object2->m_dest)) {
+  if (object1->m_dest.overlaps(object2->m_dest)) {
     Vector normal(0.0f, 0.0f);
     get_hit_normal(r1, r2, hit, normal);
 
@@ -598,7 +598,7 @@ CollisionSystem::update()
          || !object_2->is_valid())
         continue;
 
-      if (intersects(object->m_dest, object_2->m_dest)) {
+      if (object->m_dest.overlaps(object_2->m_dest)) {
         Vector normal(0.0f, 0.0f);
         CollisionHit hit;
         get_hit_normal(object->m_dest, object_2->m_dest,
@@ -687,7 +687,7 @@ CollisionSystem::is_free_of_statics(const Rectf& rect, const CollisionObject* ig
     if (object == ignore_object) continue;
     if (!object->is_valid()) continue;
     if (object->get_group() == COLGROUP_STATIC) {
-      if (intersects(rect, object->get_bbox())) return false;
+      if (rect.overlaps(object->get_bbox())) return false;
     }
   }
 
@@ -707,7 +707,7 @@ CollisionSystem::is_free_of_movingstatics(const Rectf& rect, const CollisionObje
     if ((object->get_group() == COLGROUP_MOVING)
         || (object->get_group() == COLGROUP_MOVING_STATIC)
         || (object->get_group() == COLGROUP_STATIC)) {
-      if (intersects(rect, object->get_bbox())) return false;
+      if (rect.overlaps(object->get_bbox())) return false;
     }
   }
 
@@ -723,7 +723,7 @@ CollisionSystem::is_free_of_specifically_movingstatics(const Rectf& rect, const 
     if (object == ignore_object) continue;
     if (!object->is_valid()) continue;
     if ((object->get_group() == COLGROUP_MOVING_STATIC)
-        && (intersects(rect, object->get_bbox())))
+        && (rect.overlaps(object->get_bbox())))
       return false;
   }
 

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -830,7 +830,7 @@ EditorOverlayWidget::rubber_rect()
   for (auto& moving_object : m_editor.get_sector()->get_objects_by_type<MovingObject>())
   {
     const Rectf& bbox = moving_object.get_bbox();
-    if (dr.contains(bbox)) {
+    if (dr.overlaps(bbox)) {
       moving_object.editor_delete();
     }
 

--- a/src/math/rectf.hpp
+++ b/src/math/rectf.hpp
@@ -122,9 +122,8 @@ public:
     return v.x >= m_p1.x && v.y >= m_p1.y && v.x < get_right() && v.y < get_bottom();
   }
 
-  bool contains(const Rectf& other) const
+  bool overlaps(const Rectf& other) const
   {
-    // FIXME: This is overlaps(), not contains()!
     if (m_p1.x >= other.get_right() || other.get_left() >= get_right())
       return false;
     if (m_p1.y >= other.get_bottom() || other.get_top() >= get_bottom())

--- a/src/object/ambient_sound.cpp
+++ b/src/object/ambient_sound.cpp
@@ -156,7 +156,7 @@ AmbientSound::update(float dt_sec)
   const Rectf& player_bbox = nearest_player->get_bbox();
   const Vector player_center = player_bbox.get_middle();
 
-  if (get_bbox().contains(player_bbox))
+  if (get_bbox().overlaps(player_bbox))
     m_sound_source->set_gain(m_volume);
   else
   {

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -225,7 +225,7 @@ Coin::collision(GameObject& other, const CollisionHit& )
   auto player = dynamic_cast<Player*>(&other);
   if (player == nullptr)
     return ABORT_MOVE;
-  if (m_col.get_bbox().contains(player->get_bbox().grown(-0.1f)))
+  if (m_col.get_bbox().overlaps(player->get_bbox().grown(-0.1f)))
     collect();
   return ABORT_MOVE;
 }

--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -974,7 +974,7 @@ CustomParticleSystem::collision(Particle* object, const Vector& movement)
               water = true;
           }
         } else { // Normal rectangular tile.
-          if (intersects(dest, rect)) {
+          if (dest.overlaps(rect)) {
             if (tile.get_attributes() & Tile::WATER)
               water = true;
             set_rectangle_rectangle_constraints(&constraints, dest, rect);
@@ -1056,7 +1056,7 @@ CustomParticleSystem::get_collision(Particle* object, const Vector& movement)
           AATriangle triangle = AATriangle(rect, tile.get_data());
           rectangle_aatriangle(&constraints, dest, triangle);
         } else { // Normal rectangular tile.
-          if (intersects(dest, rect)) {
+          if (dest.overlaps(rect)) {
             set_rectangle_rectangle_constraints(&constraints, dest, rect);
           }
         }

--- a/src/object/particlesystem_interactive.cpp
+++ b/src/object/particlesystem_interactive.cpp
@@ -142,7 +142,7 @@ ParticleSystem_Interactive::collision(Particle* object, const Vector& movement)
               water = true;
           }
         } else { // normal rectangular tile
-          if (intersects(dest, rect)) {
+          if (dest.overlaps(rect)) {
             if (tile.get_attributes() & Tile::WATER)
               water = true;
             set_rectangle_rectangle_constraints(&constraints, dest, rect);

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -755,7 +755,7 @@ Player::update(float dt_sec)
     sidebrickbox.set_right(get_bbox().get_right() + (m_dir == Direction::RIGHT ? 12.f : -1.f));
 
     for (auto& brick : Sector::get().get_objects_by_type<Brick>()) {
-      if (sidebrickbox.contains(brick.get_bbox()) && (m_stone || (m_sliding && brick.get_class_name() != "heavy-brick")) &&
+      if (sidebrickbox.overlaps(brick.get_bbox()) && (m_stone || (m_sliding && brick.get_class_name() != "heavy-brick")) &&
         std::abs(m_physic.get_velocity_x()) >= 150.f) {
         brick.try_break(this, is_big());
       }
@@ -769,11 +769,11 @@ Player::update(float dt_sec)
     downbox.set_bottom(downbox.get_bottom() + 16.f);
     for (auto& brick : Sector::get().get_objects_by_type<Brick>()) {
       // stoneform breaks through any kind of bricks
-      if (downbox.contains(brick.get_bbox()) && (m_stone || !dynamic_cast<HeavyBrick*>(&brick)))
+      if (downbox.overlaps(brick.get_bbox()) && (m_stone || !dynamic_cast<HeavyBrick*>(&brick)))
         brick.try_break(this, is_big());
     }
     for (auto& badguy : Sector::get().get_objects_by_type<BadGuy>()) {
-      if (downbox.contains(badguy.get_bbox()) && badguy.is_snipable() && !badguy.is_grabbed())
+      if (downbox.overlaps(badguy.get_bbox()) && badguy.is_snipable() && !badguy.is_grabbed())
         badguy.kill_fall();
     }
   }
@@ -784,7 +784,7 @@ Player::update(float dt_sec)
     Rectf topbox = get_bbox().grown(-1.f);
     topbox.set_top(get_bbox().get_top() - 16.f);
     for (auto& brick : Sector::get().get_objects_by_type<Brick>()) {
-      if (topbox.contains(brick.get_bbox()))
+      if (topbox.overlaps(brick.get_bbox()))
         brick.try_break(this, is_big());
     }
   }

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -103,7 +103,7 @@ Rectf relative_map(const Rectf& inside, const Rect& srcrect, const Rectf& dstrec
                dstrect.get_left() + (inside.get_right() - src_rectf.get_left()) * dstrect.get_width() / src_rectf.get_width(),
                dstrect.get_top() + (inside.get_bottom() - src_rectf.get_top()) * dstrect.get_height() / src_rectf.get_height());
 
-  assert(dstrect.contains(result));
+  assert(dstrect.overlaps(result));
 
   return result;
 }
@@ -117,7 +117,7 @@ void render_texture(SDL_Renderer* renderer,
   if (srcrect.empty() || dstrect.empty())
     return;
 
-  if (imgrect.contains(srcrect))
+  if (imgrect.overlaps(srcrect))
   {
     SDL_Rect sdl_srcrect = srcrect.to_sdl();
     SDL_FRect sdl_dstrect = dstrect.to_sdl();

--- a/tests/collision_test.cpp
+++ b/tests/collision_test.cpp
@@ -16,35 +16,34 @@
 
 #include <gtest/gtest.h>
 
-#include "collision/collision.hpp"
 #include "math/rectf.hpp"
 
-TEST(collisionTest, intersects_test)
+TEST(collisionTest, overlaps_test)
 {
     Rectf r1(1.0,4.0,2.0,5.0);
     Rectf r2(6.0,8.0,10.0,9.0);
 
-    ASSERT_EQ(false, collision::intersects(r1, r2));
+    ASSERT_EQ(false, r1.overlaps(r2));
 
     Rectf r3(8.0,3.0,10.0,5.0);
     Rectf r4(2.0,7.0,4.0,9.0);
 
-    ASSERT_EQ(false, collision::intersects(r3, r4));
+    ASSERT_EQ(false, r3.overlaps(r4));
 
     Rectf r5(4.0,1.0,5.0,2.0);
     Rectf r6(8.0,6.0,9.0,10.0);
 
-    ASSERT_EQ(false, collision::intersects(r5, r6));
+    ASSERT_EQ(false, r5.overlaps(r6));
 
     Rectf r7(3.0,8.0,5.0,10.0);
     Rectf r8(7.0,2.0,9.0,4.0);
 
-    ASSERT_EQ(false, collision::intersects(r7, r8));
+    ASSERT_EQ(false, r7.overlaps(r8));
 
     Rectf r9(3.0,6.0,17.0,15.0);
     Rectf r10(9.0,7.0,10.0,8.0);
 
-    ASSERT_EQ(true, collision::intersects(r9, r10));
+    ASSERT_EQ(true, r9.overlaps(r10));
 }
 
 /* EOF */

--- a/tests/rectf_test.cpp
+++ b/tests/rectf_test.cpp
@@ -24,14 +24,13 @@ TEST(RectfTest, contains_point)
   ASSERT_FALSE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).contains(Vector(250.0f, 150.0f)));
 }
 
-/* FIXME: Current implementation is actually overlaps(), not contains()
-TEST(RectfTest, contains_rect)
+TEST(RectfTest, overlaps_rect)
 {
-  ASSERT_TRUE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).contains(Rectf(150.0f, 150.0f, 190.0f, 190.0f)));
-  ASSERT_TRUE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).contains(Rectf(100.0f, 100.0f, 200.0f, 200.0f)));
-  ASSERT_FALSE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).contains(Rectf(150.0f, 150.0f, 250.0f, 250.0f)));
+  ASSERT_TRUE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).overlaps(Rectf(150.0f, 150.0f, 190.0f, 190.0f)));
+  ASSERT_TRUE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).overlaps(Rectf(100.0f, 100.0f, 200.0f, 200.0f)));
+  ASSERT_FALSE(Rectf(100.0f, 100.0f, 200.0f, 200.0f).overlaps(Rectf(250.0f, 250.0f, 300.0f, 300.0f)));
 }
-*/
+
 
 TEST(RectfTest, moved)
 {


### PR DESCRIPTION
As the title suggests. Additionally remove `collision::intersects` to avoid code duplication because it's exactly the same like `Rectf::overlaps`.