### PR TITLE
Linked sprite support, custom `MovingSprite` light sprites

### DIFF
--- a/data/images/creatures/dive_mine/dive_mine.sprite
+++ b/data/images/creatures/dive_mine/dive_mine.sprite
@@ -54,5 +54,8 @@
   (fps 15.0)
   (hitbox 14 19 32 32)
   (mirror-action "ticking-left"))
- 
+
+  (linked-sprites
+    (ticking-glow "images/creatures/dive_mine/ticking_glow/ticking_glow.sprite")
+  )
 )

--- a/data/images/creatures/ghosttree/ghosttree.sprite
+++ b/data/images/creatures/ghosttree/ghosttree.sprite
@@ -28,4 +28,8 @@
       "ghosttree-dying-0.png"
     )
   )
+
+  (linked-sprites
+    (glow "ghosttree-glow.sprite")
+  )
 )

--- a/data/images/creatures/ghosttree/root.sprite
+++ b/data/images/creatures/ghosttree/root.sprite
@@ -3,4 +3,8 @@
     (name "default")
     (images "root.png")
   )
+
+  (linked-sprites
+    (base "root_base.sprite")
+  )
 )

--- a/data/images/creatures/gold_bomb/gold_bomb.sprite
+++ b/data/images/creatures/gold_bomb/gold_bomb.sprite
@@ -177,5 +177,8 @@
   (loops 1)
   (hitbox 14 19 32 32)
   (mirror-action "ticking-left"))
- 
+
+  (linked-sprites
+    (explode "images/creatures/mr_bomb/ticking_glow/ticking_glow.sprite")
+  )
 )

--- a/data/images/creatures/granito/corrupted/big/rock_mine.sprite
+++ b/data/images/creatures/granito/corrupted/big/rock_mine.sprite
@@ -40,4 +40,9 @@
 	  (hitbox 18 26 48 48)
 	  (mirror-action "broken-left")
 	)
+
+	(linked-sprites
+	  (rock-particles "images/particles/granito_piece.sprite")
+	  (shard "root_spike.sprite")
+	)
 )

--- a/data/images/creatures/haywire/haywire.sprite
+++ b/data/images/creatures/haywire/haywire.sprite
@@ -106,4 +106,8 @@
   (fps 20.0)
   (hitbox 14 19 32 32)
   (mirror-action "jump-left"))
+
+  (linked-sprites
+    (ticking-glow "ticking_glow/ticking_glow.sprite")
+  )
 )

--- a/data/images/creatures/kugelblitz/kugelblitz.sprite
+++ b/data/images/creatures/kugelblitz/kugelblitz.sprite
@@ -23,6 +23,6 @@
           "pop-3.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light.sprite")
+    (light "images/objects/lightmap_light/lightmap_light.sprite" 0.2 0.1 0)
   )
 )

--- a/data/images/creatures/kugelblitz/kugelblitz.sprite
+++ b/data/images/creatures/kugelblitz/kugelblitz.sprite
@@ -21,4 +21,8 @@
           "pop-1.png"
           "pop-2.png"
           "pop-3.png"))
-) 
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light.sprite")
+  )
+)

--- a/data/images/creatures/mr_bomb/mr_bomb.sprite
+++ b/data/images/creatures/mr_bomb/mr_bomb.sprite
@@ -108,5 +108,8 @@
   (loops 1)
   (hitbox 14 19 32 32)
   (mirror-action "ticking-left"))
- 
+
+  (linked-sprites
+    (explode "ticking_glow/ticking_glow.sprite")
+  )
 )

--- a/data/images/objects/bonus_block/bonusblock.sprite
+++ b/data/images/objects/bonus_block/bonusblock.sprite
@@ -29,4 +29,8 @@
       (action
 		 (name "off")
          (images "lightblock_off.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/bonusblock_light.png")
+  )
 )

--- a/data/images/objects/bonus_block/bonusblock.sprite
+++ b/data/images/objects/bonus_block/bonusblock.sprite
@@ -31,6 +31,6 @@
          (images "lightblock_off.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/bonusblock_light.png")
+    (on-light "images/objects/lightmap_light/bonusblock_light.png")
   )
 )

--- a/data/images/objects/bonus_block/orangeblock.sprite
+++ b/data/images/objects/bonus_block/orangeblock.sprite
@@ -19,4 +19,8 @@
           (surface
            (diffuse-texture (file "orange_empty.png"))
            (displacement-texture (file "displacement.png")))))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/bonusblock_light.png")
+  )
 )

--- a/data/images/objects/bonus_block/orangeblock.sprite
+++ b/data/images/objects/bonus_block/orangeblock.sprite
@@ -21,6 +21,6 @@
            (displacement-texture (file "displacement.png")))))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/bonusblock_light.png")
+    (on-light "images/objects/lightmap_light/bonusblock_light.png")
   )
 )

--- a/data/images/objects/bonus_block/purpleblock.sprite
+++ b/data/images/objects/bonus_block/purpleblock.sprite
@@ -21,6 +21,6 @@
            (displacement-texture (file "displacement.png")))))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/bonusblock_light.png")
+    (on-light "images/objects/lightmap_light/bonusblock_light.png")
   )
 )

--- a/data/images/objects/bonus_block/purpleblock.sprite
+++ b/data/images/objects/bonus_block/purpleblock.sprite
@@ -19,4 +19,8 @@
           (surface
            (diffuse-texture (file "purple_empty.png"))
            (displacement-texture (file "displacement.png")))))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/bonusblock_light.png")
+  )
 )

--- a/data/images/objects/bonus_block/retroblock.sprite
+++ b/data/images/objects/bonus_block/retroblock.sprite
@@ -12,6 +12,6 @@
            (displacement-texture (file "displacement.png")))))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/bonusblock_light.png")
+    (on-light "images/objects/lightmap_light/bonusblock_light.png")
   )
 )

--- a/data/images/objects/bonus_block/retroblock.sprite
+++ b/data/images/objects/bonus_block/retroblock.sprite
@@ -10,4 +10,8 @@
           (surface
            (diffuse-texture (file "box-empty.png"))
            (displacement-texture (file "displacement.png")))))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/bonusblock_light.png")
+  )
 )

--- a/data/images/objects/bullets/firebullet.sprite
+++ b/data/images/objects/bullets/firebullet.sprite
@@ -7,4 +7,8 @@
    "fire_bullet-2.png"
    "fire_bullet-3.png")
  )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
 )

--- a/data/images/objects/bullets/firebullet.sprite
+++ b/data/images/objects/bullets/firebullet.sprite
@@ -9,6 +9,6 @@
  )
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0.3 0.1 0)
   )
 )

--- a/data/images/objects/candle/candle.sprite
+++ b/data/images/objects/candle/candle.sprite
@@ -18,5 +18,9 @@
       "candle-0.png"
 	)
   )
-)
 
+  (linked-sprites
+    (light-1 "candle-light-1.sprite")
+    (light-2 "candle-light-2.sprite")
+  )
+)

--- a/data/images/objects/door/door.sprite
+++ b/data/images/objects/door/door.sprite
@@ -41,4 +41,8 @@
       "door-1.png"
       "door-0.png")
   )
+
+  (linked-sprites
+    (lock "door_lock.sprite")
+  )
 )

--- a/data/images/objects/explosion/explosion.sprite
+++ b/data/images/objects/explosion/explosion.sprite
@@ -27,6 +27,6 @@
   )
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-large.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-large.sprite" 0.6 0.6 0.6)
   )
 )

--- a/data/images/objects/explosion/explosion.sprite
+++ b/data/images/objects/explosion/explosion.sprite
@@ -25,5 +25,8 @@
     (hitbox 0 0 48 48)
     (images "pop-0.png")
   )
-)
 
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-large.sprite")
+  )
+)

--- a/data/images/objects/keys/key.sprite
+++ b/data/images/objects/keys/key.sprite
@@ -8,4 +8,9 @@
 		(name "silver-left")
 		(hitbox 0 2 48 28)
 		(mirror-action "silver-right"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (sparkle "images/particles/sparkle.sprite")
+  )
 )

--- a/data/images/objects/lantern/lantern.sprite
+++ b/data/images/objects/lantern/lantern.sprite
@@ -20,4 +20,8 @@
         (hitbox 8 28 34 39)
         (images "lantern-1.png")
       )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light.sprite")
+  )
 )

--- a/data/images/objects/resetpoints/torch.sprite
+++ b/data/images/objects/resetpoints/torch.sprite
@@ -24,5 +24,9 @@
 "torch6.png"
 
   )
- )              
+ )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
 )

--- a/data/images/objects/resetpoints/torch.sprite
+++ b/data/images/objects/resetpoints/torch.sprite
@@ -27,6 +27,6 @@
  )
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "torch_light.sprite" 0.87 0.64 0.12)
   )
 )

--- a/data/images/objects/resetpoints/torch_light.sprite
+++ b/data/images/objects/resetpoints/torch_light.sprite
@@ -1,0 +1,8 @@
+(supertux-sprite
+    (action
+      (name "default")
+      (images "../lightmap_light/lightmap_light-small.png")
+      (hitbox 64 76 0 0)
+      (flip-offset 48)
+    )
+)

--- a/data/images/objects/rublight/rublight.sprite
+++ b/data/images/objects/rublight/rublight.sprite
@@ -19,4 +19,8 @@
     (name "inactive")
 	(images "rublight-0.png")
   )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light.sprite")
+  )
 )

--- a/data/images/objects/torch/torch1.sprite
+++ b/data/images/objects/torch/torch1.sprite
@@ -4,4 +4,10 @@
     (hitbox 0 0 16 100)
     (images "torch1.png")
   )
+
+  (linked-sprites
+    (flame "flame.sprite")
+    (glow "flame_glow.sprite")
+    (light "flame_light.sprite")
+  )
 )

--- a/data/images/objects/torch/torch2.sprite
+++ b/data/images/objects/torch/torch2.sprite
@@ -4,4 +4,10 @@
     (hitbox 0 0 16 100)
     (images "torch2.png")
   )
+
+  (linked-sprites
+    (flame "flame.sprite")
+    (glow "flame_glow.sprite")
+    (light "flame_light.sprite")
+  )
 )

--- a/data/images/objects/torch/torch3.sprite
+++ b/data/images/objects/torch/torch3.sprite
@@ -4,4 +4,10 @@
     (hitbox 0 0 16 100)
     (images "torch3.png")
   )
+
+  (linked-sprites
+    (flame "flame.sprite")
+    (glow "flame_glow.sprite")
+    (light "flame_light.sprite")
+  )
 )

--- a/data/images/objects/torch/torch4.sprite
+++ b/data/images/objects/torch/torch4.sprite
@@ -4,4 +4,10 @@
     (hitbox 0 0 16 100)
     (images "torch4.png")
   )
+
+  (linked-sprites
+    (flame "flame.sprite")
+    (glow "flame_glow.sprite")
+    (light "flame_light.sprite")
+  )
 )

--- a/data/images/objects/weak_block/strawbox.sprite
+++ b/data/images/objects/weak_block/strawbox.sprite
@@ -32,6 +32,6 @@
   )
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (burn-light "images/objects/lightmap_light/lightmap_light-small.sprite")
   )
 )

--- a/data/images/objects/weak_block/strawbox.sprite
+++ b/data/images/objects/weak_block/strawbox.sprite
@@ -30,4 +30,8 @@
       "strawbox-11.png"
     )
   )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
 )

--- a/data/images/particles/sparkle.sprite
+++ b/data/images/particles/sparkle.sprite
@@ -34,4 +34,8 @@
       "sparkle-0.png"
     )
   )
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-tiny.sprite")
+  )
 )

--- a/data/images/powerups/airflower/airflower.sprite
+++ b/data/images/powerups/airflower/airflower.sprite
@@ -6,4 +6,9 @@
                  "air_flower-2.png"
                  "air_flower-3.png"
                  "air_flower-2.png"
