### PR TITLE
Fix some enemies not going down slopes

### DIFF
--- a/src/badguy/captainsnowball.cpp
+++ b/src/badguy/captainsnowball.cpp
@@ -29,7 +29,7 @@ CaptainSnowball::CaptainSnowball(const ReaderMapping& reader) :
   m_jumping(false)
 {
   walk_speed = BOARDING_SPEED;
-  max_drop_height = -1;
+  set_ledge_behavior(LedgeBehavior::FALL);
   m_physic.set_velocity_y(-400);
 }
 

--- a/src/badguy/crystallo.cpp
+++ b/src/badguy/crystallo.cpp
@@ -25,7 +25,7 @@ Crystallo::Crystallo(const ReaderMapping& reader) :
   m_radius()
 {
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   reader.get("radius", m_radius, 100.0f);
 }
 
@@ -39,7 +39,7 @@ Crystallo::Crystallo(const Vector& pos, const Vector& start_pos, float vel_x, st
   m_dead_script = script;
   m_start_position = start_pos;
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 }
 
 ObjectSettings

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -168,7 +168,7 @@ GoldBomb::active_update(float dt_sec)
     return;
   }
 
-  if ((tstate == STATE_FLEEING || tstate == STATE_CORNERED) && on_ground() && might_fall(600+1))
+  if ((tstate == STATE_FLEEING || tstate == STATE_CORNERED) && on_ground() && might_fall(s_normal_max_drop_height+1))
   {
     // also check for STATE_CORNERED just so
     // the bomb doesnt automatically turn around

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -40,8 +40,6 @@ static const float SAFE_DIST = 32.f * 10.f;
 
 static const float NORMAL_WALK_SPEED = 80.0f;
 static const float FLEEING_WALK_SPEED = 180.0f;
-static const int NORMAL_MAX_DROP_HEIGHT = 16;
-static const int FLEEING_MAX_DROP_HEIGHT = 600;
 
 GoldBomb::GoldBomb(const ReaderMapping& reader) :
   WalkingBadguy(reader, "images/creatures/gold_bomb/gold_bomb.sprite", "left", "right"),
@@ -53,7 +51,7 @@ GoldBomb::GoldBomb(const ReaderMapping& reader) :
   assert(SAFE_DIST >= REALIZE_DIST);
 
   walk_speed = NORMAL_WALK_SPEED;
-  max_drop_height = NORMAL_MAX_DROP_HEIGHT;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   SoundManager::current()->preload("sounds/explosion.wav");
 
@@ -170,7 +168,7 @@ GoldBomb::active_update(float dt_sec)
     return;
   }
 
-  if ((tstate == STATE_FLEEING || tstate == STATE_CORNERED) && on_ground() && might_fall(FLEEING_MAX_DROP_HEIGHT+1))
+  if ((tstate == STATE_FLEEING || tstate == STATE_CORNERED) && on_ground() && might_fall(600+1))
   {
     // also check for STATE_CORNERED just so
     // the bomb doesnt automatically turn around
@@ -222,7 +220,7 @@ GoldBomb::active_update(float dt_sec)
     m_physic.set_velocity_x(NORMAL_WALK_SPEED * (m_dir == Direction::LEFT ? -1 : 1));
     m_physic.set_acceleration_x(0);
     set_action(m_dir);
-    max_drop_height = NORMAL_MAX_DROP_HEIGHT;
+    set_ledge_behavior(LedgeBehavior::SMART);
     set_walk_speed(NORMAL_WALK_SPEED);
     return;
   }
