### PR TITLE
Custom layer option for `MovingSprite`

### DIFF
--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -34,7 +34,8 @@ MovingSprite::MovingSprite(const Vector& pos, const std::string& sprite_name_,
   m_sprite(SpriteManager::current()->create(m_sprite_name)),
   m_layer(layer_),
   m_flip(NO_FLIP),
-  m_sprite_found(false)
+  m_sprite_found(false),
+  m_custom_layer(false)
 {
   m_col.m_bbox.set_pos(pos);
   update_hitbox();
@@ -54,7 +55,8 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, const std::string& sprit
   m_sprite(),
   m_layer(layer_),
   m_flip(NO_FLIP),
-  m_sprite_found(false)
+  m_sprite_found(false),
+  m_custom_layer(reader.get("z-pos", m_layer))
 {
   reader.get("x", m_col.m_bbox.get_left());
   reader.get("y", m_col.m_bbox.get_top());
@@ -77,7 +79,8 @@ MovingSprite::MovingSprite(const ReaderMapping& reader, int layer_, CollisionGro
   m_sprite(),
   m_layer(layer_),
   m_flip(NO_FLIP),
-  m_sprite_found(false)
+  m_sprite_found(false),
+  m_custom_layer(reader.get("z-pos", m_layer))
 {
   reader.get("x", m_col.m_bbox.get_left());
   reader.get("y", m_col.m_bbox.get_top());
@@ -103,10 +106,12 @@ MovingSprite::update(float )
 void
 MovingSprite::on_type_change(int old_type)
 {
-  /** Don't change the sprite to the default one for the current type,
-      if this is the initial `on_type_change()` call, and a custom sprite has just been loaded. */
+  /** Don't change the sprite/layer to the default one for the current type,
+      if this is the initial `on_type_change()` call, and a custom sprite/layer has just been loaded. */
   if (old_type >= 0 || !m_sprite_found)
     change_sprite(get_default_sprite_name());
+  if (old_type >= 0 || !m_custom_layer)
+    m_layer = get_layer();
 }
 
 bool
@@ -185,8 +190,9 @@ MovingSprite::get_settings()
   ObjectSettings result = MovingObject::get_settings();
 
   result.add_sprite(_("Sprite"), &m_sprite_name, "sprite", get_default_sprite_name());
+  result.add_int(_("Z-pos"), &m_layer, "z-pos");
 
-  result.reorder({"sprite", "x", "y"});
+  result.reorder({"sprite", "z-pos", "x", "y"});
 
   return result;
 }

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -118,6 +118,9 @@ private:
   /** A custom sprite has been successfully found and set on initialization. */
   bool m_sprite_found;
 
+  /** A custom layer has been specified. */
+  const bool m_custom_layer;
+
 private:
   MovingSprite(const MovingSprite&) = delete;
   MovingSprite& operator=(const MovingSprite&) = delete;


### PR DESCRIPTION
`MovingSprite`s can now have their layer ("Z-pos") changed via an option.

The layer is compatible with object types. Any object, which must have a different layer, based on type, should override `MovingSprite::get_layer()` (the same way it's done with `MovingSprite::get_default_sprite_name()`).