### PR TITLE
Rotate Tux sprite if sliding on slope

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1434,6 +1434,27 @@ Player::handle_input()
       m_sprite->set_angle(0);
       //m_santahatsprite->set_angle(0);
     }
+    if (m_sliding)
+    {
+      float sliding_angle = 0.0f;
+
+      if (on_ground())
+      {
+        if (m_floor_normal.y != 0.0f)
+        {
+          sliding_angle = math::degrees(math::angle(m_floor_normal)) + 90.0f;
+        }
+      }
+      else
+      {
+        sliding_angle = math::degrees(math::angle(m_physic.get_velocity()));
+        if (m_physic.get_velocity_x() < 0.0f)
+        {
+          sliding_angle += 180.0f;
+        }
+      }
+      m_sprite->set_angle(sliding_angle);
+    }
     if (!m_jump_early_apex) {
       m_physic.set_gravity_modifier(1.0f);
     }


### PR DESCRIPTION
Use the underground's normal to calculate the sprite orientation of Tux while sliding on ground.
If still sliding while in air (e.g. due to jumping off a cliff while sliding), rotate the sprite according to velocity.

Addresses, but may not fully implement #2723