@@ -432,7 +430,7 @@ void
 GoldBomb::flee(Direction dir)
 {
   set_walk_speed(FLEEING_WALK_SPEED);
-  max_drop_height = FLEEING_MAX_DROP_HEIGHT;
+  set_ledge_behavior(LedgeBehavior::NORMAL);
   m_dir = dir;
 
   const float speed = FLEEING_WALK_SPEED * (m_dir == Direction::LEFT ? -1 : 1);

--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -52,7 +52,7 @@ Haywire::Haywire(const ReaderMapping& reader) :
   stomped_timer()
 {
   walk_speed = NORMAL_WALK_SPEED;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   SoundManager::current()->preload("sounds/explosion.wav");
 }
@@ -284,7 +284,7 @@ void
 Haywire::start_exploding()
 {
   set_walk_speed (EXPLODING_WALK_SPEED);
-  max_drop_height = -1;
+  set_ledge_behavior(LedgeBehavior::FALL);
   time_until_explosion = TIME_EXPLOSION;
   m_is_exploding = true;
 
@@ -306,7 +306,7 @@ Haywire::stop_exploding()
   walk_left_action = "left";
   walk_right_action = "right";
   set_walk_speed(NORMAL_WALK_SPEED);
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   time_until_explosion = 0.0f;
   m_is_exploding = false;
 

--- a/src/badguy/igel.cpp
+++ b/src/badguy/igel.cpp
@@ -30,7 +30,6 @@ namespace {
 
 const float IGEL_NORMAL_SPEED = 80;
 const float IGEL_CORRUPTED_SPEED = 120;
-const int   IGEL_MAX_DROP_HEIGHT = 16;
 
 const float ROLL_RANGE = 32*10;
 const float ROLL_SPEED = 350;
@@ -54,7 +53,7 @@ Igel::Igel(const ReaderMapping& reader) :
   parse_type(reader);
 
   walk_speed = get_normal_walk_speed();
-  max_drop_height = IGEL_MAX_DROP_HEIGHT;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   SoundManager::current()->preload("sounds/thud.ogg");
 }
@@ -231,7 +230,7 @@ Igel::roll()
 
   set_action("roll-start", m_dir);
 
-  max_drop_height = ROLL_MAX_DROP_HEIGHT;
+  set_ledge_behavior(LedgeBehavior::FALL);
 
   m_roll_timer.start(ROLL_DURATION);
   m_ease_timer.start(ROLL_EASE_TIMER);
@@ -251,7 +250,7 @@ Igel::stop_rolling(bool bonk)
     m_physic.set_velocity_y(-250.f);
   }
 
-  max_drop_height = IGEL_MAX_DROP_HEIGHT;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   m_roll_timer.stop();
   m_roll_cooldown.start(ROLL_COOLDOWN);

--- a/src/badguy/igel.cpp
+++ b/src/badguy/igel.cpp
@@ -33,7 +33,6 @@ const float IGEL_CORRUPTED_SPEED = 120;
 
 const float ROLL_RANGE = 32*10;
 const float ROLL_SPEED = 350;
-const int   ROLL_MAX_DROP_HEIGHT = -1;
 const float ROLL_DURATION = 2.f;
 const float ROLL_EASE_TIMER = 0.5f;
 const float ROLL_COOLDOWN = 1.f;

--- a/src/badguy/livefire.cpp
+++ b/src/badguy/livefire.cpp
@@ -29,7 +29,7 @@ LiveFire::LiveFire(const ReaderMapping& reader) :
   state(STATE_WALKING)
 {
   walk_speed = 80;
-  max_drop_height = 20;
+  set_ledge_behavior(LedgeBehavior::SMART);
   m_lightsprite->set_color(Color(0.89f, 0.75f, 0.44f));
   m_glowing = true;
 }

--- a/src/badguy/mrbomb.cpp
+++ b/src/badguy/mrbomb.cpp
@@ -34,7 +34,7 @@ MrBomb::MrBomb(const ReaderMapping& reader) :
   parse_type(reader);
 
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   // Prevent stutter when Tux jumps on Mr Bomb.
   SoundManager::current()->preload("sounds/explosion.wav");

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -42,7 +42,7 @@ MrIceBlock::MrIceBlock(const ReaderMapping& reader, const std::string& sprite_na
   parse_type(reader);
 
   walk_speed = 80;
-  max_drop_height = -1;
+  set_ledge_behavior(LedgeBehavior::FALL);
   SoundManager::current()->preload("sounds/iceblock_bump.wav");
   SoundManager::current()->preload("sounds/stomp.wav");
   SoundManager::current()->preload("sounds/kick.wav");

--- a/src/badguy/mrtree.cpp
+++ b/src/badguy/mrtree.cpp
@@ -39,7 +39,7 @@ MrTree::MrTree(const ReaderMapping& reader) :
 {
   parse_type(reader);
 
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/mr_tree.ogg");
 }
 

--- a/src/badguy/rcrystallo.cpp
+++ b/src/badguy/rcrystallo.cpp
@@ -31,7 +31,7 @@ RCrystallo::RCrystallo(const ReaderMapping& reader) :
   m_radius()
 {
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   reader.get("radius", m_radius, 100.0f);
   SoundManager::current()->preload("sounds/crystallo-shatter.ogg");
 }
@@ -56,7 +56,7 @@ RCrystallo::RCrystallo(const Vector& pos, const Vector& start_pos, float vel_x, 
   m_dead_script = script;
   m_start_position = start_pos;
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/crystallo-shatter.ogg");
 }
 

--- a/src/badguy/scrystallo.cpp
+++ b/src/badguy/scrystallo.cpp
@@ -33,7 +33,7 @@ SCrystallo::SCrystallo(const ReaderMapping& reader) :
   m_radius_anchor()
 {
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   reader.get("roof", m_roof, false);
   reader.get("radius", m_radius, 100.0f);
   reader.get("range", m_range, 250.0f);

--- a/src/badguy/short_fuse.cpp
+++ b/src/badguy/short_fuse.cpp
@@ -29,7 +29,7 @@ ShortFuse::ShortFuse(const ReaderMapping& reader) :
   WalkingBadguy(reader, "images/creatures/short_fuse/short_fuse.sprite", "left", "right")
 {
   walk_speed = 100;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 
   SoundManager::current()->preload("sounds/firecracker.ogg");
 }

--- a/src/badguy/smartball.cpp
+++ b/src/badguy/smartball.cpp
@@ -24,7 +24,7 @@ SmartBall::SmartBall(const ReaderMapping& reader)
   parse_type(reader);
 
   walk_speed = 80;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 }
 
 GameObjectTypes

--- a/src/badguy/smartblock.cpp
+++ b/src/badguy/smartblock.cpp
@@ -19,7 +19,7 @@
 SmartBlock::SmartBlock(const ReaderMapping& reader) :
   MrIceBlock(reader, "images/creatures/iceblock/smart_block.sprite")
 {
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 }
 
 /* EOF */

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -48,7 +48,7 @@ Snail::Snail(const ReaderMapping& reader) :
   parse_type(reader);
 
   walk_speed = 80;
-  max_drop_height = 600;
+  set_ledge_behavior(LedgeBehavior::NORMAL);
   SoundManager::current()->preload("sounds/iceblock_bump.wav");
   SoundManager::current()->preload("sounds/stomp.wav");
   SoundManager::current()->preload("sounds/kick.wav");

--- a/src/badguy/spiky.cpp
+++ b/src/badguy/spiky.cpp
@@ -20,7 +20,7 @@ Spiky::Spiky(const ReaderMapping& reader) :
   WalkingBadguy(reader, "images/creatures/spiky/spiky.sprite", "left", "right")
 {
   walk_speed = 80;
-  max_drop_height = 600;
+  set_ledge_behavior(LedgeBehavior::NORMAL);
 }
 
 bool

--- a/src/badguy/sspiky.cpp
+++ b/src/badguy/sspiky.cpp
@@ -23,7 +23,7 @@ SSpiky::SSpiky(const ReaderMapping& reader) :
   WalkingBadguy(reader, "images/creatures/spiky/sleepingspiky.sprite", "left", "right"), state(SSPIKY_SLEEPING)
 {
   walk_speed = 80;
-  max_drop_height = 600;
+  set_ledge_behavior(LedgeBehavior::NORMAL);
 }
 
 void

--- a/src/badguy/stumpy.cpp
+++ b/src/badguy/stumpy.cpp
@@ -36,7 +36,7 @@ Stumpy::Stumpy(const ReaderMapping& reader) :
   invincible_timer()
 {
   walk_speed = STUMPY_SPEED;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/mr_treehit.ogg");
 }
 
@@ -46,7 +46,7 @@ Stumpy::Stumpy(const Vector& pos, Direction d) :
   invincible_timer()
 {
   walk_speed = STUMPY_SPEED;
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/mr_treehit.ogg");
   invincible_timer.start(INVINCIBLE_TIME);
 }

--- a/src/badguy/walking_badguy.cpp
+++ b/src/badguy/walking_badguy.cpp
@@ -99,7 +99,7 @@ void WalkingBadguy::set_ledge_behavior(LedgeBehavior behavior)
       break;
 
     case LedgeBehavior::SMART:
-      max_drop_height = get_bbox().get_width() / 2;
+      max_drop_height = static_cast<int>(get_bbox().get_width()) / 2;
       break;
 
     case LedgeBehavior::NORMAL:

--- a/src/badguy/walking_badguy.cpp
+++ b/src/badguy/walking_badguy.cpp
@@ -90,6 +90,28 @@ WalkingBadguy::set_walk_speed (float ws)
   /* physic.set_velocity_x(dir == LEFT ? -walk_speed : walk_speed); */
 }
 
+void WalkingBadguy::set_ledge_behavior(LedgeBehavior behavior)
+{
+  switch (behavior)
+  {
+    case LedgeBehavior::STRICT:
+      max_drop_height = 0;
+      break;
+
+    case LedgeBehavior::SMART:
+      max_drop_height = get_bbox().get_width() / 2;
+      break;
+
+    case LedgeBehavior::NORMAL:
+      max_drop_height = 600;
+      break;
+
+    case LedgeBehavior::FALL:
+      max_drop_height = -1;
+      break;
+  }
+}
+
 void
 WalkingBadguy::add_velocity (const Vector& velocity)
 {

--- a/src/badguy/walking_badguy.cpp
+++ b/src/badguy/walking_badguy.cpp
@@ -103,7 +103,7 @@ void WalkingBadguy::set_ledge_behavior(LedgeBehavior behavior)
       break;
 
     case LedgeBehavior::NORMAL:
-      max_drop_height = 600;
+      max_drop_height = s_normal_max_drop_height;
       break;
 
     case LedgeBehavior::FALL:

--- a/src/badguy/walking_badguy.hpp
+++ b/src/badguy/walking_badguy.hpp
@@ -25,6 +25,33 @@ class Timer;
 class WalkingBadguy : public BadGuy
 {
 public:
+  enum class LedgeBehavior
+  {
+    /**
+     * Do not fall off any ledge at all.
+     */
+    STRICT,
+
+    /**
+     * Do not fall off any ledge, but still
+     * go down slopes.
+     */
+    SMART,
+
+    /**
+     * Fall off any ledge, unless the ledge
+     * is too tall (600px) or the ledge falls
+     * offscreen.
+     */
+    NORMAL,
+
+    /**
+     * Fall off any ledge.
+     */
+    FALL
+  };
+
+public:
   WalkingBadguy(const Vector& pos,
                 const std::string& sprite_name,
                 const std::string& walk_left_action,
@@ -65,6 +92,9 @@ public:
   float get_walk_speed() const { return walk_speed; }
   void set_walk_speed (float);
   bool is_active() const { return BadGuy::is_active(); }
+
+  /** Set max_drop_height depending on the given behavior */
+  void set_ledge_behavior(LedgeBehavior behavior);
 
 protected:
   void turn_around();

--- a/src/badguy/walking_badguy.hpp
+++ b/src/badguy/walking_badguy.hpp
@@ -21,34 +21,19 @@
 
 class Timer;
 
+static const int s_normal_max_drop_height = 600;
+
 /** Base class for Badguys that walk on the floor. */
 class WalkingBadguy : public BadGuy
 {
 public:
   enum class LedgeBehavior
   {
-    /**
-     * Do not fall off any ledge at all.
-     */
-    STRICT,
 
-    /**
-     * Do not fall off any ledge, but still
-     * go down slopes.
-     */
-    SMART,
-
-    /**
-     * Fall off any ledge, unless the ledge
-     * is too tall (600px) or the ledge falls
-     * offscreen.
-     */
-    NORMAL,
-
-    /**
-     * Fall off any ledge.
-     */
-    FALL
+    STRICT, /**< Do not fall off any ledge at all. */
+    SMART, /**< Do not fall off any ledge, but still go down slopes. */
+    NORMAL, /**< Fall off any ledge, unless the ledge is too tall (600px) or the ledge falls offscreen. */
+    FALL /**< Fall off any ledge. */
   };
 
 public:

--- a/src/badguy/walking_badguy.hpp
+++ b/src/badguy/walking_badguy.hpp
@@ -21,15 +21,12 @@
 
 class Timer;
 
-static const int s_normal_max_drop_height = 600;
-
 /** Base class for Badguys that walk on the floor. */
 class WalkingBadguy : public BadGuy
 {
 public:
   enum class LedgeBehavior
   {
-
     STRICT, /**< Do not fall off any ledge at all. */
     SMART, /**< Do not fall off any ledge, but still go down slopes. */
     NORMAL, /**< Fall off any ledge, unless the ledge is too tall (600px) or the ledge falls offscreen. */
@@ -83,6 +80,9 @@ public:
 
 protected:
   void turn_around();
+
+protected:
+  static const int s_normal_max_drop_height = 600;
 
 protected:
   std::string walk_left_action;

--- a/src/badguy/walkingleaf.cpp
+++ b/src/badguy/walkingleaf.cpp
@@ -25,7 +25,7 @@ WalkingLeaf::WalkingLeaf(const ReaderMapping& reader) :
 {
   parse_type(reader);
 
-  max_drop_height = 16;
+  set_ledge_behavior(LedgeBehavior::SMART);
 }
 
 GameObjectTypes


### PR DESCRIPTION
Some enemies with big hitboxes didn't go down slopes. This was because the max drop height was too small. The max drop height for smart enemies is now `width / 2`.

I also added `LedgeBehavior`, which can be used with `WalkingBadguy::set_ledge_behavior`, instead of setting numbers like -1, 16 or 600