### PR TITLE
Have Tux swim instead of floating when going up/down

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2035,7 +2035,10 @@ Player::draw(DrawingContext& context)
       {
         if (m_water_jump && m_dir != m_old_dir)
           log_debug << "Obracanko (:" << std::endl;
-        if (glm::length(m_physic.get_velocity()) < 50.f)
+        // By using get_velocity_y, we can switch to "-swim" so as to give off the impression that the
+        // penguin is working extra hard to go upwards (in a platformer that's mostly involving the X
+        // coordinates. TL;DR: "Resistance" when going upwards, "zooooom" when going downwards.
+        if ((glm::length(m_physic.get_velocity()) < 60.f) && (glm::length(m_physic.get_velocity_y()) < 30.f))
           m_sprite->set_action(sa_prefix + "-float" + sa_postfix);
         else if (m_water_jump)
           m_sprite->set_action(sa_prefix + "-swimjump" + sa_postfix);


### PR DESCRIPTION
This is a small detail that I mostly made so as to get used to the
codebase.

If the vertical velocity is under a specific threshold, then the
floating animation will be used. Otherwise, if v is too low but
vy is too high, show the swimming animation instead.

I feel like the change in itself makes sense, even if it won't
be noticed by any player that isn't willing to move around in squares.