### PR TITLE
Save VSync setting

### DIFF
--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -51,7 +51,7 @@ Config::Config() :
   use_fullscreen(false),
 #endif
   video(VideoSystem::VIDEO_AUTO),
-  try_vsync(true),
+  vsync(),
   show_fps(false),
   show_player_pos(false),
   show_controller(false),
@@ -260,7 +260,7 @@ Config::load()
     std::string video_string;
     config_video_mapping->get("video", video_string);
     video = VideoSystem::get_video_system(video_string);
-    config_video_mapping->get("vsync", try_vsync);
+    config_video_mapping->get("vsync", vsync);
 
     config_video_mapping->get("fullscreen_width",  fullscreen_size.width);
     config_video_mapping->get("fullscreen_height", fullscreen_size.height);
@@ -416,7 +416,7 @@ Config::save()
   } else {
     writer.write("video", VideoSystem::get_video_string(video));
   }
-  writer.write("vsync", try_vsync);
+  writer.write("vsync", VideoSystem::current()->get_vsync());
 
   writer.write("fullscreen_width",  fullscreen_size.width);
   writer.write("fullscreen_height", fullscreen_size.height);

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -51,7 +51,7 @@ Config::Config() :
   use_fullscreen(false),
 #endif
   video(VideoSystem::VIDEO_AUTO),
-  vsync(),
+  vsync(1),
   show_fps(false),
   show_player_pos(false),
   show_controller(false),

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -416,7 +416,7 @@ Config::save()
   } else {
     writer.write("video", VideoSystem::get_video_string(video));
   }
-  writer.write("vsync", VideoSystem::current()->get_vsync());
+  writer.write("vsync", vsync);
 
   writer.write("fullscreen_width",  fullscreen_size.width);
   writer.write("fullscreen_height", fullscreen_size.height);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -60,7 +60,7 @@ public:
 
   bool use_fullscreen;
   VideoSystem::Enum video;
-  bool try_vsync;
+  int vsync;
   bool show_fps;
   bool show_player_pos;
   bool show_controller;

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -644,22 +644,27 @@ OptionsMenu::menu_action(MenuItem& item)
 #endif
 
     case MNID_VSYNC:
+    {
+      int vsync = 0;
       switch (m_vsyncs.next)
       {
         case 2:
-          VideoSystem::current()->set_vsync(-1);
+          vsync = -1;
           break;
         case 1:
-          VideoSystem::current()->set_vsync(0);
+          vsync = 1;
           break;
         case 0:
-          VideoSystem::current()->set_vsync(1);
+          vsync = 0;
           break;
         default:
           assert(false);
           break;
       }
-      break;
+      g_config->vsync = vsync;
+      VideoSystem::current()->set_vsync(vsync);
+    }
+    break;
 
     case MNID_FULLSCREEN:
       VideoSystem::current()->apply_config();

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -652,10 +652,10 @@ OptionsMenu::menu_action(MenuItem& item)
           vsync = -1;
           break;
         case 1:
-          vsync = 1;
+          vsync = 0;
           break;
         case 0:
-          vsync = 0;
+          vsync = 1;
           break;
         default:
           assert(false);

--- a/src/video/gl/gl_video_system.cpp
+++ b/src/video/gl/gl_video_system.cpp
@@ -179,11 +179,7 @@ GLVideoSystem::create_gl_context()
   m_glcontext = SDL_GL_CreateContext(m_sdl_window.get());
 
   assert_gl();
-
-  if (g_config->vsync > 0) {
-    set_vsync(g_config->vsync);
-  }
-
+  set_vsync(g_config->vsync);
   assert_gl();
 
 #if defined(USE_OPENGLES2)
@@ -317,7 +313,23 @@ GLVideoSystem::set_vsync(int mode)
 {
   if (SDL_GL_SetSwapInterval(mode) < 0)
   {
-    log_warning << "Setting vsync mode failed: " << SDL_GetError() << std::endl;
+    log_warning << "Setting vsync mode to " << mode << " failed: " << SDL_GetError() << std::endl;
+    if(mode != 1)
+    {
+      mode = 1;
+      log_warning << "Trying to set vsync mode to 1" << std::endl;
+      if (SDL_GL_SetSwapInterval(1) < 0)
+      {
+        log_warning << "Setting vsync mode failed: " << SDL_GetError() << ". Trying to set vsync mode to 0" << std::endl;
+        if(mode != 0)
+        {
+          mode = 0;
+          log_warning << "Trying to set vsync mode to 0" << std::endl;
+          SDL_GL_SetSwapInterval(0);
+        }
+      }
+      g_config->vsync = mode;
+    }
   }
   else
   {

--- a/src/video/gl/gl_video_system.cpp
+++ b/src/video/gl/gl_video_system.cpp
@@ -180,16 +180,8 @@ GLVideoSystem::create_gl_context()
 
   assert_gl();
 
-  if (g_config->try_vsync) {
-    // We want VSync for smooth scrolling.
-    if (SDL_GL_SetSwapInterval(-1) != 0)
-    {
-      log_info << "no support for late swap tearing vsync: " << SDL_GetError() << std::endl;
-      if (SDL_GL_SetSwapInterval(1))
-      {
-        log_info << "no support for vsync: " << SDL_GetError() << std::endl;
-      }
-    }
+  if (g_config->vsync > 0) {
+    set_vsync(g_config->vsync);
   }
 
   assert_gl();


### PR DESCRIPTION
Fixes #2780

I'm not sure if this is the right approach, as we seem to be checking for the best possible vsync value earlier and picking one.

What's saved is: boolean yes / no: Check for vsync and not the exact vsync value.