### PR TITLE
Improve chasing fish

### DIFF
--- a/src/badguy/dive_mine.cpp
+++ b/src/badguy/dive_mine.cpp
@@ -101,6 +101,12 @@ DiveMine::collision_player(Player& player, const CollisionHit& hit)
 }
 
 void
+DiveMine::kill_fall()
+{
+  explode();
+}
+
+void
 DiveMine::draw(DrawingContext& context)
 {
   BadGuy::draw(context);

--- a/src/badguy/dive_mine.hpp
+++ b/src/badguy/dive_mine.hpp
@@ -35,6 +35,8 @@ public:
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
   virtual HitResponse collision_player(Player& player, const CollisionHit& hit) override;
 
+  virtual void kill_fall() override;
+
   virtual void draw(DrawingContext& context) override;
   virtual void active_update(float dt_sec) override;
 

--- a/src/badguy/fish_chasing.cpp
+++ b/src/badguy/fish_chasing.cpp
@@ -25,11 +25,16 @@ static const float TRACK_DISTANCE = 200.0f;
 static const float LOST_DISTANCE = 400.0f;
 static const float CHASE_SPEED = 300.0f;
 static const float REALIZATION_TIME = 0.7f;
+static const float ACCELERATION_TIME = 0.2f;
+static const float DECELERATION_TIME = 0.4f;
 
 FishChasing::FishChasing(const ReaderMapping& reader) :
   FishSwimming(reader, "images/creatures/fish/ice/greenfish.sprite"),
   m_chase_state(ChaseState::NORMAL),
   m_realization_timer(),
+  m_acceleration_timer(),
+  m_is_accelerating(false),
+  m_last_chase_velocity(),
   m_track_distance(),
   m_lost_distance(),
   m_chase_speed()
@@ -57,7 +62,12 @@ FishChasing::active_update(float dt_sec) {
   // Perform basic updates.
   BadGuy::active_update(dt_sec);
   m_in_water = !Sector::get().is_free_of_tiles(get_bbox(), true, Tile::WATER);
-  m_physic.enable_gravity((!m_frozen && m_in_water) ? false : true);
+
+  Rectf top_of_fish = get_bbox();
+  top_of_fish.set_height(1.0f);
+
+  const bool is_completely_in_water = !Sector::get().is_free_of_tiles(top_of_fish, true, Tile::WATER);
+  m_physic.enable_gravity(m_frozen || !is_completely_in_water);
 
   // Handle beached state when the fish is in water and beached_timer is active.
   if (m_in_water && m_beached_timer.started())
@@ -73,16 +83,19 @@ FishChasing::active_update(float dt_sec) {
   // Behavior - chase the nearest player.
   auto player = get_nearest_player();
   if (!player) return;
-  Vector p1 = m_col.m_bbox.get_middle();
-  Vector p2 = player->get_bbox().get_middle();
-  Vector dist = (p2 - p1);
+  const Vector p1 = m_col.m_bbox.get_middle();
+  const Vector p2 = player->get_bbox().get_middle();
+  const Vector dist = (p2 - p1);
+  const bool is_player_in_water = player->is_swimming() || player->is_swimboosting() || player->is_water_jumping();
+  const bool is_facing_player = (m_dir == Direction::LEFT && dist.x <= 0.0f) || (m_dir == Direction::RIGHT && dist.x >= 0.0f );
+  const bool can_see_player = Sector::get().free_line_of_sight(p1,p2, true, this);
 
   switch (m_chase_state)
   {
   case NORMAL:
     FishSwimming::active_update(dt_sec);
 
-    if (glm::length(dist) <= m_track_distance && m_in_water && !m_frozen)
+    if (glm::length(dist) <= m_track_distance && m_in_water && !m_frozen && is_player_in_water && is_facing_player && can_see_player)
     {
       m_realization_timer.start(REALIZATION_TIME);
       m_chase_state = ChaseState::FOUND;
@@ -98,47 +111,80 @@ FishChasing::active_update(float dt_sec) {
     if (m_realization_timer.check())
     {
       m_realization_timer.stop();
+      m_is_accelerating = true;
+      m_acceleration_timer.start(ACCELERATION_TIME);
       m_chase_state = ChaseState::CHASING;
     }
     break;
   case CHASING:
-    if (glm::length(dist) > m_lost_distance)
+    if (glm::length(dist) > m_lost_distance || !is_player_in_water || !can_see_player)
     {
-      m_realization_timer.start(REALIZATION_TIME);
+      m_last_chase_velocity = glm::length(m_physic.get_velocity());
+      m_acceleration_timer.start(DECELERATION_TIME);
+      m_is_accelerating = true;
       m_chase_state = ChaseState::LOST;
     }
     else if (glm::length(dist) >= 1 && m_in_water && !m_frozen)
     {
-      m_dir = (m_physic.get_velocity_x() <= 0.f ? Direction::LEFT : Direction::RIGHT);
-      set_action("chase", m_dir);
-      Vector dir = glm::normalize(dist);
-      m_physic.set_velocity(dir * m_chase_speed);
+      const Vector dir = glm::normalize(dist);
+      float swim_velocity = m_chase_speed;
+
+      if (m_acceleration_timer.check())
+      {
+        m_is_accelerating = false;
+      }
+
+      if (m_is_accelerating)
+      {
+        const float acceleration_progress = m_acceleration_timer.get_timegone() / ACCELERATION_TIME;
+        swim_velocity = acceleration_progress * m_chase_speed;
+      }
+      m_physic.set_velocity(dir * swim_velocity);
     }
     else
     {
       /* We somehow landed right on top of the player without colliding.
        * Sit tight and avoid a division by zero. */
     }
+    m_dir = (m_physic.get_velocity_x() <= 0.f ? Direction::LEFT : Direction::RIGHT);
+    set_action("chase", m_dir);
     break;
   case LOST:
     set_action("swim", m_dir);
 
     if (m_in_water && !m_frozen)
     {
-      if (std::abs(glm::length(m_physic.get_velocity())) >= 10.f) {
-        m_physic.set_velocity(m_physic.get_velocity() / 1.25f);
-      }
-      else if (std::abs(glm::length(m_physic.get_velocity())) < 10.f && m_realization_timer.check())
+      if (m_is_accelerating)
       {
-        m_realization_timer.stop();
-        m_physic.set_velocity(0.f, 0.f);
-        m_start_position = get_pos();
-        m_state = FishYState::BALANCED;
-        m_chase_state = ChaseState::NORMAL;
+        if (m_acceleration_timer.check())
+        {
+          m_is_accelerating = false;
+          m_start_position = get_pos();
+          m_state = FishYState::BALANCED;
+          m_chase_state = ChaseState::NORMAL;
+          m_physic.set_velocity(0.f, 0.f);
+        }
+        else
+        {
+          const float swim_velocity = m_last_chase_velocity * (m_acceleration_timer.get_timeleft() / DECELERATION_TIME);
+          m_physic.set_velocity(glm::normalize(m_physic.get_velocity()) * swim_velocity);
+        }
       }
     }
     break;
   }
+}
+
+HitResponse
+FishChasing::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
+{
+  if (m_chase_state == ChaseState::CHASING)
+  {
+    badguy.kill_fall();
+    return FORCE_MOVE;
+  }
+
+  return FishSwimming::collision_badguy(badguy, hit);
 }
 
 ObjectSettings

--- a/src/badguy/fish_chasing.hpp
+++ b/src/badguy/fish_chasing.hpp
@@ -26,6 +26,8 @@ public:
 
   virtual void active_update(float dt_sec) override;
 
+  virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
+
   static std::string class_name() { return "fish-chasing"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Chasing Fish"); }
@@ -45,6 +47,9 @@ private:
 
   ChaseState m_chase_state;
   Timer m_realization_timer;
+  Timer m_acceleration_timer;
+  bool m_is_accelerating;
+  float m_last_chase_velocity;
   float m_track_distance;
   float m_lost_distance;
   float m_chase_speed;


### PR DESCRIPTION
I tried to implement all suggestions from #2711:
- Kill badguy on collision if in chase mode
- Only spot Tux if it is in water and fish is facing Tux
- Stop chasing if player leaves the water
- Do not track player if obstacles are in the way
- Enable gravity until fish is completely in water
- Use linear acceleration at beginning of chase

Feel free to test and leave comments.