### PR TITLE
Small cosmetic wind adjustments

### DIFF
--- a/src/object/sprite_particle.hpp
+++ b/src/object/sprite_particle.hpp
@@ -39,6 +39,8 @@ public:
                  int drawing_layer = LAYER_OBJECTS-1, bool notimeout = false, Color color = Color::WHITE);
   ~SpriteParticle() override;
 
+  SpritePtr& get_sprite() { return sprite; }
+
 protected:
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/sprite_particle.hpp
+++ b/src/object/sprite_particle.hpp
@@ -39,7 +39,7 @@ public:
                  int drawing_layer = LAYER_OBJECTS-1, bool notimeout = false, Color color = Color::WHITE);
   ~SpriteParticle() override;
 
-  SpritePtr& get_sprite() { return sprite; }
+  Sprite& get_sprite() { return *sprite; }
 
 protected:
   virtual void update(float dt_sec) override;

--- a/src/object/wind.cpp
+++ b/src/object/wind.cpp
@@ -111,7 +111,7 @@ Wind::update(float dt_sec_)
     {
       auto& windparticle = Sector::get().add<SpriteParticle>("images/particles/wind.sprite", "default",
         ppos, ANCHOR_MIDDLE, pspeed, Vector(0, 0), get_layer());
-      windparticle.get_sprite()->set_angle(math::degrees(partangle));
+      windparticle.get_sprite().set_angle(math::degrees(partangle));
 	  }
 	  else
     {

--- a/src/object/wind.cpp
+++ b/src/object/wind.cpp
@@ -19,6 +19,7 @@
 #include "badguy/badguy.hpp"
 #include "editor/editor.hpp"
 #include "math/random.hpp"
+#include "math/util.hpp"
 #include "object/particles.hpp"
 #include "object/player.hpp"
 #include "object/rock.hpp"
@@ -96,6 +97,7 @@ Wind::update(float dt_sec_)
 
   if (!blowing) return;
   if (m_col.m_bbox.get_width() <= 16 || m_col.m_bbox.get_height() <= 16) return;
+  float partangle = math::angle(speed);
 
   Vector ppos = Vector(graphicsRandom.randf(m_col.m_bbox.get_left()+8, m_col.m_bbox.get_right()-8), graphicsRandom.randf(m_col.m_bbox.get_top()+8, m_col.m_bbox.get_bottom()-8));
   Vector pspeed = Vector(graphicsRandom.randf(speed.x-20, speed.x+20), graphicsRandom.randf(speed.y-20, speed.y+20));
@@ -107,11 +109,13 @@ Wind::update(float dt_sec_)
     // emit a particle
 	  if (fancy_wind)
     {
-	    Sector::get().add<SpriteParticle>("images/particles/wind.sprite", (std::abs(speed.x) > std::abs(speed.y)) ? "default" : "flip", ppos, ANCHOR_MIDDLE, pspeed, Vector(0, 0), LAYER_BACKGROUNDTILES + 1); 
+      auto& windparticle = Sector::get().add<SpriteParticle>("images/particles/wind.sprite", "default",
+        ppos, ANCHOR_MIDDLE, pspeed, Vector(0, 0), get_layer());
+      windparticle.get_sprite()->set_angle(math::degrees(partangle));
 	  }
 	  else
     {
-	    Sector::get().add<Particles>(ppos, 44, 46, pspeed, Vector(0, 0), 1, Color(.4f, .4f, .4f), 3, .1f, LAYER_BACKGROUNDTILES + 1);
+	    Sector::get().add<Particles>(ppos, 44, 46, pspeed, Vector(0, 0), 1, Color(.4f, .4f, .4f), 3, .1f, get_layer());
 	  }
   }
 }
@@ -121,7 +125,7 @@ Wind::draw(DrawingContext& context)
 {
   if (Editor::is_active()) {
     context.color().draw_filled_rect(m_col.m_bbox, Color(0.0f, 1.0f, 1.0f, 0.6f),
-                             0.0f, LAYER_OBJECTS);
+                             0.0f, get_layer());
   }
 }
 

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -45,7 +45,7 @@ public:
 
   virtual ObjectSettings get_settings() override;
 
-  virtual int get_layer() const override { return LAYER_OBJECTS; }
+  virtual int get_layer() const override { return LAYER_BACKGROUNDTILES + 1; }
 
   virtual void on_flip(float height) override;
 


### PR DESCRIPTION
This PR makes the wind particles point in the proper direction now, as well as putting wind on a layer behind others so that you can actually grab other objects in the editor when there's wind in the level.