### PR TITLE
Fix outdated file paths in custom particles code

### DIFF
--- a/src/object/custom_particle_system.cpp
+++ b/src/object/custom_particle_system.cpp
@@ -49,7 +49,7 @@ CustomParticleSystem::CustomParticleSystem() :
   script_easings(),
   m_textures(),
   custom_particles(),
-  m_particle_main_texture("/images/engine/editor/sparkle.png"),
+  m_particle_main_texture("/images/engine/editor/particle.png"),
   m_max_amount(25),
   m_delay(0.1f),
   m_particle_lifetime(5.f),
@@ -93,7 +93,7 @@ CustomParticleSystem::CustomParticleSystem(const ReaderMapping& reader) :
   script_easings(),
   m_textures(),
   custom_particles(),
-  m_particle_main_texture("/images/engine/editor/sparkle.png"),
+  m_particle_main_texture("/images/engine/editor/particle.png"),
   m_max_amount(25),
   m_delay(0.1f),
   m_particle_lifetime(5.f),
@@ -126,7 +126,7 @@ CustomParticleSystem::CustomParticleSystem(const ReaderMapping& reader) :
   m_particle_offscreen_mode(),
   m_cover_screen(true)
 {
-  reader.get("main-texture", m_particle_main_texture, "/images/engine/editor/sparkle.png");
+  reader.get("main-texture", m_particle_main_texture, "/images/engine/editor/particle.png");
 
   // FIXME: Is there a cleaner way to get a list of textures?
   auto iter = reader.get_iter();

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -49,7 +49,7 @@ public:
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {
-    return "images/engine/editor/sparkle.png";
+    return "images/engine/editor/particle.png";
   }
 
   virtual void expose(HSQUIRRELVM vm, SQInteger table_idx) override {
@@ -137,7 +137,7 @@ private:
     SpriteProperties() :
       likeliness(1.f),
       color(1.f, 1.f, 1.f, 1.f),
-      texture(Surface::from_file("images/engine/editor/sparkle.png")),
+      texture(Surface::from_file("images/engine/editor/particle.png")),
       scale(1.f, 1.f),
       hb_scale(1.f, 1.f),
       hb_offset(0.f, 0.f)

--- a/src/object/custom_particle_system_file.hpp
+++ b/src/object/custom_particle_system_file.hpp
@@ -42,7 +42,7 @@ public:
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {
-    return "images/engine/editor/sparkle-file.png";
+    return "images/engine/editor/particle_file.png";
   }
 
 private:


### PR DESCRIPTION
This updates the path from `images/engine/editor/sparkle.png` and `images/engine/editor/sparkle-file.png` to `images/engine/editor/particle.png` and `images/engine/editor/particle_file.png` in `custom_particle_system.h/cpp` and `custom_particle_system_file.hpp`.

The filenames were changed at some point but these paths weren't, resulting in a lot of complaining from the game's console and a missing texture instead of the proper image for custom particles and custom particles from file in the editor's bottom panel.