### PR TITLE
Do not increment powerup counter on restart_level()

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1878,7 +1878,7 @@ Player::add_bonus(BonusType type, bool animate)
 }
 
 bool
-Player::set_bonus(BonusType type, bool animate)
+Player::set_bonus(BonusType type, bool animate, bool increment_powerup_counter)
 {
   if (m_dying) {
     return false;
@@ -1920,10 +1920,14 @@ Player::set_bonus(BonusType type, bool animate)
     m_player_status.max_air_time[get_id()] = 0;
     m_player_status.max_earth_time[get_id()] = 0;
   }
-  if (type == FIRE_BONUS) m_player_status.max_fire_bullets[get_id()]++;
-  if (type == ICE_BONUS) m_player_status.max_ice_bullets[get_id()]++;
-  if (type == AIR_BONUS) m_player_status.max_air_time[get_id()]++;
-  if (type == EARTH_BONUS) m_player_status.max_earth_time[get_id()]++;
+
+  if (increment_powerup_counter)
+  {
+    if (type == FIRE_BONUS) m_player_status.max_fire_bullets[get_id()]++;
+    if (type == ICE_BONUS) m_player_status.max_ice_bullets[get_id()]++;
+    if (type == AIR_BONUS) m_player_status.max_air_time[get_id()]++;
+    if (type == EARTH_BONUS) m_player_status.max_earth_time[get_id()]++;
+  }
 
   if (!m_second_growup_sound_timer.started() &&
      type > GROWUP_BONUS && type != get_bonus())

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -127,7 +127,7 @@ public:
   bool add_bonus(BonusType type, bool animate = false);
 
   /** like add_bonus, but can also downgrade the bonus items carried */
-  bool set_bonus(BonusType type, bool animate = false);
+  bool set_bonus(BonusType type, bool animate = false, bool increment_powerup_counter = true);
   BonusType get_bonus() const;
 
   std::string bonus_to_string() const;

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -128,7 +128,7 @@ GameSession::restart_level(bool after_death, bool preserve_music)
     {
       for (const auto& p : m_currentsector->get_players())
       {
-        p->set_bonus(m_boni_at_start.at(p->get_id()));
+        p->set_bonus(m_boni_at_start.at(p->get_id()), false, false);
         m_boni_at_start[p->get_id()] = currentStatus.bonus[p->get_id()];
       }
     }


### PR DESCRIPTION
This prevents the powerup counter to be incremented unintentionally when the level is restarted for the first time.

Fixes #2295