-                 "air_flower-1.png")))
+                 "air_flower-1.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/airflower/airflower.sprite
+++ b/data/images/powerups/airflower/airflower.sprite
@@ -9,6 +9,6 @@
                  "air_flower-1.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0.15 0 0.15)
   )
 )

--- a/data/images/powerups/earthflower/earthflower.sprite
+++ b/data/images/powerups/earthflower/earthflower.sprite
@@ -6,4 +6,9 @@
                  "earth_flower-2.png"
                  "earth_flower-3.png"
                  "earth_flower-2.png"
-                 "earth_flower-1.png")))
+                 "earth_flower-1.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/earthflower/earthflower.sprite
+++ b/data/images/powerups/earthflower/earthflower.sprite
@@ -9,6 +9,6 @@
                  "earth_flower-1.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0 0.3 0)
   )
 )

--- a/data/images/powerups/egg/egg.sprite
+++ b/data/images/powerups/egg/egg.sprite
@@ -10,6 +10,6 @@
 
   (linked-sprites
     (shade "egg.sprite")
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0.2 0.2 0)
   )
 )

--- a/data/images/powerups/egg/egg.sprite
+++ b/data/images/powerups/egg/egg.sprite
@@ -7,5 +7,9 @@
     (name "shadow")
     (images "egg-shade.png")
   )
-)
 
+  (linked-sprites
+    (shade "egg.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/fireflower/fireflower.sprite
+++ b/data/images/powerups/fireflower/fireflower.sprite
@@ -6,4 +6,9 @@
                  "fire_flower-2.png"
                  "fire_flower-3.png"
                  "fire_flower-2.png"
-                 "fire_flower-1.png")))
+                 "fire_flower-1.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/fireflower/fireflower.sprite
+++ b/data/images/powerups/fireflower/fireflower.sprite
@@ -9,6 +9,6 @@
                  "fire_flower-1.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0.3 0 0)
   )
 )

--- a/data/images/powerups/iceflower/iceflower.sprite
+++ b/data/images/powerups/iceflower/iceflower.sprite
@@ -9,6 +9,6 @@
                  "ice_flower-1.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0 0.1 0.2)
   )
 )

--- a/data/images/powerups/iceflower/iceflower.sprite
+++ b/data/images/powerups/iceflower/iceflower.sprite
@@ -6,4 +6,9 @@
                  "ice_flower-2.png"
                  "ice_flower-3.png"
                  "ice_flower-2.png"
-                 "ice_flower-1.png")))
+                 "ice_flower-1.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/potions/red-potion.sprite
+++ b/data/images/powerups/potions/red-potion.sprite
@@ -1,6 +1,5 @@
 (supertux-sprite
- (action
-  (name "default")
-  (images "red-potion.png")
- )
-)  
+  (action
+    (name "default")
+    (images "red-potion.png")
+  ))

--- a/data/images/powerups/star/star.sprite
+++ b/data/images/powerups/star/star.sprite
@@ -8,4 +8,9 @@
                  "star-4.png"
                  "star-3.png"
                  "star-2.png"
-                 "star-1.png")))
+                 "star-1.png"))
+
+  (linked-sprites
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+  )
+)

--- a/data/images/powerups/star/star.sprite
+++ b/data/images/powerups/star/star.sprite
@@ -11,6 +11,6 @@
                  "star-1.png"))
 
   (linked-sprites
-    (light "images/objects/lightmap_light/lightmap_light-small.sprite")
+    (light "images/objects/lightmap_light/lightmap_light-small.sprite" 0.4 0.4 0.4)
   )
 )

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -140,9 +140,8 @@ BadGuy::draw(DrawingContext& context)
 
   if (m_state == STATE_INIT || m_state == STATE_INACTIVE)
   {
-    if (Editor::is_active()) {
-      m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
-    }
+    if (Editor::is_active())
+      MovingSprite::draw(context);
   }
   else
   {
@@ -150,7 +149,7 @@ BadGuy::draw(DrawingContext& context)
     {
       context.push_transform();
       context.set_flip(context.get_flip() ^ VERTICAL_FLIP);
-      m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
+      MovingSprite::draw(context);
       context.pop_transform();
     }
     else
@@ -165,7 +164,11 @@ BadGuy::draw(DrawingContext& context)
       {
         if (m_frozen && is_portable())
           m_freezesprite->draw(context.color(), get_pos(), m_layer);
-        m_sprite->draw(context.color(), get_pos(), m_layer - (m_frozen ? 1 : 0), m_flip);
+
+        if (m_frozen)
+          m_sprite->draw(context.color(), get_pos(), m_layer - 1, m_flip);
+        else
+          MovingSprite::draw(context);
       }
 
       if (m_glowing)

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -28,7 +28,7 @@
 Bomb::Bomb(const Vector& pos, Direction dir_, const std::string& custom_sprite /*= "images/creatures/mr_bomb/mr_bomb.sprite"*/ ) :
   BadGuy( pos, dir_, custom_sprite ),
   ticking(SoundManager::current()->create_sound_source("sounds/fizz.wav")),
-  m_exploding_sprite(SpriteManager::current()->create("images/creatures/mr_bomb/ticking_glow/ticking_glow.sprite"))
+  m_exploding_sprite(m_sprite->get_linked_sprite("explode"))
 {
   SoundManager::current()->preload("sounds/explosion.wav");
   set_action("ticking", dir_, 1);
@@ -39,6 +39,14 @@ Bomb::Bomb(const Vector& pos, Direction dir_, const std::string& custom_sprite /
   ticking->set_gain(1.0f);
   ticking->set_reference_distance(32);
   ticking->play();
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Bomb::get_linked_sprites()
+{
+  return {
+    { "explode", m_exploding_sprite }
+  };
 }
 
 void

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -41,7 +41,7 @@ Bomb::Bomb(const Vector& pos, Direction dir_, const std::string& custom_sprite /
   ticking->play();
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Bomb::get_linked_sprites()
 {
   return {

--- a/src/badguy/bomb.hpp
+++ b/src/badguy/bomb.hpp
@@ -48,7 +48,7 @@ public:
   virtual void play_looping_sounds() override;
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   std::unique_ptr<SoundSource> ticking;

--- a/src/badguy/bomb.hpp
+++ b/src/badguy/bomb.hpp
@@ -47,6 +47,9 @@ public:
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   std::unique_ptr<SoundSource> ticking;
   SpritePtr m_exploding_sprite;

--- a/src/badguy/corrupted_granito_big.cpp
+++ b/src/badguy/corrupted_granito_big.cpp
@@ -25,7 +25,6 @@
 #include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
-static const std::string SHARD_SPRITE = "images/creatures/granito/corrupted/big/root_spike.sprite";
 static const float RANGE = 5; // tiles
 static const float CRACK_TIME = 1.f; // seconds
 static const float SHAKE_TIME = 0.1f; // seconds
@@ -35,8 +34,7 @@ CorruptedGranitoBig::CorruptedGranitoBig(const ReaderMapping& reader) :
   m_state(STATE_READY),
   m_crack_timer(),
   m_shake_timer(),
-  m_shake_delta(0.f),
-  m_rock_particles(SpriteManager::current()->create("images/particles/granito_piece.sprite"))
+  m_shake_delta(0.f)
 {
   parse_type(reader);
 
@@ -87,10 +85,11 @@ CorruptedGranitoBig::kill_fall()
 
   run_dead_script();
 
-  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(100.f, -500.f), SHARD_SPRITE);
-  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(270.f, -350.f), SHARD_SPRITE);
-  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(-100.f, -500.f),SHARD_SPRITE);
-  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(-270.f, -350.f),SHARD_SPRITE);
+  const std::string shard_sprite = m_sprite->get_linked_sprite_file("shard");
+  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(100.f, -500.f), shard_sprite);
+  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(270.f, -350.f), shard_sprite);
+  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(-100.f, -500.f),shard_sprite);
+  Sector::get().add<Shard>(get_bbox().get_middle(), Vector(-270.f, -350.f),shard_sprite);
 
   crack_effects(6);
 }
