### PR TITLE
Fix some Tux animation glitches

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -470,7 +470,7 @@ Player::update(float dt_sec)
         adjust_height(BIG_TUX_HEIGHT, 10.f);
         do_duck();
       }
-      else if (!is_big() || m_stone)
+      else if (!is_big() || (m_stone && !m_growing))
       {
         adjust_height(SMALL_TUX_HEIGHT);
       }
@@ -592,8 +592,8 @@ Player::update(float dt_sec)
 
   //End of wallclinging
 
-  // Roll the sprite if Tux is rolling
-  if (m_stone)
+  // Roll the sprite if Tux is rolling (and not growing)
+  if (m_stone && !m_growing)
   {
     float f = 1.f;
 
@@ -713,7 +713,8 @@ Player::update(float dt_sec)
   }
 
   if (m_growing) {
-    if (m_sprite->animation_done()) m_growing = false;
+    if (m_sprite->animation_done())
+      m_growing = false;
   }
 
   // when climbing animate only while moving
@@ -795,19 +796,19 @@ Player::update(float dt_sec)
 
     //if you stop holding down when sliding, then it stops.
     //or, stop sliding if you come to a stop and are not on a slope.
-    if (!m_controller->hold(Control::DOWN) ||
-      (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f))
+    if (!m_controller->hold(Control::DOWN))
     {
-      if (is_big())
-      {
-        if (m_controller->hold(Control::LEFT) || m_controller->hold(Control::RIGHT)) {
-          m_crawl = true;
-        }
-        m_duck = true;
-      }
       m_sliding = false;
       m_slidejumping = false;
-      m_was_crawling_before_slide = false;
+
+      do_standup(false);
+    }
+    else if (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f)
+    {
+      if (is_big() || m_growing)
+          m_crawl = true;
+      m_sliding = false;
+      m_slidejumping = false;
     }
   }
 
@@ -1565,7 +1566,7 @@ Player::handle_input()
   }
 
   /* Turn to Stone */
-  if (m_controller->hold(Control::DOWN) && !m_does_buttjump && m_coyote_timer.started() && !m_swimming && (std::abs(m_physic.get_velocity_x()) > 150.f) && get_bonus() == EARTH_BONUS) {
+  if (m_controller->hold(Control::DOWN) && !m_does_buttjump && m_coyote_timer.started() && !m_swimming && (std::abs(m_physic.get_velocity_x()) > 150.f) && get_bonus() == EARTH_BONUS && !m_growing) {
     m_physic.set_gravity_modifier(1.0f); // Undo jump_early_apex
     adjust_height(TUX_WIDTH);
     m_stone = true;
@@ -1580,11 +1581,11 @@ Player::handle_input()
     apply_friction();
 
   /* Duck or Standup! */
-  if ((m_controller->pressed(Control::DOWN) || ((m_duck || m_wants_buttjump) && m_controller->hold(Control::DOWN))) &&
-    !m_swimming && !m_sliding && !m_stone) {
+  if (((m_controller->pressed(Control::DOWN) && !m_growing && !m_stone) || ((m_duck || m_wants_buttjump || m_crawl) && m_controller->hold(Control::DOWN))) &&
+    !m_swimming && !m_sliding && !m_stone && !m_growing) {
     do_duck();
   }
-  else {
+  else if (!m_sliding && !m_growing) {
     do_standup(false);
   }
 
@@ -1884,7 +1885,7 @@ Player::set_bonus(BonusType type, bool animate, bool increment_powerup_counter)
   }
 
   if ((get_bonus() == NO_BONUS) && (type != NO_BONUS || m_stone)) {
-    if (!m_swimming)
+    if (!m_swimming && !m_sliding)
     {
       if (!adjust_height(BIG_TUX_HEIGHT))
       {
@@ -2070,15 +2071,16 @@ Player::draw(DrawingContext& context)
       m_sprite->set_action(sa_prefix +"-slidejump"+ sa_postfix);
     }
     else {
+      const bool was_growing_before = (m_sprite->get_action().substr(0, 9) == "slidegrow");
       m_sprite->set_action(sa_prefix + "-slide" + sa_postfix);
-      if (m_was_crawling_before_slide)
+      if (m_was_crawling_before_slide || was_growing_before)
       {
-        m_sprite->set_frame(m_sprite->get_frames()); // Skip the "duck" animation when coming from crawling
+        m_sprite->set_frame(m_sprite->get_frames()); // Skip the "duck" animation when coming from crawling or slidegrowing
         m_was_crawling_before_slide = false;
       }
     }
   }
-  else if (m_duck && is_big() && !m_swimming && !m_crawl) {
+  else if (m_duck && is_big() && !m_swimming && !m_crawl && !m_stone) {
     m_sprite->set_action(sa_prefix+"-duck"+sa_postfix);
   }
   else if (m_crawl)


### PR DESCRIPTION
* Wait until the growing animation is finished before changing to stone animation when smallTux gains an earth flower.
* Fix animation glitch from sliding to slidegrow
* Remain in crawling action when down is held and Tux stops sliding due to friction

Fixes #2533