### PR TITLE
Camera: Customizable peek multiplier

### DIFF
--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -22,6 +22,8 @@
 #include "math/random.hpp"
 #include "math/util.hpp"
 #include "object/player.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "supertux/level.hpp"
 #include "supertux/sector.hpp"
 #include "util/reader_mapping.hpp"
@@ -31,11 +33,6 @@
 
 /* Very small value, used in Camera checks. */
 static const float CAMERA_EPSILON = .00001f;
-
-/* This is the fractional distance toward the peek
-   position to move each frame; lower is slower,
-   0 is never get there, 1 is instant. */
-static const float PEEK_ARRIVE_RATIO = 0.03f;
 
 /**
  * For the multiplayer camera, the camera will ensure all players are visible.
@@ -464,7 +461,7 @@ Camera::update_scroll_normal(float dt_sec)
     else if (player.peeking_direction_y() == Direction::DOWN)
       peek_to_y = top_edge - translation_compensation_y;
 
-    float peek_move_y = (peek_to_y - m_peek_pos.y) * PEEK_ARRIVE_RATIO;
+    float peek_move_y = (peek_to_y - m_peek_pos.y) * g_config->camera_peek_multiplier;
     if (fabsf(peek_move_y) < 1.0f)
       peek_move_y = 0.0;
 
@@ -527,7 +524,7 @@ Camera::update_scroll_normal(float dt_sec)
     else if (player.peeking_direction_x() == Direction::RIGHT)
       peek_to_x = left_edge - translation_compensation_x;
 
-    float peek_move_x = (peek_to_x - m_peek_pos.x) * PEEK_ARRIVE_RATIO;
+    float peek_move_x = (peek_to_x - m_peek_pos.x) * g_config->camera_peek_multiplier;
     if (fabsf(peek_move_x) < 1.0f)
       peek_move_x = 0.0f;
 

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -461,11 +461,8 @@ Camera::update_scroll_normal(float dt_sec)
     else if (player.peeking_direction_y() == Direction::DOWN)
       peek_to_y = top_edge - translation_compensation_y;
 
-    float peek_move_y = (peek_to_y - m_peek_pos.y) * g_config->camera_peek_multiplier;
-    if (fabsf(peek_move_y) < 1.0f)
-      peek_move_y = 0.0;
-
-    m_peek_pos.y += peek_move_y;
+    if (m_translation.y + m_screen_size.height < get_parent()->get_height())
+      m_peek_pos.y += (peek_to_y - m_peek_pos.y) * g_config->camera_peek_multiplier;
 
     m_translation.y -= m_peek_pos.y;
     m_translation.y = math::clamp(m_translation.y,
@@ -524,11 +521,7 @@ Camera::update_scroll_normal(float dt_sec)
     else if (player.peeking_direction_x() == Direction::RIGHT)
       peek_to_x = left_edge - translation_compensation_x;
 
-    float peek_move_x = (peek_to_x - m_peek_pos.x) * g_config->camera_peek_multiplier;
-    if (fabsf(peek_move_x) < 1.0f)
-      peek_move_x = 0.0f;
-
-    m_peek_pos.x += peek_move_x;
+    m_peek_pos.x += (peek_to_x - m_peek_pos.x) * g_config->camera_peek_multiplier;
 
     m_translation.x -= m_peek_pos.x;
     m_translation.x = math::clamp(m_translation.x,

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -19,6 +19,7 @@
 #include <ctime>
 
 #include "editor/overlay_widget.hpp"
+#include "math/util.hpp"
 #include "supertux/colorscheme.hpp"
 #include "util/reader_collection.hpp"
 #include "util/reader_document.hpp"
@@ -55,6 +56,7 @@ Config::Config() :
   show_fps(false),
   show_player_pos(false),
   show_controller(false),
+  camera_peek_multiplier(0.03f),
   sound_enabled(true),
   music_enabled(true),
   sound_volume(100),
@@ -143,6 +145,7 @@ Config::load()
   config_mapping.get("show_fps", show_fps);
   config_mapping.get("show_player_pos", show_player_pos);
   config_mapping.get("show_controller", show_controller);
+  config_mapping.get("camera_peek_multiplier", camera_peek_multiplier);
   config_mapping.get("developer", developer_mode);
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
@@ -342,11 +345,15 @@ Config::load()
       }
     }
   }
+
+  check_values();
 }
 
 void
 Config::save()
 {
+  check_values();
+
   Writer writer("config");
 
   writer.start_list("supertux-config");
@@ -356,6 +363,7 @@ Config::save()
   writer.write("show_fps", show_fps);
   writer.write("show_player_pos", show_player_pos);
   writer.write("show_controller", show_controller);
+  writer.write("camera_peek_multiplier", camera_peek_multiplier);
   writer.write("developer", developer_mode);
   writer.write("confirmation_dialog", confirmation_dialog);
   writer.write("pause_on_focusloss", pause_on_focusloss);
@@ -489,6 +497,12 @@ Config::save()
   writer.end_list("editor");
 
   writer.end_list("supertux-config");
+}
+
+void
+Config::check_values()
+{
+  camera_peek_multiplier = math::clamp(camera_peek_multiplier, 0.f, 1.f);
 }
 
 

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -34,6 +34,9 @@ public:
   void load();
   void save();
 
+  void check_values();
+
+public:
   int profile;
 
   /** the width/height to be used to display the game in fullscreen */
@@ -64,6 +67,7 @@ public:
   bool show_fps;
   bool show_player_pos;
   bool show_controller;
+  float camera_peek_multiplier;
   bool sound_enabled;
   bool music_enabled;
   int sound_volume;

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -19,6 +19,7 @@
 
 #include "audio/sound_manager.hpp"
 #include "gui/dialog.hpp"
+#include "gui/item_floatfield.hpp"
 #include "gui/item_goto.hpp"
 #include "gui/item_stringselect.hpp"
 #include "gui/item_toggle.hpp"
@@ -113,9 +114,11 @@ OptionsMenu::OptionsMenu(Type type, bool complete) :
       add_aspect_ratio();
 #endif
 
+      add_floatfield(_("Camera Peek Multiplier"), &g_config->camera_peek_multiplier)
+        .set_help(_("The fractional distance towards the camera peek position to move each frame.\n\n0 = No Peek, 1 = Instant Peek"));
+
       add_submenu(_("Change Video System"), MenuStorage::MenuId::VIDEO_SYSTEM_MENU)
         .set_help(_("Change video system used to render graphics"));
-
       break;
     }
 
@@ -227,6 +230,7 @@ OptionsMenu::OptionsMenu(Type type, bool complete) :
 
 OptionsMenu::~OptionsMenu()
 {
+  g_config->save();
 }
 
 void


### PR DESCRIPTION
Allows for customizing the fractional distance towards the camera peek position to move each frame, from "Options" -> "Video".

Additionally removes a peek cap, which was the reason peeking caused a slightly offset position on return, the offset being bigger the smaller the peek multiplier is.