### PR TITLE
Ignore reserved indentifier warnings

### DIFF
--- a/mk/cmake/SuperTux/WarningFlags.cmake
+++ b/mk/cmake/SuperTux/WarningFlags.cmake
@@ -68,6 +68,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         "-Wno-documentation "
         "-Wno-reserved-id-macro "
         "-Wno-sign-conversion "
+        "-Wno-reserved-identifier "
 
         # warnings that should probably be fixed in code
         "-Wno-documentation-unknown-command "

--- a/mk/cmake/SuperTux/WarningFlags.cmake
+++ b/mk/cmake/SuperTux/WarningFlags.cmake
@@ -69,6 +69,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         "-Wno-reserved-id-macro "
         "-Wno-sign-conversion "
         "-Wno-reserved-identifier "
+        "-Wno-unknown-warning-option "
 
         # warnings that should probably be fixed in code
         "-Wno-documentation-unknown-command "


### PR DESCRIPTION
Because the __ function is used everywhere, and apparently this is a reserved identifier, we must add this warning flag.