### PR TITLE
Properly handle SoundObject play time

### DIFF
--- a/src/audio/dummy_sound_source.cpp
+++ b/src/audio/dummy_sound_source.cpp
@@ -39,6 +39,11 @@ public:
     is_playing = false;
   }
 
+  virtual void pause() override
+  {
+    is_playing = false;
+  }
+
   virtual bool playing() const override
   {
     return is_playing;

--- a/src/audio/openal_sound_source.cpp
+++ b/src/audio/openal_sound_source.cpp
@@ -62,6 +62,20 @@ OpenALSoundSource::stop(bool unload_buffer)
 }
 
 void
+OpenALSoundSource::pause()
+{
+  alSourcePause(m_source);
+  try
+  {
+    SoundManager::check_al_error("Couldn't pause audio source: ");
+  }
+  catch(const std::exception& e)
+  {
+    log_warning << e.what() << std::endl;
+  }
+}
+
+void
 OpenALSoundSource::play()
 {
   alSourcePlay(m_source);
@@ -83,20 +97,6 @@ OpenALSoundSource::playing() const
   ALint state = AL_PLAYING;
   alGetSourcei(m_source, AL_SOURCE_STATE, &state);
   return state == AL_PLAYING;
-}
-
-void
-OpenALSoundSource::pause()
-{
-  alSourcePause(m_source);
-  try
-  {
-    SoundManager::check_al_error("Couldn't pause audio source: ");
-  }
-  catch(const std::exception& e)
-  {
-    log_warning << e.what() << std::endl;
-  }
 }
 
 void

--- a/src/audio/openal_sound_source.hpp
+++ b/src/audio/openal_sound_source.hpp
@@ -31,6 +31,7 @@ public:
 
   virtual void play() override;
   virtual void stop(bool unload_buffer = true) override;
+  virtual void pause() override;
   virtual bool playing() const override;
 
   virtual void set_looping(bool looping) override;
@@ -43,7 +44,6 @@ public:
 
   virtual void set_volume(float volume);
 
-  virtual void pause();
   virtual bool paused() const;
   virtual void resume();
   virtual void update();

--- a/src/audio/sound_source.hpp
+++ b/src/audio/sound_source.hpp
@@ -30,6 +30,7 @@ public:
 
   virtual void play() = 0;
   virtual void stop(bool unload_buffer = true) = 0;
+  virtual void pause() {}
   virtual bool playing() const = 0;
 
   virtual void set_looping(bool looping) = 0;

--- a/src/audio/sound_source.hpp
+++ b/src/audio/sound_source.hpp
@@ -30,7 +30,7 @@ public:
 
   virtual void play() = 0;
   virtual void stop(bool unload_buffer = true) = 0;
-  virtual void pause() {}
+  virtual void pause() = 0;
   virtual bool playing() const = 0;
 
   virtual void set_looping(bool looping) = 0;

--- a/src/object/sound_object.hpp
+++ b/src/object/sound_object.hpp
@@ -35,7 +35,7 @@ public:
   ~SoundObject() override;
 
   virtual void draw(DrawingContext& context) override {}
-  virtual void update(float dt_sec) override {}
+  virtual void update(float dt_sec) override;
 
   static std::string class_name() { return "sound-object"; }
   virtual std::string get_class_name() const override { return class_name(); }
@@ -58,6 +58,7 @@ private:
   std::string m_sample;
   std::unique_ptr<SoundSource> m_sound_source;
   float m_volume;
+  bool m_started;
 
 private:
   void prepare_sound_source();


### PR DESCRIPTION
Fixes two issues:
- OpenAL source not properly stopping via using `alSourcePause` instead of `alSourceStop`
- `SoundObject`s playing from currently inactive `Sector`s via playing OpenAL source in `update()`

Fixes #2744 