### PR TITLE
Show editor mode below mouse cursor

### DIFF
--- a/src/gui/mousecursor.cpp
+++ b/src/gui/mousecursor.cpp
@@ -108,10 +108,7 @@ MouseCursor::draw(DrawingContext& context)
     m_sprite->draw(context.color(), mouse_pos, LAYER_GUI + 100);
 
     if (m_icon) {
-      context.color().draw_surface(m_icon,
-                                   Vector(mouse_pos.x,
-                                          mouse_pos.y - static_cast<float>(m_icon->get_height())),
-                                   LAYER_GUI + 100);
+      context.color().draw_surface(m_icon, mouse_pos + m_sprite->get_size(), LAYER_GUI + 100);
     }
   }
 }

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -192,6 +192,12 @@ Sprite::get_height() const
   return static_cast<int>(m_action->surfaces[m_frameidx]->get_height());
 }
 
+Vector
+Sprite::get_size() const
+{
+  return Vector(get_width(), get_height());
+}
+
 bool
 Sprite::is_current_hitbox_unisolid() const
 {

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -88,6 +88,7 @@ public:
 
   int get_width() const;
   int get_height() const;
+  Vector get_size() const;
 
   /** Return the "unisolid" property for the current action's hitbox. */
   bool is_current_hitbox_unisolid() const;


### PR DESCRIPTION
I find it more intuitive to have the editor mode show below the cursor.

Even better would it be if the cursor itself could be replaced with the actual mode (rubber for "delete") etc.