@@ -161,7 +160,8 @@ CorruptedGranitoBig::crack_effects(int particles)
   {
     const Vector velocity(graphicsRandom.randf(-100, 100),
                           graphicsRandom.randf(-400, -300));
-    Sector::get().add<SpriteParticle>(m_rock_particles->clone(), "piece-" + std::to_string(i),
+    Sector::get().add<SpriteParticle>(m_sprite->get_linked_sprite("rock-particles"),
+                                      "piece-" + std::to_string(i),
                                       get_bbox().get_middle(), ANCHOR_MIDDLE,
                                       velocity, Vector(0, gravity),
                                       LAYER_OBJECTS + 3, true);

--- a/src/badguy/corrupted_granito_big.hpp
+++ b/src/badguy/corrupted_granito_big.hpp
@@ -59,8 +59,6 @@ private:
   Timer m_shake_timer;
   float m_shake_delta;
 
-  SpritePtr m_rock_particles;
-
 private:
   CorruptedGranitoBig(const CorruptedGranitoBig&) = delete;
   CorruptedGranitoBig& operator=(const CorruptedGranitoBig&) = delete;

--- a/src/badguy/dive_mine.cpp
+++ b/src/badguy/dive_mine.cpp
@@ -29,10 +29,18 @@ const float DiveMine::s_max_float_acceleration = 15.f;
 
 DiveMine::DiveMine(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/dive_mine/dive_mine.sprite"),
-  m_ticking_glow(SpriteManager::current()->create("images/creatures/dive_mine/ticking_glow/ticking_glow.sprite")),
+  m_ticking_glow(m_sprite->get_linked_sprite("ticking-glow")),
   m_chasing(true)
 {
   reset_sprites();
+}
+
+std::vector<MovingSprite::LinkedSprite>
+DiveMine::get_linked_sprites()
+{
+  return {
+    { "ticking-glow", m_ticking_glow }
+  };
 }
 
 void

--- a/src/badguy/dive_mine.cpp
+++ b/src/badguy/dive_mine.cpp
@@ -35,7 +35,7 @@ DiveMine::DiveMine(const ReaderMapping& reader) :
   reset_sprites();
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 DiveMine::get_linked_sprites()
 {
   return {

--- a/src/badguy/dive_mine.hpp
+++ b/src/badguy/dive_mine.hpp
@@ -50,6 +50,7 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
+  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   void reset_sprites();

--- a/src/badguy/dive_mine.hpp
+++ b/src/badguy/dive_mine.hpp
@@ -50,7 +50,7 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   void reset_sprites();

--- a/src/badguy/ghosttree.cpp
+++ b/src/badguy/ghosttree.cpp
@@ -59,7 +59,7 @@ GhostTree::GhostTree(const ReaderMapping& mapping) :
   SoundManager::current()->preload("sounds/tree_suck.ogg");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 GhostTree::get_linked_sprites()
 {
   return {

--- a/src/badguy/ghosttree.cpp
+++ b/src/badguy/ghosttree.cpp
@@ -45,7 +45,7 @@ GhostTree::GhostTree(const ReaderMapping& mapping) :
   willo_radius(200),
   willo_speed(1.8f),
   willo_color(0),
-  glow_sprite(SpriteManager::current()->create("images/creatures/ghosttree/ghosttree-glow.sprite")),
+  glow_sprite(m_sprite->get_linked_sprite("glow")),
   colorchange_timer(),
   suck_timer(),
   root_timer(),
@@ -57,6 +57,14 @@ GhostTree::GhostTree(const ReaderMapping& mapping) :
   set_colgroup_active(COLGROUP_TOUCHABLE);
   SoundManager::current()->preload("sounds/tree_howling.ogg");
   SoundManager::current()->preload("sounds/tree_suck.ogg");
+}
+
+std::vector<MovingSprite::LinkedSprite>
+GhostTree::get_linked_sprites()
+{
+  return {
+    { "glow", glow_sprite }
+  };
 }
 
 void

--- a/src/badguy/ghosttree.hpp
+++ b/src/badguy/ghosttree.hpp
@@ -50,7 +50,7 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   enum MyState {

--- a/src/badguy/ghosttree.hpp
+++ b/src/badguy/ghosttree.hpp
@@ -50,6 +50,7 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
+  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   enum MyState {

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -60,7 +60,7 @@ GoldBomb::GoldBomb(const ReaderMapping& reader) :
   m_exploding_sprite->set_action("default", 1);
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 GoldBomb::get_linked_sprites()
 {
   return {

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -48,7 +48,7 @@ GoldBomb::GoldBomb(const ReaderMapping& reader) :
   tstate(STATE_NORMAL),
   m_realize_timer(),
   ticking(),
-  m_exploding_sprite(SpriteManager::current()->create("images/creatures/mr_bomb/ticking_glow/ticking_glow.sprite"))
+  m_exploding_sprite(m_sprite->get_linked_sprite("explode"))
 {
   assert(SAFE_DIST >= REALIZE_DIST);
 
@@ -58,6 +58,14 @@ GoldBomb::GoldBomb(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/explosion.wav");
 
   m_exploding_sprite->set_action("default", 1);
+}
+
+std::vector<MovingSprite::LinkedSprite>
+GoldBomb::get_linked_sprites()
+{
+  return {
+    { "explode", m_exploding_sprite }
+  };
 }
 
 void

--- a/src/badguy/goldbomb.hpp
+++ b/src/badguy/goldbomb.hpp
@@ -59,6 +59,8 @@ public:
 protected:
   virtual bool collision_squished(GameObject& object) override;
 
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   void flee(Direction dir);
   void cornered();

--- a/src/badguy/goldbomb.hpp
+++ b/src/badguy/goldbomb.hpp
@@ -59,7 +59,7 @@ public:
 protected:
   virtual bool collision_squished(GameObject& object) override;
 
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   void flee(Direction dir);

--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -57,7 +57,7 @@ Haywire::Haywire(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/explosion.wav");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Haywire::get_linked_sprites()
 {
   return {

--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -43,7 +43,7 @@ Haywire::Haywire(const ReaderMapping& reader) :
   time_until_explosion(0.0f),
   is_stunned(false),
   time_stunned(0.0f),
-  m_exploding_sprite(SpriteManager::current()->create("images/creatures/haywire/ticking_glow/ticking_glow.sprite")),
+  m_exploding_sprite(m_sprite->get_linked_sprite("ticking-glow")),
   m_jumping(false),
   m_skid_timer(),
   m_last_player_direction(Direction::LEFT),
@@ -55,6 +55,14 @@ Haywire::Haywire(const ReaderMapping& reader) :
   max_drop_height = 16;
 
   SoundManager::current()->preload("sounds/explosion.wav");
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Haywire::get_linked_sprites()
+{
+  return {
+    { "ticking-glow", m_exploding_sprite }
+  };
 }
 
 Direction

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -53,7 +53,7 @@ protected:
   virtual bool collision_squished(GameObject& object) override;
   virtual void collision_solid(const CollisionHit& hit) override;
 
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   Direction get_player_direction(const Player* player) const;

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -53,6 +53,8 @@ protected:
   virtual bool collision_squished(GameObject& object) override;
   virtual void collision_solid(const CollisionHit& hit) override;
 
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   Direction get_player_direction(const Player* player) const;
 

--- a/src/badguy/kugelblitz.cpp
+++ b/src/badguy/kugelblitz.cpp
@@ -43,7 +43,7 @@ Kugelblitz::Kugelblitz(const ReaderMapping& reader) :
   movement_timer(),
   lifetime(),
   direction(),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
+  lightsprite(m_sprite->get_linked_sprite("light"))
 {
   m_start_position.x = m_col.m_bbox.get_left();
   set_action("falling");
@@ -62,6 +62,14 @@ Kugelblitz::initialize()
   m_physic.set_velocity(-20, 300); // Fall a little to the left.
   direction = 1;
   dying = false;
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Kugelblitz::get_linked_sprites()
+{
+  return {
+    { "light", lightsprite }
+  };
 }
 
 void

--- a/src/badguy/kugelblitz.cpp
+++ b/src/badguy/kugelblitz.cpp
@@ -42,16 +42,12 @@ Kugelblitz::Kugelblitz(const ReaderMapping& reader) :
   dying(),
   movement_timer(),
   lifetime(),
-  direction(),
-  lightsprite(m_sprite->get_linked_sprite("light"))
+  direction()
 {
   m_start_position.x = m_col.m_bbox.get_left();
   set_action("falling");
   m_physic.enable_gravity(false);
   m_countMe = false;
-
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.2f, 0.1f, 0.0f));
 
   SoundManager::current()->preload("sounds/lightning.wav");
 }
@@ -62,14 +58,6 @@ Kugelblitz::initialize()
   m_physic.set_velocity(-20, 300); // Fall a little to the left.
   direction = 1;
   dying = false;
-}
-
-std::vector<MovingSprite::LinkedSprite>
-Kugelblitz::get_linked_sprites()
-{
-  return {
-    { "light", lightsprite }
-  };
 }
 
 void
@@ -159,8 +147,7 @@ Kugelblitz::active_update(float dt_sec)
 void
 Kugelblitz::draw(DrawingContext& context)
 {
-  m_sprite->draw(context.color(), get_pos(), m_layer);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  MovingSprite::draw(context);
 }
 
 void

--- a/src/badguy/kugelblitz.hpp
+++ b/src/badguy/kugelblitz.hpp
@@ -44,7 +44,6 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
-  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   void try_activate();
@@ -57,7 +56,6 @@ private:
   Timer movement_timer;
   Timer lifetime;
   int direction;
-  SpritePtr lightsprite;
 
 private:
   Kugelblitz(const Kugelblitz&) = delete;

--- a/src/badguy/kugelblitz.hpp
+++ b/src/badguy/kugelblitz.hpp
@@ -44,6 +44,7 @@ public:
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;
+  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   void try_activate();

--- a/src/badguy/root.cpp
+++ b/src/badguy/root.cpp
@@ -48,7 +48,7 @@ Root::deactivate()
   // No dead-script required for deactivation.
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Root::get_linked_sprites()
 {
   return {

--- a/src/badguy/root.cpp
+++ b/src/badguy/root.cpp
@@ -26,7 +26,7 @@ static const float HATCH_TIME = 0.75;
 Root::Root(const Vector& pos, Flip flip) :
   BadGuy(pos, "images/creatures/ghosttree/root.sprite", LAYER_TILES-1),
   mystate(STATE_APPEARING),
-  base_sprite(SpriteManager::current()->create("images/creatures/ghosttree/root-base.sprite")),
+  base_sprite(m_sprite->get_linked_sprite("base")),
   offset_y(0),
   hatch_timer()
 {
@@ -46,6 +46,14 @@ Root::deactivate()
 {
   remove_me();
   // No dead-script required for deactivation.
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Root::get_linked_sprites()
+{
+  return {
+    { "base", base_sprite }
+  };
 }
 
 void

--- a/src/badguy/root.hpp
+++ b/src/badguy/root.hpp
@@ -33,6 +33,9 @@ public:
   virtual void kill_fall() override { }
 
 protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
+private:
   enum MyState {
     STATE_APPEARING, STATE_HATCHING, STATE_GROWING, STATE_SHRINKING, STATE_VANISHING
   };

--- a/src/badguy/root.hpp
+++ b/src/badguy/root.hpp
@@ -33,7 +33,7 @@ public:
   virtual void kill_fall() override { }
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   enum MyState {

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -138,7 +138,7 @@ BonusBlock::BonusBlock(const ReaderMapping& mapping) :
   if (m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON)
   {
     SoundManager::current()->preload("sounds/switch.ogg");
-    m_lightsprite = m_sprite->get_linked_sprite("light");
+    m_lightsprite = m_sprite->get_linked_sprite("on-light");
     if (m_contents == Content::LIGHT_ON)
       set_action("on");
     else

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -44,7 +44,6 @@
 #include "util/reader_mapping.hpp"
 #include "util/writer.hpp"
 #include "video/drawing_context.hpp"
-#include "video/surface.hpp"
 
 namespace {
 
@@ -139,7 +138,7 @@ BonusBlock::BonusBlock(const ReaderMapping& mapping) :
   if (m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON)
   {
     SoundManager::current()->preload("sounds/switch.ogg");
-    m_lightsprite = Surface::from_file("/images/objects/lightmap_light/bonusblock_light.png");
+    m_lightsprite = m_sprite->get_linked_sprite("light");
     if (m_contents == Content::LIGHT_ON)
       set_action("on");
     else
@@ -163,6 +162,18 @@ BonusBlock::set_object(std::unique_ptr<GameObject> object)
 
   m_objects.clear();
   m_objects.push_back(std::move(object));
+}
+
+std::vector<MovingSprite::LinkedSprite>
+BonusBlock::get_linked_sprites()
+{
+  if (m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON)
+  {
+    return {
+      { "light", m_lightsprite }
+    };
+  }
+  return {};
 }
 
 GameObjectTypes
@@ -688,7 +699,7 @@ BonusBlock::draw(DrawingContext& context)
   {
     Vector pos = get_pos() + (m_col.m_bbox.get_size().as_vector() - Vector(static_cast<float>(m_lightsprite->get_width()),
                                                                    static_cast<float>(m_lightsprite->get_height()))) / 2.0f;
-    context.light().draw_surface(m_lightsprite, pos, 10);
+    m_lightsprite->draw(context.light(), pos, 10);
   }
 }
 
@@ -748,7 +759,7 @@ BonusBlock::preload_contents(int d)
     case 6: // Light.
     case 15: // Light (On).
       SoundManager::current()->preload("sounds/switch.ogg");
-      m_lightsprite=Surface::from_file("/images/objects/lightmap_light/bonusblock_light.png");
+      m_lightsprite = m_sprite->get_linked_sprite("light");
       break;
 
     case 7:

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -164,7 +164,7 @@ BonusBlock::set_object(std::unique_ptr<GameObject> object)
   m_objects.push_back(std::move(object));
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 BonusBlock::get_linked_sprites()
 {
   if (m_contents == Content::LIGHT || m_contents == Content::LIGHT_ON)

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -71,6 +71,9 @@ public:
 
   void try_open(Player* player);
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   void add_object(std::unique_ptr<GameObject> object);
   void set_object(std::unique_ptr<GameObject> object);
@@ -110,7 +113,7 @@ private:
 
   int m_hit_counter;
   std::string m_script;
-  SurfacePtr m_lightsprite;
+  SpritePtr m_lightsprite;
   std::string m_coin_sprite;
 
 private:

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -72,7 +72,7 @@ public:
   void try_open(Player* player);
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   void add_object(std::unique_ptr<GameObject> object);

--- a/src/object/bullet.cpp
+++ b/src/object/bullet.cpp
@@ -30,7 +30,7 @@ Bullet::Bullet(const Vector& pos, const Vector& xm, Direction dir, BonusType typ
   physic(),
   life_count(3),
   sprite(),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite")),
+  lightsprite(),
   type(type_)
 {
   physic.set_velocity(xm);
@@ -38,6 +38,7 @@ Bullet::Bullet(const Vector& pos, const Vector& xm, Direction dir, BonusType typ
   switch (type) {
     case FIRE_BONUS:
       sprite = SpriteManager::current()->create("images/objects/bullets/firebullet.sprite");
+      lightsprite = sprite->get_linked_sprite("light");
       lightsprite->set_blend(Blend::ADD);
       lightsprite->set_color(Color(0.3f, 0.1f, 0.0f));
       break;
@@ -61,12 +62,19 @@ void
 Bullet::update(float dt_sec)
 {
   // Cause fireball color to flicker randomly.
-  if (graphicsRandom.rand(5) != 0) {
-    lightsprite->set_color(Color(0.3f + graphicsRandom.randf(10) / 100.0f,
-                                 0.1f + graphicsRandom.randf(20.0f) / 100.0f,
-                                 graphicsRandom.randf(10.0f) / 100.0f));
-  } else
-    lightsprite->set_color(Color(0.3f, 0.1f, 0.0f));
+  if (lightsprite)
+  {
+    if (graphicsRandom.rand(5) != 0)
+    {
+      lightsprite->set_color(Color(0.3f + graphicsRandom.randf(10) / 100.0f,
+                                   0.1f + graphicsRandom.randf(20.0f) / 100.0f,
+                                   graphicsRandom.randf(10.0f) / 100.0f));
+    }
+    else
+    {
+      lightsprite->set_color(Color(0.3f, 0.1f, 0.0f));
+    }
+  }
 
   if (life_count <= 0)
   {
@@ -92,9 +100,8 @@ void
 Bullet::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), get_pos(), LAYER_OBJECTS);
-  if (type == FIRE_BONUS){
+  if (lightsprite)
     lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
-  }
 }
 
 void

--- a/src/object/bullet.cpp
+++ b/src/object/bullet.cpp
@@ -38,9 +38,6 @@ Bullet::Bullet(const Vector& pos, const Vector& xm, Direction dir, BonusType typ
   switch (type) {
     case FIRE_BONUS:
       sprite = SpriteManager::current()->create("images/objects/bullets/firebullet.sprite");
-      lightsprite = sprite->get_linked_sprite("light");
-      lightsprite->set_blend(Blend::ADD);
-      lightsprite->set_color(Color(0.3f, 0.1f, 0.0f));
       break;
 
     case ICE_BONUS:
@@ -53,6 +50,10 @@ Bullet::Bullet(const Vector& pos, const Vector& xm, Direction dir, BonusType typ
       sprite = SpriteManager::current()->create("images/objects/bullets/firebullet.sprite");
       break;
   }
+
+  lightsprite = sprite->get_linked_light_sprite();
+  if (lightsprite)
+    lightsprite->set_blend(Blend::ADD);
 
   m_col.m_bbox.set_pos(pos);
   m_col.m_bbox.set_size(sprite->get_current_hitbox_width(), sprite->get_current_hitbox_height());

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -53,7 +53,7 @@ Candle::Candle(const ReaderMapping& mapping) :
   set_action(burning ? "on" : "off");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Candle::get_linked_sprites()
 {
   return {

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -19,7 +19,6 @@
 #include "math/random.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
@@ -30,8 +29,8 @@ Candle::Candle(const ReaderMapping& mapping) :
   burning(true),
   flicker(true),
   lightcolor(1.0f, 1.0f, 1.0f),
-  candle_light_1(SpriteManager::current()->create("images/objects/candle/candle-light-1.sprite")),
-  candle_light_2(SpriteManager::current()->create("images/objects/candle/candle-light-2.sprite"))
+  candle_light_1(m_sprite->get_linked_sprite("light-1")),
+  candle_light_2(m_sprite->get_linked_sprite("light-2"))
 {
   mapping.get("burning", burning, true);
   mapping.get("flicker", flicker, true);
@@ -52,6 +51,15 @@ Candle::Candle(const ReaderMapping& mapping) :
   }
 
   set_action(burning ? "on" : "off");
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Candle::get_linked_sprites()
+{
+  return {
+    { "light-1", candle_light_1 },
+    { "light-2", candle_light_2 }
+  };
 }
 
 void

--- a/src/object/candle.hpp
+++ b/src/object/candle.hpp
@@ -50,7 +50,7 @@ public:
   /** @} */
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   bool burning; /**< true if candle is currently lighted */

--- a/src/object/candle.hpp
+++ b/src/object/candle.hpp
@@ -25,7 +25,7 @@
  * A burning candle: Simple, scriptable level decoration.
  */
 class Candle final : public MovingSprite,
-               public ExposedObject<Candle, scripting::Candle>
+                     public ExposedObject<Candle, scripting::Candle>
 {
 public:
   Candle(const ReaderMapping& mapping);
@@ -48,6 +48,9 @@ public:
   bool get_burning() const; /**< returns true if candle is lighted */
   void set_burning(bool burning); /**< true: light candle, false: extinguish candle */
   /** @} */
+
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   bool burning; /**< true if candle is currently lighted */

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -28,7 +28,6 @@
 #include "object/weak_block.hpp"
 #include "supertux/sector.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
 Explosion::Explosion(const Vector& pos, float p_push_strength,
@@ -38,7 +37,7 @@ Explosion::Explosion(const Vector& pos, float p_push_strength,
   push_strength(p_push_strength),
   num_particles(p_num_particles),
   state(STATE_WAITING),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  lightsprite(m_sprite->get_linked_sprite("light")),
   short_fuse(p_short_fuse)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
@@ -53,12 +52,20 @@ Explosion::Explosion(const ReaderMapping& reader) :
   push_strength(-1),
   num_particles(100),
   state(STATE_WAITING),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  lightsprite(m_sprite->get_linked_sprite("light")),
   short_fuse(false)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
   lightsprite->set_blend(Blend::ADD);
   lightsprite->set_color(Color(0.6f, 0.6f, 0.6f));
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Explosion::get_linked_sprites()
+{
+  return {
+    { "light", lightsprite }
+  };
 }
 
 void

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -37,13 +37,10 @@ Explosion::Explosion(const Vector& pos, float p_push_strength,
   push_strength(p_push_strength),
   num_particles(p_num_particles),
   state(STATE_WAITING),
-  lightsprite(m_sprite->get_linked_sprite("light")),
   short_fuse(p_short_fuse)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
   set_pos(get_pos() - (m_col.m_bbox.get_middle() - get_pos()));
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.6f, 0.6f, 0.6f));
 }
 
 Explosion::Explosion(const ReaderMapping& reader) :
@@ -52,20 +49,9 @@ Explosion::Explosion(const ReaderMapping& reader) :
   push_strength(-1),
   num_particles(100),
   state(STATE_WAITING),
-  lightsprite(m_sprite->get_linked_sprite("light")),
   short_fuse(false)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.6f, 0.6f, 0.6f));
-}
-
-std::vector<MovingSprite::LinkedSprite>
-Explosion::get_linked_sprites()
-{
-  return {
-    { "light", lightsprite }
-  };
 }
 
 void
@@ -174,7 +160,9 @@ void
 Explosion::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS+40);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+
+  if (m_light_sprite)
+    m_light_sprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
 HitResponse

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -43,6 +43,9 @@ public:
   bool hurts() const { return hurt; }
   void hurts (bool val) { hurt = val; }
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   /** plays sound, starts animation */
   void explode();

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -43,9 +43,6 @@ public:
   bool hurts() const { return hurt; }
   void hurts (bool val) { hurt = val; }
 
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
-
 private:
   /** plays sound, starts animation */
   void explode();
@@ -61,7 +58,6 @@ private:
   float push_strength;
   int num_particles;
   State state;
-  SpritePtr lightsprite;
   bool short_fuse;
 
 private:

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -24,7 +24,6 @@
 #include "object/player.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/sector.hpp"
@@ -40,7 +39,7 @@ Firefly::Firefly(const ReaderMapping& mapping) :
    initial_position(get_pos())
 {
   if (m_sprite_name.find("torch", 0) != std::string::npos) {
-    m_sprite_light = SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite");
+    m_sprite_light = m_sprite->get_linked_sprite("light");
     m_sprite_light->set_blend(Blend::ADD);
     m_sprite_light->set_color(TORCH_LIGHT_COLOR);
   }
@@ -57,6 +56,19 @@ Firefly::Firefly(const ReaderMapping& mapping) :
   else {
     SoundManager::current()->preload("sounds/savebell2.wav");
   }
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Firefly::get_linked_sprites()
+{
+  // FIXME: Sprite name hardcoding
+  if (m_sprite_name.find("torch", 0) != std::string::npos)
+  {
+    return {
+      { "light", m_sprite_light }
+    };
+  }
+  return {};
 }
 
 void

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -29,21 +29,11 @@
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
 
-static const Color TORCH_LIGHT_COLOR = Color(0.87f, 0.64f, 0.12f); /** Color of the light specific to the torch firefly sprite. */
-static const Vector TORCH_LIGHT_OFFSET = Vector(0, 12); /** Offset of the light specific to the torch firefly sprite. */
-
 Firefly::Firefly(const ReaderMapping& mapping) :
-   MovingSprite(mapping, "images/objects/resetpoints/default-resetpoint.sprite", LAYER_TILES, COLGROUP_TOUCHABLE),
-   m_sprite_light(),
-   activated(false),
-   initial_position(get_pos())
+  MovingSprite(mapping, "images/objects/resetpoints/default-resetpoint.sprite", LAYER_TILES, COLGROUP_TOUCHABLE),
+  activated(false),
+  initial_position(get_pos())
 {
-  if (m_sprite_name.find("torch", 0) != std::string::npos) {
-    m_sprite_light = m_sprite->get_linked_sprite("light");
-    m_sprite_light->set_blend(Blend::ADD);
-    m_sprite_light->set_color(TORCH_LIGHT_COLOR);
-  }
-
   update_state();
 
   // Load sound.
@@ -58,28 +48,13 @@ Firefly::Firefly(const ReaderMapping& mapping) :
   }
 }
 
-std::vector<MovingSprite::LinkedSprite>
-Firefly::get_linked_sprites()
-{
-  // FIXME: Sprite name hardcoding
-  if (m_sprite_name.find("torch", 0) != std::string::npos)
-  {
-    return {
-      { "light", m_sprite_light }
-    };
-  }
-  return {};
-}
-
 void
 Firefly::draw(DrawingContext& context)
 {
-  MovingSprite::draw(context);
+  m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
 
-  if (m_sprite_name.find("torch", 0) != std::string::npos && (activated ||
-        m_sprite->get_action() == "ringing")) {
-    m_sprite_light->draw(context.light(), m_col.m_bbox.get_middle() + (m_flip == NO_FLIP ? -TORCH_LIGHT_OFFSET : TORCH_LIGHT_OFFSET), 0);
-  }
+  if (m_light_sprite && (activated || m_sprite->get_action() == "ringing"))
+    m_light_sprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, m_flip);
 }
 
 void

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -41,14 +41,10 @@ public:
 
   virtual void on_flip(float height) override;
 
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
-
 private:
   void update_state();
 
 private:
-  SpritePtr m_sprite_light;
   bool activated;
   Vector initial_position; /**< position as in level file. This is where Tux will have to respawn, as the level is reset every time */
 

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -41,6 +41,9 @@ public:
 
   virtual void on_flip(float height) override;
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   void update_state();
 

--- a/src/object/flower.cpp
+++ b/src/object/flower.cpp
@@ -26,34 +26,38 @@ Flower::Flower(BonusType _type, const std::string& custom_sprite) :
   type(_type),
   sprite(),
   flip(NO_FLIP),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite"))
+  lightsprite()
 {
   m_col.m_bbox.set_size(32, 32);
-  lightsprite->set_blend(Blend::ADD);
 
   if (type == FIRE_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/fireflower/fireflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
+    lightsprite = sprite->get_linked_sprite("light");
     lightsprite->set_color(Color(0.3f, 0.0f, 0.0f));
   }
   else if (type == ICE_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/iceflower/iceflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
+    lightsprite = sprite->get_linked_sprite("light");
     lightsprite->set_color(Color(0.0f, 0.1f, 0.2f));
   }
   else if (type == AIR_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/airflower/airflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
+    lightsprite = sprite->get_linked_sprite("light");
     lightsprite->set_color(Color(0.15f, 0.0f, 0.15f));
   }
   else if (type == EARTH_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/earthflower/earthflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
+    lightsprite = sprite->get_linked_sprite("light");
     lightsprite->set_color(Color(0.0f, 0.3f, 0.0f));
   } else {
     assert(false);
   }
 
+  lightsprite->set_blend(Blend::ADD);
   set_group(COLGROUP_TOUCHABLE);
 }
 

--- a/src/object/flower.cpp
+++ b/src/object/flower.cpp
@@ -33,31 +33,27 @@ Flower::Flower(BonusType _type, const std::string& custom_sprite) :
   if (type == FIRE_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/fireflower/fireflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
-    lightsprite = sprite->get_linked_sprite("light");
-    lightsprite->set_color(Color(0.3f, 0.0f, 0.0f));
   }
   else if (type == ICE_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/iceflower/iceflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
-    lightsprite = sprite->get_linked_sprite("light");
-    lightsprite->set_color(Color(0.0f, 0.1f, 0.2f));
   }
   else if (type == AIR_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/airflower/airflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
-    lightsprite = sprite->get_linked_sprite("light");
-    lightsprite->set_color(Color(0.15f, 0.0f, 0.15f));
   }
   else if (type == EARTH_BONUS) {
     sprite = SpriteManager::current()->create(custom_sprite.empty() ? "images/powerups/earthflower/earthflower.sprite" : custom_sprite);
     SoundManager::current()->preload("sounds/fire-flower.wav");
-    lightsprite = sprite->get_linked_sprite("light");
-    lightsprite->set_color(Color(0.0f, 0.3f, 0.0f));
-  } else {
+  }
+  else {
     assert(false);
   }
 
-  lightsprite->set_blend(Blend::ADD);
+  lightsprite = sprite->get_linked_light_sprite();
+  if (lightsprite)
+    lightsprite->set_blend(Blend::ADD);
+
   set_group(COLGROUP_TOUCHABLE);
 }
 
@@ -70,7 +66,8 @@ void
 Flower::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), get_pos(), LAYER_OBJECTS, flip);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  if (lightsprite)
+    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
 HitResponse

--- a/src/object/growup.cpp
+++ b/src/object/growup.cpp
@@ -36,7 +36,7 @@ GrowUp::GrowUp(const Vector& pos, Direction direction, const std::string& custom
   shadesprite->set_action("shadow");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 GrowUp::get_linked_sprites()
 {
   return {

--- a/src/object/growup.cpp
+++ b/src/object/growup.cpp
@@ -22,14 +22,13 @@
 #include "math/util.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 
 GrowUp::GrowUp(const Vector& pos, Direction direction, const std::string& custom_sprite) :
   MovingSprite(pos, custom_sprite.empty() ? "images/powerups/egg/egg.sprite" : custom_sprite, LAYER_OBJECTS, COLGROUP_MOVING),
   physic(),
   m_custom_sprite(!custom_sprite.empty()),
-  shadesprite(SpriteManager::current()->create("images/powerups/egg/egg.sprite")),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite"))
+  shadesprite(m_sprite->get_linked_sprite("shade")),
+  lightsprite(m_sprite->get_linked_sprite("light"))
 {
   physic.enable_gravity(true);
   physic.set_velocity_x((direction == Direction::LEFT) ? -100.0f : 100.0f);
@@ -39,6 +38,15 @@ GrowUp::GrowUp(const Vector& pos, Direction direction, const std::string& custom
   // Configure the light sprite for the glow effect.
   lightsprite->set_blend(Blend::ADD);
   lightsprite->set_color(Color(0.2f, 0.2f, 0.0f));
+}
+
+std::vector<MovingSprite::LinkedSprite>
+GrowUp::get_linked_sprites()
+{
+  return {
+    { "shade", shadesprite },
+    { "light", lightsprite }
+  };
 }
 
 void

--- a/src/object/growup.cpp
+++ b/src/object/growup.cpp
@@ -27,25 +27,20 @@ GrowUp::GrowUp(const Vector& pos, Direction direction, const std::string& custom
   MovingSprite(pos, custom_sprite.empty() ? "images/powerups/egg/egg.sprite" : custom_sprite, LAYER_OBJECTS, COLGROUP_MOVING),
   physic(),
   m_custom_sprite(!custom_sprite.empty()),
-  shadesprite(m_sprite->get_linked_sprite("shade")),
-  lightsprite(m_sprite->get_linked_sprite("light"))
+  shadesprite(m_sprite->get_linked_sprite("shade"))
 {
   physic.enable_gravity(true);
   physic.set_velocity_x((direction == Direction::LEFT) ? -100.0f : 100.0f);
   SoundManager::current()->preload("sounds/grow.ogg");
   // Set the shadow action for the egg sprite, so it remains in place as the egg rolls.
   shadesprite->set_action("shadow");
-  // Configure the light sprite for the glow effect.
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.2f, 0.2f, 0.0f));
 }
 
 std::vector<MovingSprite::LinkedSprite>
 GrowUp::get_linked_sprites()
 {
   return {
-    { "shade", shadesprite },
-    { "light", lightsprite }
+    { "shade", shadesprite }
   };
 }
 
@@ -67,7 +62,6 @@ GrowUp::draw(DrawingContext& context)
     return;
 
   shadesprite->draw(context.color(), get_pos(), m_layer);
-  lightsprite->draw(context.light(), get_bbox().get_middle(), 0);
 }
 
 void

--- a/src/object/growup.hpp
+++ b/src/object/growup.hpp
@@ -44,7 +44,6 @@ private:
 
   const bool m_custom_sprite;
   SpritePtr shadesprite;
-  SpritePtr lightsprite;
 
 private:
   GrowUp(const GrowUp&) = delete;

--- a/src/object/growup.hpp
+++ b/src/object/growup.hpp
@@ -36,6 +36,9 @@ public:
 
   void do_jump();
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   Physic physic;
 

--- a/src/object/growup.hpp
+++ b/src/object/growup.hpp
@@ -37,7 +37,7 @@ public:
   void do_jump();
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   Physic physic;

--- a/src/object/key.cpp
+++ b/src/object/key.cpp
@@ -22,7 +22,6 @@
 #include "object/player.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 #include "trigger/door.hpp"
 #include "util/reader_mapping.hpp"
@@ -39,7 +38,7 @@ Key::Key(const ReaderMapping& reader) :
   m_my_door_pos(0.f, 0.f),
   m_color(Color::WHITE),
   m_owner(),
-  m_lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite")),
+  m_lightsprite(m_sprite->get_linked_sprite("light")),
   m_total_time_elapsed(),
   m_target_speed()
 {
@@ -54,6 +53,14 @@ Key::Key(const ReaderMapping& reader) :
   SoundManager::current()->preload("sounds/metal_hit.ogg");
   m_sprite->set_color(m_color);
   m_physic.enable_gravity(false);
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Key::get_linked_sprites()
+{
+  return {
+    { "light", m_lightsprite }
+  };
 }
 
 void
@@ -74,7 +81,7 @@ Key::update(float dt_sec)
     if (spawn_particle_now)
     {
       Sector::get().add<SpriteParticle>(
-        "images/particles/sparkle.sprite", "small",
+        m_sprite->get_linked_sprite_file("sparkle"), "small",
         ppos, ANCHOR_MIDDLE, Vector(0, 0), Vector(0, 0), LAYER_OBJECTS + 6, false, m_color);
     }
 
@@ -219,7 +226,7 @@ Key::spawn_use_particles()
   for (int i = 1; i < 9; i++)
   {
     Vector direction = glm::normalize(Vector(std::cos(float(i) * math::PI_4), std::sin(float(i) * math::PI_4)));
-    Sector::get().add<SpriteParticle>("images/particles/sparkle.sprite", "small-key-collect",
+    Sector::get().add<SpriteParticle>(m_sprite->get_linked_sprite_file("sparkle"), "small-key-collect",
       get_bbox().get_middle(),
       ANCHOR_MIDDLE, Vector(400.f * direction), -Vector(400.f * direction) * 2.8f, LAYER_OBJECTS + 6, false, m_color);
   }

--- a/src/object/key.cpp
+++ b/src/object/key.cpp
@@ -38,7 +38,6 @@ Key::Key(const ReaderMapping& reader) :
   m_my_door_pos(0.f, 0.f),
   m_color(Color::WHITE),
   m_owner(),
-  m_lightsprite(m_sprite->get_linked_sprite("light")),
   m_total_time_elapsed(),
   m_target_speed()
 {
@@ -46,21 +45,13 @@ Key::Key(const ReaderMapping& reader) :
   if (reader.get("color", vColor)) {
     m_color = Color(vColor);
   }
-  m_lightsprite->set_blend(Blend::ADD);
-  m_lightsprite->set_color(m_color);
+  if (m_light_sprite)
+    m_light_sprite->set_color(m_color);
 
   // TODO: Add proper sound
   SoundManager::current()->preload("sounds/metal_hit.ogg");
   m_sprite->set_color(m_color);
   m_physic.enable_gravity(false);
-}
-
-std::vector<MovingSprite::LinkedSprite>
-Key::get_linked_sprites()
-{
-  return {
-    { "light", m_lightsprite }
-  };
 }
 
 void
@@ -188,7 +179,9 @@ void
 Key::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
-  m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), m_layer+1);
+
+  if (m_light_sprite)
+    m_light_sprite->draw(context.light(), m_col.m_bbox.get_middle(), m_layer + 1);
 }
 
 ObjectSettings
@@ -208,8 +201,8 @@ Key::after_editor_set()
 {
   MovingSprite::after_editor_set();
 
-  m_lightsprite->set_blend(Blend::ADD);
-  m_lightsprite->set_color(m_color);
+  if (m_light_sprite)
+    m_light_sprite->set_color(m_color);
   m_sprite->set_color(m_color);
 }
 

--- a/src/object/key.hpp
+++ b/src/object/key.hpp
@@ -43,9 +43,6 @@ public:
 
   void update_pos();
 
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
-
 private:
   enum KeyState {
     NORMAL,
@@ -65,7 +62,6 @@ private:
   Vector m_my_door_pos;
   Color m_color;
   Player* m_owner;
-  SpritePtr m_lightsprite;
   float m_total_time_elapsed;
   float m_target_speed;
 

--- a/src/object/key.hpp
+++ b/src/object/key.hpp
@@ -43,6 +43,9 @@ public:
 
   void update_pos();
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   enum KeyState {
     NORMAL,

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -23,13 +23,12 @@
 #include "badguy/willowisp.hpp"
 #include "editor/editor.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "util/reader_mapping.hpp"
 
 Lantern::Lantern(const ReaderMapping& reader) :
   Rock(reader, "images/objects/lantern/lantern.sprite"),
   lightcolor(1.0f, 1.0f, 1.0f),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
+  lightsprite(m_sprite->get_linked_sprite("light"))
 {
   std::vector<float> vColor;
   if (reader.get("color", vColor)) {
@@ -47,11 +46,19 @@ Lantern::Lantern(const ReaderMapping& reader) :
 Lantern::Lantern(const Vector& pos) :
   Rock(pos, "images/objects/lantern/lantern.sprite"),
   lightcolor(0.0f, 0.0f, 0.0f),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
+  lightsprite(m_sprite->get_linked_sprite("light"))
 {
   lightsprite->set_blend(Blend::ADD);
   updateColor();
   SoundManager::current()->preload("sounds/willocatch.wav");
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Lantern::get_linked_sprites()
+{
+  return {
+    { "light", lightsprite }
+  };
 }
 
 ObjectSettings

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -27,8 +27,7 @@
 
 Lantern::Lantern(const ReaderMapping& reader) :
   Rock(reader, "images/objects/lantern/lantern.sprite"),
-  lightcolor(1.0f, 1.0f, 1.0f),
-  lightsprite(m_sprite->get_linked_sprite("light"))
+  lightcolor(1.0f, 1.0f, 1.0f)
 {
   std::vector<float> vColor;
   if (reader.get("color", vColor)) {
@@ -38,27 +37,16 @@ Lantern::Lantern(const ReaderMapping& reader) :
       lightcolor = Color(1, 1, 1);
     }
   }
-  lightsprite->set_blend(Blend::ADD);
   updateColor();
   SoundManager::current()->preload("sounds/willocatch.wav");
 }
 
 Lantern::Lantern(const Vector& pos) :
   Rock(pos, "images/objects/lantern/lantern.sprite"),
-  lightcolor(0.0f, 0.0f, 0.0f),
-  lightsprite(m_sprite->get_linked_sprite("light"))
+  lightcolor(0.0f, 0.0f, 0.0f)
 {
-  lightsprite->set_blend(Blend::ADD);
   updateColor();
   SoundManager::current()->preload("sounds/willocatch.wav");
-}
-
-std::vector<MovingSprite::LinkedSprite>
-Lantern::get_linked_sprites()
-{
-  return {
-    { "light", lightsprite }
-  };
 }
 
 ObjectSettings
@@ -82,8 +70,10 @@ Lantern::after_editor_set()
 }
 
 void
-Lantern::updateColor(){
-  lightsprite->set_color(lightcolor);
+Lantern::updateColor()
+{
+  if (m_light_sprite)
+    m_light_sprite->set_color(lightcolor);
   //Turn lantern off if light is black
   if (lightcolor.red == 0 && lightcolor.green == 0 && lightcolor.blue == 0){
     set_action("off");
@@ -95,15 +85,17 @@ Lantern::updateColor(){
 }
 
 void
-Lantern::draw(DrawingContext& context){
+Lantern::draw(DrawingContext& context
+){
   //Draw the Sprite.
   MovingSprite::draw(context);
   //Let there be light.
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  if (m_light_sprite)
+    m_light_sprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
-HitResponse Lantern::collision(GameObject& other, const CollisionHit& hit) {
-
+HitResponse Lantern::collision(GameObject& other, const CollisionHit& hit)
+{
   WillOWisp* wow = dynamic_cast<WillOWisp*>(&other);
 
   if (wow && (is_open() || wow->get_color().greyscale() == 0.f)) {
@@ -135,7 +127,6 @@ Lantern::grab(MovingObject& object, const Vector& pos, Direction dir)
   if (is_open()) {
     set_action("off-open");
   }
-
 }
 
 void

--- a/src/object/lantern.hpp
+++ b/src/object/lantern.hpp
@@ -49,13 +49,11 @@ public:
   Color get_color() const { return lightcolor; }
   void add_color(const Color& c);
 
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+private:
+  void updateColor();
 
 private:
   Color lightcolor;
-  SpritePtr lightsprite;
-  void updateColor();
 
 private:
   Lantern(const Lantern&) = delete;

--- a/src/object/lantern.hpp
+++ b/src/object/lantern.hpp
@@ -49,6 +49,9 @@ public:
   Color get_color() const { return lightcolor; }
   void add_color(const Color& c);
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   Color lightcolor;
   SpritePtr lightsprite;

--- a/src/object/lit_object.cpp
+++ b/src/object/lit_object.cpp
@@ -27,8 +27,7 @@ LitObject::LitObject(const ReaderMapping& reader) :
   m_light_offset(-6.f, -17.f),
   m_light_sprite_name("images/objects/lightflower/light/glow_light.sprite"),
   m_sprite_action("default"),
-  m_light_sprite_action("default"),
-  m_light_sprite()
+  m_light_sprite_action("default")
 {
   reader.get("light-offset-x", m_light_offset.x);
   reader.get("light-offset-y", m_light_offset.y);

--- a/src/object/lit_object.hpp
+++ b/src/object/lit_object.hpp
@@ -56,7 +56,6 @@ private:
   std::string m_light_sprite_name;
   std::string m_sprite_action;
   std::string m_light_sprite_action;
-  SpritePtr m_light_sprite;
 
 private:
   LitObject(const LitObject&) = delete;

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -180,7 +180,14 @@ MovingSprite::change_sprite(const std::string& new_sprite_name)
 {
   m_sprite = SpriteManager::current()->create(new_sprite_name);
   m_sprite_name = new_sprite_name;
+
+  // Update hitbox
   update_hitbox();
+
+  // Update all linked sprites
+  auto linked_sprites = get_linked_sprites();
+  for (const LinkedSprite& data : linked_sprites)
+    data.sprite = m_sprite->get_linked_sprite(data.key);
 
   return SpriteManager::current()->last_load_successful();
 }

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -192,8 +192,8 @@ MovingSprite::change_sprite(const std::string& new_sprite_name)
 
   // Update other linked sprites
   auto linked_sprites = get_linked_sprites();
-  for (const LinkedSprite& data : linked_sprites)
-    data.sprite = m_sprite->get_linked_sprite(data.key);
+  for (const auto& [key, sprite] : linked_sprites)
+    sprite = m_sprite->get_linked_sprite(key);
 
   return SpriteManager::current()->last_load_successful();
 }

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -99,18 +99,11 @@ public:
   void set_action(const std::string& action, int loops, AnchorPoint anchorPoint);
 
 public:
-  struct LinkedSprite final
-  {
-    LinkedSprite(const std::string& key_, SpritePtr& sprite_) :
-      key(key_), sprite(sprite_)
-    {}
-
-    std::string key;
-    SpritePtr& sprite;
-  };
+  typedef std::map<std::string, SpritePtr&> LinkedSprites;
 
 protected:
-  virtual std::vector<LinkedSprite> get_linked_sprites() { return {}; }
+  /** Provides all linked sprites of the object, so they can be updated on main sprite change. */
+  virtual LinkedSprites get_linked_sprites() { return {}; }
 
   /** Update hitbox, based on sprite. */
   virtual void update_hitbox();

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -98,7 +98,20 @@ public:
       resizing the bounding box. */
   void set_action(const std::string& action, int loops, AnchorPoint anchorPoint);
 
+public:
+  struct LinkedSprite final
+  {
+    LinkedSprite(const std::string& key_, SpritePtr& sprite_) :
+      key(key_), sprite(sprite_)
+    {}
+
+    std::string key;
+    SpritePtr& sprite;
+  };
+
 protected:
+  virtual std::vector<LinkedSprite> get_linked_sprites() { return {}; }
+
   /** Update hitbox, based on sprite. */
   virtual void update_hitbox();
 

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -123,6 +123,7 @@ protected:
             so support for sprite switching for object types is retained. */
   std::string m_default_sprite_name;
   SpritePtr m_sprite;
+  SpritePtr m_light_sprite;
   int m_layer; /**< Sprite's z-position. Refer to video/drawing_context.hpp for sensible values. */
 
   Flip m_flip;

--- a/src/object/powerup.cpp
+++ b/src/object/powerup.cpp
@@ -30,8 +30,7 @@ PowerUp::PowerUp(const ReaderMapping& mapping) :
   MovingSprite(mapping, "images/powerups/egg/egg.sprite", LAYER_OBJECTS, COLGROUP_MOVING),
   physic(),
   script(),
-  no_physics(),
-  lightsprite()
+  no_physics()
 {
   parse_type(mapping);
   mapping.get("script", script, "");
@@ -43,26 +42,13 @@ PowerUp::PowerUp(const Vector& pos, int type) :
   MovingSprite(pos, "images/powerups/egg/egg.sprite", LAYER_OBJECTS, COLGROUP_MOVING),
   physic(),
   script(),
-  no_physics(false),
-  lightsprite()
+  no_physics(false)
 {
   m_type = type;
   on_type_change();
 
   update_version();
   initialize();
-}
-
-std::vector<MovingSprite::LinkedSprite>
-PowerUp::get_linked_sprites()
-{
-  if (has_lightsprite())
-  {
-    return {
-      { "light", lightsprite }
-    };
-  }
-  return {};
 }
 
 GameObjectTypes
@@ -141,68 +127,6 @@ PowerUp::initialize()
     else if (matches_sprite("images/powerups/potions/red-potion.sprite"))
       m_type = FLIP;
   }
-
-  setup_lightsprite();
-}
-
-void
-PowerUp::setup_lightsprite()
-{
-  if (!has_lightsprite())
-  {
-    lightsprite.reset();
-    return;
-  }
-
-  lightsprite = m_sprite->get_linked_sprite("light");
-  lightsprite->set_blend(Blend::ADD);
-
-  switch (m_type)
-  {
-    case EGG:
-      lightsprite->set_color(Color(0.2f, 0.2f, 0.0f));
-      break;
-    case FIRE:
-      lightsprite->set_color(Color(0.3f, 0.0f, 0.0f));
-      break;
-    case ICE:
-      lightsprite->set_color(Color(0.0f, 0.1f, 0.2f));
-      break;
-    case AIR:
-      lightsprite->set_color(Color(0.15f, 0.0f, 0.15f));
-      break;
-    case EARTH:
-      lightsprite->set_color(Color(0.0f, 0.3f, 0.0f));
-      break;
-    case STAR:
-      lightsprite->set_color(Color(0.4f, 0.4f, 0.4f));
-      break;
-  }
-}
-
-bool
-PowerUp::has_lightsprite() const
-{
-  switch (m_type)
-  {
-    case EGG:
-    case FIRE:
-    case ICE:
-    case AIR:
-    case EARTH:
-    case STAR:
-      return true;
-
-    default:
-      return false;
-  }
-}
-
-void
-PowerUp::after_editor_set()
-{
-  MovingSprite::after_editor_set();
-  setup_lightsprite();
 }
 
 void
@@ -322,8 +246,8 @@ PowerUp::draw(DrawingContext& context)
   if (m_type == STAR || m_type == HERRING)
     m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
 
-  if (lightsprite)
-    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  if (m_light_sprite)
+    m_light_sprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
 ObjectSettings

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -42,17 +42,10 @@ public:
 
   std::vector<std::string> get_patches() const override;
   virtual ObjectSettings get_settings() override;
-  virtual void after_editor_set() override;
-
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   /** Initialize power up sprites and other defaults */
   void initialize();
-  void setup_lightsprite();
-
-  bool has_lightsprite() const;
 
 public:
   enum Type {
@@ -73,7 +66,6 @@ private:
   Physic physic;
   std::string script;
   bool no_physics;
-  SpritePtr lightsprite;
 
 private:
   PowerUp(const PowerUp&) = delete;

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -44,10 +44,15 @@ public:
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   /** Initialize power up sprites and other defaults */
   void initialize();
   void setup_lightsprite();
+
+  bool has_lightsprite() const;
 
 public:
   enum Type {

--- a/src/object/rublight.cpp
+++ b/src/object/rublight.cpp
@@ -29,7 +29,6 @@ RubLight::RubLight(const ReaderMapping& mapping) :
     COLGROUP_STATIC),
   state(STATE_DARK),
   stored_energy(0),
-  light(m_sprite->get_linked_sprite("light")),
   color(1.f, 1.f, 1.f),
   fading_speed(5.0f),
   strength_multiplier(1.0f)
@@ -41,14 +40,6 @@ RubLight::RubLight(const ReaderMapping& mapping) :
     color = Color(vColor);
   mapping.get("fading_speed", fading_speed);
   mapping.get("strength_multiplier", strength_multiplier);
-}
-
-std::vector<MovingSprite::LinkedSprite>
-RubLight::get_linked_sprites()
-{
-  return {
-    { "light", light }
-  };
 }
 
 ObjectSettings
@@ -140,12 +131,15 @@ RubLight::get_brightness() const
 void
 RubLight::draw(DrawingContext& context)
 {
-  if (state == STATE_FADING) {
+  if (state == STATE_FADING)
+  {
     float brightness = get_brightness();
     Color col = color.multiply_linearly(brightness);
-    light->set_color(col);
-    light->set_blend(Blend::ADD);
-    light->draw(context.light(), get_pos(), m_layer);
+    if (m_light_sprite)
+    {
+      m_light_sprite->set_color(col);
+      m_light_sprite->draw(context.light(), get_pos(), m_layer);
+    }
   }
 
   m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);

--- a/src/object/rublight.cpp
+++ b/src/object/rublight.cpp
@@ -19,20 +19,17 @@
 #include "badguy/walking_badguy.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/constants.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "video/color.hpp"
 #include "util/reader_mapping.hpp"
-
 
 RubLight::RubLight(const ReaderMapping& mapping) :
   MovingSprite(mapping, "images/objects/rublight/rublight.sprite", LAYER_TILES,
     COLGROUP_STATIC),
   state(STATE_DARK),
   stored_energy(0),
-  light(SpriteManager::current()->create(
-    "images/objects/lightmap_light/lightmap_light.sprite")),
+  light(m_sprite->get_linked_sprite("light")),
   color(1.f, 1.f, 1.f),
   fading_speed(5.0f),
   strength_multiplier(1.0f)
@@ -44,6 +41,14 @@ RubLight::RubLight(const ReaderMapping& mapping) :
     color = Color(vColor);
   mapping.get("fading_speed", fading_speed);
   mapping.get("strength_multiplier", strength_multiplier);
+}
+
+std::vector<MovingSprite::LinkedSprite>
+RubLight::get_linked_sprites()
+{
+  return {
+    { "light", light }
+  };
 }
 
 ObjectSettings

--- a/src/object/rublight.hpp
+++ b/src/object/rublight.hpp
@@ -37,6 +37,9 @@ public:
 
   virtual void on_flip(float height) override;
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   enum State {
     STATE_DARK,
@@ -55,6 +58,7 @@ private:
   void rub(float strength);
   float get_brightness() const;
 
+private:
   RubLight(const RubLight&) = delete;
   RubLight& operator=(const RubLight&) = delete;
 };

--- a/src/object/rublight.hpp
+++ b/src/object/rublight.hpp
@@ -17,7 +17,7 @@
 #define HEADER_SUPERTUX_OBJECT_RUBLIGHT_HPP
 
 #include "object/moving_sprite.hpp"
-#include "sprite/sprite_ptr.hpp"
+
 #include "video/color.hpp"
 
 /** A triboluminescent (or something similar) block */
@@ -29,16 +29,15 @@ public:
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
+
   static std::string class_name() { return "rublight"; }
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Rublight"); }
   virtual std::string get_display_name() const override { return display_name(); }
+
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;
-
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
 
 private:
   enum State {
@@ -48,7 +47,6 @@ private:
 
   State state;
   float stored_energy;
-  SpritePtr light;
 
   Color color;
   float fading_speed;

--- a/src/object/sprite_particle.cpp
+++ b/src/object/sprite_particle.cpp
@@ -31,17 +31,16 @@ SpriteParticle::SpriteParticle(const std::string& sprite_name, const std::string
                  position_, anchor, velocity_, acceleration_,
                  drawing_layer_, notimeout, color_)
 {
-  if (sprite_name == "images/particles/sparkle.sprite")
+  if (sprite_name == "images/particles/sparkle.sprite") // Sparkles glow in the dark
   {
-    lightsprite = sprite->get_linked_sprite("light");
-    lightsprite->set_blend(Blend::ADD);
-    if (action == "dark")
+    lightsprite = sprite->get_linked_light_sprite();
+    if (lightsprite)
     {
-      lightsprite->set_color(Color(0.1f, 0.1f, 0.1f));
-    }
-    else
-    {
-      lightsprite->set_color(color_);
+      lightsprite->set_blend(Blend::ADD);
+      if (action == "dark")
+        lightsprite->set_color(Color(0.1f, 0.1f, 0.1f));
+      else
+        lightsprite->set_color(color_);
     }
   }
   no_time_out = notimeout;
@@ -100,7 +99,6 @@ SpriteParticle::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), position, drawing_layer);
 
-  // Sparkles glow in the dark.
   if (lightsprite)
   {
     sprite->draw(context.light(), position, drawing_layer);

--- a/src/object/sprite_particle.cpp
+++ b/src/object/sprite_particle.cpp
@@ -33,16 +33,16 @@ SpriteParticle::SpriteParticle(const std::string& sprite_name, const std::string
 {
   if (sprite_name == "images/particles/sparkle.sprite")
   {
-    glow = true;
+    lightsprite = sprite->get_linked_sprite("light");
     lightsprite->set_blend(Blend::ADD);
-    if (action=="dark") {
+    if (action == "dark")
+    {
       lightsprite->set_color(Color(0.1f, 0.1f, 0.1f));
     }
     else
     {
       lightsprite->set_color(color_);
     }
-
   }
   no_time_out = notimeout;
   sprite->set_color(color_);
@@ -56,8 +56,7 @@ SpriteParticle::SpriteParticle(SpritePtr sprite_, const std::string& action,
   velocity(velocity_),
   acceleration(acceleration_),
   drawing_layer(drawing_layer_),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-tiny.sprite")),
-  glow(false),
+  lightsprite(),
   no_time_out(false),
   color(Color::WHITE)
 {
@@ -101,13 +100,12 @@ SpriteParticle::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), position, drawing_layer);
 
-  //Sparkles glow in the dark
-  if (glow)
+  // Sparkles glow in the dark.
+  if (lightsprite)
   {
     sprite->draw(context.light(), position, drawing_layer);
     lightsprite->draw(context.light(), position + Vector(12, 12), 0);
   }
-
 }
 
 /* EOF */

--- a/src/object/sprite_particle.hpp
+++ b/src/object/sprite_particle.hpp
@@ -53,7 +53,6 @@ private:
   Vector acceleration;
   int drawing_layer;
   SpritePtr lightsprite;
-  bool glow;
   bool no_time_out;
   Color color;
 

--- a/src/object/star.cpp
+++ b/src/object/star.cpp
@@ -28,21 +28,9 @@ static const float JUMPSTAR_SPEED = -300;
 
 Star::Star(const Vector& pos, Direction direction, const std::string& custom_sprite) :
   MovingSprite(pos, custom_sprite.empty() ? "images/powerups/star/star.sprite" : custom_sprite, LAYER_OBJECTS, COLGROUP_MOVING),
-  physic(),
-  lightsprite(m_sprite->get_linked_sprite("light"))
+  physic()
 {
   physic.set_velocity((direction == Direction::LEFT) ? -STAR_SPEED : STAR_SPEED, INITIALJUMP);
-  //set light for glow effect
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.4f, 0.4f, 0.4f));
-}
-
-std::vector<MovingSprite::LinkedSprite>
-Star::get_linked_sprites()
-{
-  return {
-    { "light", lightsprite }
-  };
 }
 
 void
@@ -72,13 +60,6 @@ Star::update(float dt_sec)
       }
     }
   }
-}
-
-void
-Star::draw(DrawingContext& context)
-{
-  MovingSprite::draw(context);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
 void

--- a/src/object/star.cpp
+++ b/src/object/star.cpp
@@ -20,7 +20,6 @@
 #include "object/player.hpp"
 #include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
 static const float INITIALJUMP = -400;
@@ -30,12 +29,20 @@ static const float JUMPSTAR_SPEED = -300;
 Star::Star(const Vector& pos, Direction direction, const std::string& custom_sprite) :
   MovingSprite(pos, custom_sprite.empty() ? "images/powerups/star/star.sprite" : custom_sprite, LAYER_OBJECTS, COLGROUP_MOVING),
   physic(),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-small.sprite"))
+  lightsprite(m_sprite->get_linked_sprite("light"))
 {
   physic.set_velocity((direction == Direction::LEFT) ? -STAR_SPEED : STAR_SPEED, INITIALJUMP);
   //set light for glow effect
   lightsprite->set_blend(Blend::ADD);
   lightsprite->set_color(Color(0.4f, 0.4f, 0.4f));
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Star::get_linked_sprites()
+{
+  return {
+    { "light", lightsprite }
+  };
 }
 
 void

--- a/src/object/star.hpp
+++ b/src/object/star.hpp
@@ -35,6 +35,9 @@ public:
 
   virtual bool is_saveable() const override { return false; }
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   Physic physic;
   SpritePtr lightsprite;

--- a/src/object/star.hpp
+++ b/src/object/star.hpp
@@ -28,19 +28,14 @@ public:
   Star(const Vector& pos, Direction direction = Direction::RIGHT, const std::string& custom_sprite = "");
 
   virtual void update(float dt_sec) override;
-  virtual void draw(DrawingContext& context) override;
 
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual bool is_saveable() const override { return false; }
 
-protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
-
 private:
   Physic physic;
-  SpritePtr lightsprite;
 
 private:
   Star(const Star&) = delete;

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -28,7 +28,6 @@ Torch::Torch(const ReaderMapping& reader) :
   m_light_color(1.f, 1.f, 1.f),
   m_flame(m_sprite->get_linked_sprite("flame")),
   m_flame_glow(m_sprite->get_linked_sprite("glow")),
-  m_flame_light(m_sprite->get_linked_sprite("light")),
   m_burning(true)
 {
   reader.get("burning", m_burning, true);
@@ -38,13 +37,13 @@ Torch::Torch(const ReaderMapping& reader) :
   if (!reader.get("color", vColor)) vColor = { 1.f, 1.f, 1.f };
 
   m_flame_glow->set_blend(Blend::ADD);
-  m_flame_light->set_blend(Blend::ADD);
   if (vColor.size() >= 3)
   {
     m_light_color = Color(vColor);
     m_flame->set_color(m_light_color);
     m_flame_glow->set_color(m_light_color);
-    m_flame_light->set_color(m_light_color);
+    if (m_light_sprite)
+      m_light_sprite->set_color(m_light_color);
   }
   set_group(COLGROUP_TOUCHABLE);
 }
@@ -54,8 +53,7 @@ Torch::get_linked_sprites()
 {
   return {
     { "flame", m_flame },
-    { "glow", m_flame_glow },
-    { "light", m_flame_light }
+    { "glow", m_flame_glow }
   };
 }
 
@@ -69,8 +67,11 @@ Torch::draw(DrawingContext& context)
     m_flame->draw(context.color(), pos, m_layer - 1, m_flip);
     m_flame->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
 
-    m_flame_light->draw(context.light(), pos, m_layer);
-    m_flame_light->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
+    if (m_light_sprite)
+    {
+      m_light_sprite->draw(context.light(), pos, m_layer);
+      m_light_sprite->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
+    }
 
     m_flame_glow->draw(context.color(), pos, m_layer - 1, m_flip);
     m_flame_glow->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
@@ -116,7 +117,8 @@ Torch::after_editor_set()
 
   m_flame->set_color(m_light_color);
   m_flame_glow->set_color(m_light_color);
-  m_flame_light->set_color(m_light_color);
+  if (m_light_sprite)
+    m_light_sprite->set_color(m_light_color);
 }
 
 bool

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -48,7 +48,7 @@ Torch::Torch(const ReaderMapping& reader) :
   set_group(COLGROUP_TOUCHABLE);
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Torch::get_linked_sprites()
 {
   return {

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -19,7 +19,6 @@
 
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "util/reader_mapping.hpp"
 
@@ -27,9 +26,9 @@ Torch::Torch(const ReaderMapping& reader) :
   MovingSprite(reader, "images/objects/torch/torch1.sprite"),
   ExposedObject<Torch, scripting::Torch>(this),
   m_light_color(1.f, 1.f, 1.f),
-  m_flame(SpriteManager::current()->create("images/objects/torch/flame.sprite")),
-  m_flame_glow(SpriteManager::current()->create("images/objects/torch/flame_glow.sprite")),
-  m_flame_light(SpriteManager::current()->create("images/objects/torch/flame_light.sprite")),
+  m_flame(m_sprite->get_linked_sprite("flame")),
+  m_flame_glow(m_sprite->get_linked_sprite("glow")),
+  m_flame_light(m_sprite->get_linked_sprite("light")),
   m_burning(true)
 {
   reader.get("burning", m_burning, true);
@@ -48,6 +47,16 @@ Torch::Torch(const ReaderMapping& reader) :
     m_flame_light->set_color(m_light_color);
   }
   set_group(COLGROUP_TOUCHABLE);
+}
+
+std::vector<MovingSprite::LinkedSprite>
+Torch::get_linked_sprites()
+{
+  return {
+    { "flame", m_flame },
+    { "glow", m_flame_glow },
+    { "light", m_flame_light }
+  };
 }
 
 void

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -62,7 +62,6 @@ private:
   Color m_light_color;
   SpritePtr m_flame;
   SpritePtr m_flame_glow;
-  SpritePtr m_flame_light;
   bool m_burning;
 
 private:

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -56,7 +56,7 @@ public:
   /** @} */
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   Color m_light_color;

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -55,6 +55,9 @@ public:
                                      torch */
   /** @} */
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   Color m_light_color;
   SpritePtr m_flame;

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -32,7 +32,7 @@
 #include "util/writer.hpp"
 
 WeakBlock::WeakBlock(const ReaderMapping& mapping) :
-  MovingSprite(mapping, "images/objects/weak_block/meltbox.sprite", LAYER_TILES, COLGROUP_STATIC),
+  MovingSprite(mapping, "images/objects/weak_block/meltbox.sprite", LAYER_OBJECTS + 10, COLGROUP_STATIC),
   state(STATE_NORMAL),
   lightsprite()
 {
@@ -59,7 +59,7 @@ WeakBlock::WeakBlock(const ReaderMapping& mapping) :
 
   if (m_type == HAY)
   {
-    lightsprite = m_sprite->get_linked_sprite("light");
+    lightsprite = m_sprite->get_linked_sprite("burn-light");
     SoundManager::current()->preload("sounds/fire.ogg"); // TODO: Use own sound?
   }
   else
@@ -76,7 +76,7 @@ WeakBlock::get_linked_sprites()
   if (m_type == HAY)
   {
     return {
-      { "light", lightsprite }
+      { "burn-light", lightsprite }
     };
   }
   return {};
@@ -229,8 +229,7 @@ WeakBlock::update(float )
 void
 WeakBlock::draw(DrawingContext& context)
 {
-  //Draw the Sprite just in front of other objects
-  m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 10, m_flip);
+  MovingSprite::draw(context);
 
   if (lightsprite && (state != STATE_NORMAL))
     lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -70,7 +70,7 @@ WeakBlock::WeakBlock(const ReaderMapping& mapping) :
   set_action("normal");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 WeakBlock::get_linked_sprites()
 {
   if (m_type == HAY)

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -48,7 +48,7 @@ public:
   void startBurning();
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   virtual HitResponse collision_bullet(Bullet& bullet, const CollisionHit& hit);

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -47,6 +47,9 @@ public:
 
   void startBurning();
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   virtual HitResponse collision_bullet(Bullet& bullet, const CollisionHit& hit);
 

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 
+#include "sprite/sprite_manager.hpp"
 #include "supertux/direction.hpp"
 #include "supertux/globals.hpp"
 #include "util/log.hpp"
@@ -176,6 +177,25 @@ Sprite::draw(Canvas& canvas, const Vector& pos, int layer,
                     layer);
 
   context.pop_transform();
+}
+
+SpritePtr
+Sprite::get_linked_sprite(const std::string& key) const
+{
+  return SpriteManager::current()->create(get_linked_sprite_file(key));
+}
+
+std::string
+Sprite::get_linked_sprite_file(const std::string& key) const
+{
+  auto it = m_data.linked_sprites.find(key);
+  if (it == m_data.linked_sprites.end()) // No linked sprite with such key
+  {
+    log_warning << "No linked sprite with key '" << key << "'." << std::endl;
+    return ""; // Empty sprite name leads to a dummy sprite
+  }
+
+  return it->second;
 }
 
 int

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -170,13 +170,33 @@ Sprite::draw(Canvas& canvas, const Vector& pos, int layer,
   context.set_alpha(context.get_alpha() * m_alpha);
 
   canvas.draw_surface(m_action->surfaces[m_frameidx],
-                    pos - Vector(m_action->x_offset, flip == NO_FLIP ? m_action->y_offset : (static_cast<float>(m_action->surfaces[m_frameidx]->get_height()) - m_action->y_offset - m_action->hitbox_h)),
-                    m_angle,
-                    m_color,
-                    m_blend,
-                    layer);
+                      pos - Vector(m_action->x_offset,
+                                   flip == NO_FLIP ? m_action->y_offset :
+                                     (static_cast<float>(m_action->surfaces[m_frameidx]->get_height()) - m_action->y_offset - m_action->hitbox_h + m_action->flip_offset)),
+                      m_angle,
+                      m_color,
+                      m_blend,
+                      layer);
 
   context.pop_transform();
+}
+
+SpritePtr
+Sprite::get_linked_light_sprite() const
+{
+  if (!m_data.linked_light_sprite)
+    return nullptr;
+
+  SpritePtr sprite = SpriteManager::current()->create(m_data.linked_light_sprite->file);
+  sprite->set_blend(Blend::ADD);
+  sprite->set_color(m_data.linked_light_sprite->color);
+  return sprite;
+}
+
+std::string
+Sprite::get_linked_light_sprite_file() const
+{
+  return m_data.linked_light_sprite ? m_data.linked_light_sprite->file : "";
 }
 
 SpritePtr

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -86,6 +86,10 @@ public:
   /** Get current action name */
   const std::string& get_action() const { return m_action->name; }
 
+  /** Get linked light sprite */
+  SpritePtr get_linked_light_sprite() const;
+  std::string get_linked_light_sprite_file() const;
+
   /** Get linked sprite by key */
   SpritePtr get_linked_sprite(const std::string& key) const;
   std::string get_linked_sprite_file(const std::string& key) const;

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -86,6 +86,10 @@ public:
   /** Get current action name */
   const std::string& get_action() const { return m_action->name; }
 
+  /** Get linked sprite by key */
+  SpritePtr get_linked_sprite(const std::string& key) const;
+  std::string get_linked_sprite_file(const std::string& key) const;
+
   int get_width() const;
   int get_height() const;
 

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "video/surface_ptr.hpp"
 
@@ -98,6 +99,7 @@ private:
 private:
   Actions actions;
   std::string name;
+  std::unordered_map<std::string, std::string> linked_sprites;
 };
 
 #endif

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -20,8 +20,10 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <optional>
 #include <unordered_map>
 
+#include "video/color.hpp"
 #include "video/surface_ptr.hpp"
 
 class ReaderMapping;
@@ -56,6 +58,7 @@ private:
     /** Position correction */
     float x_offset;
     float y_offset;
+    float flip_offset;
 
     /** Hitbox width */
     float hitbox_w;
@@ -99,6 +102,17 @@ private:
 private:
   Actions actions;
   std::string name;
+
+  struct LinkedLightSprite final
+  {
+    LinkedLightSprite(const std::string& file_) :
+      file(file_), color()
+    {}
+
+    std::string file;
+    Color color;
+  };
+  std::optional<LinkedLightSprite> linked_light_sprite;
   std::unordered_map<std::string, std::string> linked_sprites;
 };
 

--- a/src/sprite/sprite_manager.cpp
+++ b/src/sprite/sprite_manager.cpp
@@ -27,14 +27,24 @@
 #include "util/reader_mapping.hpp"
 #include "util/string_util.hpp"
 
-std::unique_ptr<SpriteData> SpriteManager::s_dummy_sprite_data = nullptr;
+SpriteData* SpriteManager::s_dummy_sprite_data = nullptr;
 
 SpriteManager::SpriteManager() :
   m_sprites(),
   m_load_successful(false)
 {
   if (!s_dummy_sprite_data)
-    s_dummy_sprite_data.reset(new SpriteData());
+  {
+    auto dummy_data = std::make_unique<SpriteData>();
+    s_dummy_sprite_data = dummy_data.get();
+    m_sprites[""] = std::move(dummy_data); // Empty sprite name -> dummy sprite
+  }
+}
+
+SpritePtr
+SpriteManager::create_dummy_sprite() const
+{
+  return SpritePtr(new Sprite(*s_dummy_sprite_data));
 }
 
 SpritePtr
@@ -53,7 +63,7 @@ SpriteManager::create(const std::string& name)
     {
       log_warning << "Error loading sprite '" << name << "', using dummy texture: " << err.what() << std::endl;
       m_load_successful = false;
-      return SpritePtr(new Sprite(*s_dummy_sprite_data)); // Return a dummy sprite.
+      return create_dummy_sprite(); // Return a dummy sprite.
     }
   }
   else

--- a/src/sprite/sprite_manager.hpp
+++ b/src/sprite/sprite_manager.hpp
@@ -31,7 +31,7 @@ class SpriteData;
 class SpriteManager final : public Currenton<SpriteManager>
 {
 private:
-  static std::unique_ptr<SpriteData> s_dummy_sprite_data;
+  static SpriteData* s_dummy_sprite_data;
 
 private:
   typedef std::map<std::string, std::unique_ptr<SpriteData> > Sprites;
@@ -45,6 +45,7 @@ public:
 
   /** loads a sprite. */
   SpritePtr create(const std::string& filename);
+  SpritePtr create_dummy_sprite() const;
 
 private:
   SpriteData* load(const std::string& filename);

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -19,9 +19,8 @@
 #include "audio/sound_manager.hpp"
 #include "math/random.hpp"
 #include "object/player.hpp"
-#include "object/sprite_particle.hpp"
 #include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
+#include "object/sprite_particle.hpp"
 #include "supertux/fadetoblack.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/screen_manager.hpp"
@@ -35,7 +34,7 @@ Door::Door(const ReaderMapping& mapping) :
   target_sector(),
   target_spawnpoint(),
   script(),
-  lock_sprite(SpriteManager::current()->create("images/objects/door/door_lock.sprite")),
+  lock_sprite(m_sprite->get_linked_sprite("lock")),
   stay_open_timer(),
   unlocking_timer(),
   lock_warn_timer(),
@@ -64,6 +63,14 @@ Door::Door(const ReaderMapping& mapping) :
   SoundManager::current()->preload("sounds/turnkey.ogg");
 }
 
+std::vector<MovingSprite::LinkedSprite>
+Door::get_linked_sprites()
+{
+  return {
+    { "lock", lock_sprite }
+  };
+}
+
 ObjectSettings
 Door::get_settings()
 {
@@ -85,6 +92,7 @@ Door::after_editor_set()
 {
   SpritedTrigger::after_editor_set();
 
+  state = m_locked ? DoorState::LOCKED : DoorState::CLOSED;
   lock_sprite->set_color(lock_color);
 }
 

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -63,7 +63,7 @@ Door::Door(const ReaderMapping& mapping) :
   SoundManager::current()->preload("sounds/turnkey.ogg");
 }
 
-std::vector<MovingSprite::LinkedSprite>
+MovingSprite::LinkedSprites
 Door::get_linked_sprites()
 {
   return {

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -47,6 +47,9 @@ public:
 
   Color get_lock_color() const { return lock_color; }
 
+protected:
+  std::vector<LinkedSprite> get_linked_sprites() override;
+
 private:
   enum DoorState {
     CLOSED,

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -48,7 +48,7 @@ public:
   Color get_lock_color() const { return lock_color; }
 
 protected:
-  std::vector<LinkedSprite> get_linked_sprites() override;
+  LinkedSprites get_linked_sprites() override;
 
 private:
   enum DoorState {


### PR DESCRIPTION
Custom light sprites can now be added to all objects, which inherit `MovingSprite`. Setting a custom color for the light sprite is also possible, as long as the object is not designed to use foreign color values (for example, from an option).

To add a light sprite with an RGB color of `0.5, 0.2, 0.25`, in a `.sprite` file:

```
(linked-sprites
  (light "path/to/light/sprite" 0.5 0.2 0.25)
)
```

Keep in mind that specifying color values is optional. The entry can also end after specifying the file.

**Additionally:**

* Objects which utilize more than 1 sprite are now able to get the files of their additional sprites from the main one's `linked-sprites` list (the same block where `light` sprites can also be added, as shown above). This allows for expanded sprite customization for objects.

To add linked sprites, in a `.sprite` file:

```
(linked-sprites
  (key "path/to/sprite")
  (key2 "another/sprite/file")
)
```

Sprites, which the specific object does not support, will be ignored.

* Sprite actions now support the `flip-offset` property, which determines how much the sprite should be vertically offset when flipped vertically.
