### PR TITLE
Fix macOS CI

### DIFF
--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -2,7 +2,7 @@
 
 shopt -s nullglob
 
-if ([ "$OS_NAME" = "macos-10.15" ] || [ "$OS_NAME" = "macos-11" ]) && [ "$PACKAGE" = "ON" ]; then
+if ([ "$OS_NAME" = "macos-10.15" ] || [ "$OS_NAME" = "macos-12" ]) && [ "$PACKAGE" = "ON" ]; then
     sudo chmod -R +w /usr/local/Cellar
     cpack -G Bundle;
 fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-12]
         build_type: [Debug, Release]
         glbinding: [ON, OFF]
         include:
-          - os: macos-11
+          - os: macos-12
             build_type: Release
             glbinding: OFF
             release: ON
@@ -48,7 +48,7 @@ jobs:
           submodules: true
 
       - name: Install macos dependencies
-        if: ${{ matrix.os == 'macos-11' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           brew install cmake googletest bash rename libogg libvorbis glew \
                        openal-soft sdl2 sdl2_image sdl2_ttf freetype harfbuzz \
@@ -138,8 +138,8 @@ jobs:
         env:
           OS: ${{ matrix.os }}
         run: |
-          if [ "$OS" = "macos-11" ]; then
-            rename 's/.dmg/-11.dmg/' build/upload/SuperTux-*
+          if [ "$OS" = "macos-12" ]; then
+            rename 's/.dmg/-12.dmg/' build/upload/SuperTux-*
           fi
 
       - name: Create Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,10 @@ jobs:
             '@rpath/libsharpyuv.0.dylib' \
             /usr/local/opt/webp/lib/libsharpyuv.0.dylib \
             /usr/local/opt/webp/lib/libwebp.7.dylib
+          install_name_tool -change \
+            '@rpath/libjxl_cms.0.9.dylib' \
+            /usr/local/opt/jpeg-xl/lib/libjxl_cms.0.9.dylib \
+            /usr/local/opt/jpeg-xl/lib/libjxl.dylib
 
           # Something funky happens with freetype if mono is left
           sudo mv /Library/Frameworks/Mono.framework                           \


### PR DESCRIPTION
- Run macOS CI on `macos-12`. macOS 11 is no longer supported by Homebrew (and Apple); many packages now need to be built from source.
- Fix `libjxl_cms`'s install name in `libjxl`. This caused CI to fail, as reported in https://github.com/orgs/Homebrew/discussions/4735#discussioncomment-8197975. CMake's `fixup_bundle` does not recognise install names with `@rpath`, so it fails while bundling `libjxl_cms` as `libjxl`'s dependency. Make CMake happy by changing its install name to a full path instead.

See also: https://github.com/SuperTux/supertux/pull/2622#issuecomment-1706816598

CC @tobbi
