### PR TITLE
Re-enable uploading WASM builds to supertux.semphris.com

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -97,5 +97,4 @@ jobs:
           cd build/upload/
           mv supertux2.html index.html
           zip supertux2.zip *
-          # TODO: Decomment (or replace URL with a different host)
-          # curl -F "archive=@$(pwd)/supertux2.zip" -F "message=$(git log --format=%B -n 1 | head -1)" $UPLOAD_URL
+          curl -F "archive=@$(pwd)/supertux2.zip" -F "message=$(git log --format=%B -n 1 | head -1)" $UPLOAD_URL


### PR DESCRIPTION
I noticed the website was outdated.

With agreement of one person, I've re-enabled uploads on my server's side. Normally, this PR should be enough for uploads to work.

If this is fine with everybody, I would let another person do the merge.