### PR TITLE
Fix sliding player clipping through floor

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -793,13 +793,8 @@ Player::update(float dt_sec)
 
     //if you stop holding down when sliding, then it stops.
     //or, stop sliding if you come to a stop and are not on a slope.
-    if (!m_controller->hold(Control::DOWN))
-    {
-      m_sliding = false;
-      m_was_crawling_before_slide = false;
-      m_slidejumping = false;
-    }
-    else if (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f)
+
+    if (!m_controller->hold(Control::DOWN) || (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f))
     {
       if (is_big())
       {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -793,8 +793,8 @@ Player::update(float dt_sec)
 
     //if you stop holding down when sliding, then it stops.
     //or, stop sliding if you come to a stop and are not on a slope.
-
-    if (!m_controller->hold(Control::DOWN) || (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f))
+    if (!m_controller->hold(Control::DOWN) ||
+      (m_floor_normal.y == 0.f && std::abs(m_physic.get_velocity_x()) <= 1.f))
     {
       if (is_big())
       {


### PR DESCRIPTION
For whatever reason that is beyond me, the PR #2795 appears to have intentionally introduced a bug where Tux would clip through the floor if he stopped sliding but was still moving (meaning, the player stopped pressing the down key).  In areas where Tux ended sliding in a 1-block hole, he would clip into the floor.  This clipping was also noticeable under normally-tall terrain gaps, but it resolves itself immediately.  However, this PR fixes it.  Let me know if there are any issues or side effects with it.  