### PR TITLE
Fix cannon sprite bug when direction set to auto (#2811)

### DIFF
--- a/src/badguy/dispenser.cpp
+++ b/src/badguy/dispenser.cpp
@@ -97,8 +97,12 @@ Dispenser::add_object(std::unique_ptr<GameObject> object)
 void
 Dispenser::draw(DrawingContext& context)
 {
-  if (m_type != DispenserType::POINT || Editor::is_active())
+  if (m_type != DispenserType::POINT || Editor::is_active()) {
+    if (m_type == DispenserType::CANNON && m_start_dir == Direction::AUTO) {
+      set_action("center", 1);
+    }
     BadGuy::draw(context);
+  }
 }
 
 void


### PR DESCRIPTION
Fix cannon sprite bug when direction set to auto (#2811)

The sprite is now set to "center" in the draw method (in case the dispenser is a cannon and direction is set to auto). I am not sure if this is the best solution (the draw method is probably called very often, and will slow things down). The code changes were tested both in the level editor and in the game itself, seems working without errors: 
![Screenshot from 2024-03-06 12-17-42](https://github.com/SuperTux/supertux/assets/161934214/cf42cc98-6f6c-4274-ae2f-b4750fb4227b)
