### PR TITLE
Door and teleport improvements

### DIFF
--- a/data/scripts/default.nut
+++ b/data/scripts/default.nut
@@ -8,6 +8,7 @@ Level <- {
   finish=Level_finish,
   has_active_sequence=Level_has_active_sequence,
   spawn=Level_spawn,
+  spawn_transition=Level_spawn_transition,
   set_start_point=Level_set_start_point,
   set_start_pos=Level_set_start_pos,
   set_respawn_point=Level_set_respawn_point,

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -108,6 +108,8 @@ public:
 
   void set_mode(Mode mode_) { m_mode = mode_; }
 
+  Mode get_mode() const { return m_mode; }
+
   /** get the exact scale at this exact moment */
   float get_current_scale() const { return m_enfore_minimum_scale ? std::min(m_minimum_scale, m_scale) : m_scale; }
 

--- a/src/object/infoblock.cpp
+++ b/src/object/infoblock.cpp
@@ -204,12 +204,12 @@ InfoBlock::draw(DrawingContext& context)
   context.color().draw_filled_rect(Rectf(Vector(m_fadetransition ? x1 - border : growposx,
     m_fadetransition ? y1 - border : growposy),
     Sizef(width + 2 * border, height + 2 * border - 4) * (m_fadetransition ? 1.f : m_shown_pct)),
-    m_frontcolor, m_roundness, LAYER_GUI - 50);
+    m_frontcolor, m_roundness, LAYER_FOREGROUND1 - 1);
 
   context.color().draw_filled_rect(Rectf(Vector((m_fadetransition ? x1 - border : growposx) - 4.f,
     (m_fadetransition ? y1 - border : growposy) - 4.f),
     Sizef(8.f, 8.f) + (Sizef((width + 2 * border), (height + 2 * border - 4)) * (m_fadetransition ? 1.f : m_shown_pct))),
-    m_backcolor, m_roundness + 4.f, LAYER_GUI - 51);
+    m_backcolor, m_roundness + 4.f, LAYER_FOREGROUND1 - 2);
 
   float y = y1;
   for (size_t i = 0; i < m_lines.size(); ++i) {
@@ -222,7 +222,7 @@ InfoBlock::draw(DrawingContext& context)
 
     if (m_fadetransition || m_shown_pct >= 1.f)
     {
-      m_lines[i]->draw(context, Rectf(x1, y, x2, y), LAYER_GUI - 50 + 1);
+      m_lines[i]->draw(context, Rectf(x1, y, x2, y), LAYER_FOREGROUND1);
       y += m_lines[i]->get_height();
     }
   }

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -203,6 +203,7 @@ Player::Player(PlayerStatus& player_status, const std::string& name_, int player
   m_invincible_timer(),
   m_skidding_timer(),
   m_safe_timer(),
+  m_is_intentionally_safe(false),
   m_kick_timer(),
   m_buttjump_timer(),
   m_dying_timer(),
@@ -2205,7 +2206,7 @@ Player::draw(DrawingContext& context)
   */
 
   /* Draw Tux */
-  if (!m_visible || (m_safe_timer.started() && m_safe_due_to_hurt && size_t(g_game_time * 40) % 2))
+  if (!m_visible || (m_safe_timer.started() && !m_is_intentionally_safe && size_t(g_game_time * 40) % 2))
   {
   }  // don't draw Tux
 
@@ -2378,7 +2379,7 @@ void
 Player::make_temporarily_safe(const float safe_time)
 {
   m_safe_timer.start(safe_time);
-  m_safe_due_to_hurt = false;
+  m_is_intentionally_safe = true;
 }
 
 void
@@ -2408,11 +2409,11 @@ Player::kill(bool completely)
       || get_bonus() == AIR_BONUS
       || get_bonus() == EARTH_BONUS) {
       m_safe_timer.start(TUX_SAFE_TIME);
-      m_safe_due_to_hurt = true;
+      m_is_intentionally_safe = false;
       set_bonus(GROWUP_BONUS, true);
     } else if (get_bonus() == GROWUP_BONUS) {
       m_safe_timer.start(TUX_SAFE_TIME /* + GROWING_TIME */);
-      m_safe_due_to_hurt = true;
+      m_is_intentionally_safe = false;
       m_duck = false;
       stop_backflipping();
       set_bonus(NO_BONUS, true);
@@ -2511,7 +2512,9 @@ Player::check_bounds()
   }
 
   /* fallen out of the level? */
-  if ((get_pos().y > Sector::get().get_height()) && (!m_ghost_mode)) {
+  if ((get_pos().y > Sector::get().get_height())
+      && (!m_ghost_mode)
+      && !(m_is_intentionally_safe && m_safe_timer.started())) {
     kill(true);
     return;
   }

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2375,9 +2375,9 @@ Player::make_invincible()
 }
 
 void
-Player::make_temporarily_safe()
+Player::make_temporarily_safe(const float safe_time)
 {
-  m_safe_timer.start(TUX_SAFE_TIME);
+  m_safe_timer.start(safe_time);
   m_safe_due_to_hurt = false;
 }
 

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2205,7 +2205,7 @@ Player::draw(DrawingContext& context)
   */
 
   /* Draw Tux */
-  if (!m_visible || (m_safe_timer.started() && size_t(g_game_time * 40) % 2))
+  if (!m_visible || (m_safe_timer.started() && m_safe_due_to_hurt && size_t(g_game_time * 40) % 2))
   {
   }  // don't draw Tux
 
@@ -2375,6 +2375,13 @@ Player::make_invincible()
 }
 
 void
+Player::make_temporarily_safe()
+{
+  m_safe_timer.start(TUX_SAFE_TIME);
+  m_safe_due_to_hurt = false;
+}
+
+void
 Player::kill(bool completely)
 {
   if (m_dying || m_deactivated || is_winning() )
@@ -2401,9 +2408,11 @@ Player::kill(bool completely)
       || get_bonus() == AIR_BONUS
       || get_bonus() == EARTH_BONUS) {
       m_safe_timer.start(TUX_SAFE_TIME);
+      m_safe_due_to_hurt = true;
       set_bonus(GROWUP_BONUS, true);
     } else if (get_bonus() == GROWUP_BONUS) {
       m_safe_timer.start(TUX_SAFE_TIME /* + GROWING_TIME */);
+      m_safe_due_to_hurt = true;
       m_duck = false;
       stop_backflipping();
       set_bonus(NO_BONUS, true);

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2376,7 +2376,7 @@ Player::make_invincible()
 }
 
 void
-Player::make_temporarily_safe(const float safe_time)
+Player::make_temporarily_safe(float safe_time)
 {
   m_safe_timer.start(safe_time);
   m_is_intentionally_safe = true;
@@ -2513,7 +2513,7 @@ Player::check_bounds()
 
   /* fallen out of the level? */
   if ((get_pos().y > Sector::get().get_height())
-      && (!m_ghost_mode)
+      && !m_ghost_mode
       && !(m_is_intentionally_safe && m_safe_timer.started())) {
     kill(true);
     return;

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -105,6 +105,7 @@ public:
   void move_to_sector(Sector& other);
 
   void make_invincible();
+  void make_temporarily_safe();
 
   bool is_invincible() const { return m_invincible_timer.started(); }
   bool is_dying() const { return m_dying; }
@@ -354,6 +355,7 @@ public:
 private:
   Timer m_skidding_timer;
   Timer m_safe_timer;
+  bool m_safe_due_to_hurt;
   Timer m_kick_timer;
   Timer m_buttjump_timer;
 

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -105,7 +105,7 @@ public:
   void move_to_sector(Sector& other);
 
   void make_invincible();
-  void make_temporarily_safe();
+  void make_temporarily_safe(const float safe_time);
 
   bool is_invincible() const { return m_invincible_timer.started(); }
   bool is_dying() const { return m_dying; }

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -105,7 +105,7 @@ public:
   void move_to_sector(Sector& other);
 
   void make_invincible();
-  void make_temporarily_safe(const float safe_time);
+  void make_temporarily_safe(float safe_time);
 
   bool is_invincible() const { return m_invincible_timer.started(); }
   bool is_dying() const { return m_dying; }

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -355,7 +355,7 @@ public:
 private:
   Timer m_skidding_timer;
   Timer m_safe_timer;
-  bool m_safe_due_to_hurt;
+  bool m_is_intentionally_safe;
   Timer m_kick_timer;
   Timer m_buttjump_timer;
 

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -57,7 +57,7 @@ Level_spawn_transition(const std::string& sector, const std::string& spawnpoint,
   else if (transition == "circle")
     fade_type = ScreenFade::FadeType::CIRCLE;
 
-  game_session.respawn_with_fade(sector, spawnpoint, fade_type, {0.0f, 0.0f});
+  game_session.respawn_with_fade(sector, spawnpoint, fade_type, {0.0f, 0.0f}, true);
 }
 
 void

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -16,12 +16,10 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "scripting/level.hpp"
-
 #include "supertux/d_scope.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/sector.hpp"
-
 #include "util/log.hpp"
 
 namespace scripting {

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -22,6 +22,8 @@
 #include "supertux/game_session.hpp"
 #include "supertux/sector.hpp"
 
+#include "util/log.hpp"
+
 namespace scripting {
 
 void
@@ -56,6 +58,8 @@ Level_spawn_transition(const std::string& sector, const std::string& spawnpoint,
     fade_type = ScreenFade::FadeType::FADE;
   else if (transition == "circle")
     fade_type = ScreenFade::FadeType::CIRCLE;
+  else
+    log_warning << "Invalid transition type '" << transition << "'." << std::endl;
 
   game_session.respawn_with_fade(sector, spawnpoint, fade_type, {0.0f, 0.0f}, true);
 }

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -46,6 +46,21 @@ Level_spawn(const std::string& sector, const std::string& spawnpoint)
 }
 
 void
+Level_spawn_transition(const std::string& sector, const std::string& spawnpoint, const std::string& transition)
+{
+  SCRIPT_GUARD_GAMESESSION();
+
+  GameSession::FadeType fade_type = GameSession::FadeType::NONE;
+
+  if (transition == "fade")
+    fade_type = GameSession::FadeType::FADE;
+  else if (transition == "circle")
+    fade_type = GameSession::FadeType::CIRCLE;
+
+  game_session.respawn_with_fade(sector, spawnpoint, fade_type, {0.0f, 0.0f});
+}
+
+void
 Level_set_start_point(const std::string& sector, const std::string& spawnpoint)
 {
   SCRIPT_GUARD_GAMESESSION();

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -16,6 +16,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "scripting/level.hpp"
+
 #include "supertux/d_scope.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/game_session.hpp"

--- a/src/scripting/level.cpp
+++ b/src/scripting/level.cpp
@@ -50,12 +50,12 @@ Level_spawn_transition(const std::string& sector, const std::string& spawnpoint,
 {
   SCRIPT_GUARD_GAMESESSION();
 
-  GameSession::FadeType fade_type = GameSession::FadeType::NONE;
+  ScreenFade::FadeType fade_type = ScreenFade::FadeType::NONE;
 
   if (transition == "fade")
-    fade_type = GameSession::FadeType::FADE;
+    fade_type = ScreenFade::FadeType::FADE;
   else if (transition == "circle")
-    fade_type = GameSession::FadeType::CIRCLE;
+    fade_type = ScreenFade::FadeType::CIRCLE;
 
   game_session.respawn_with_fade(sector, spawnpoint, fade_type, {0.0f, 0.0f});
 }

--- a/src/scripting/level.hpp
+++ b/src/scripting/level.hpp
@@ -66,6 +66,19 @@ bool Level_has_active_sequence();
  */
 void Level_spawn(const std::string& sector, const std::string& spawnpoint);
 
+
+/**
+ * Respawns Tux in sector named ""sector"" at spawnpoint named ""spawnpoint"" with the given transition ""transition"".${SRG_TABLENEWPARAGRAPH}
+   Exceptions: If ""sector"" or ""spawnpoint"" are empty, or the specified sector does not exist, the function will bail out the first chance it gets.
+   If the specified spawnpoint doesn't exist, Tux will be spawned at the spawnpoint named “main”.
+   If that spawnpoint doesn't exist either, Tux will simply end up at the origin (top-left 0, 0).
+ * @param string $sector
+ * @param string $spawnpoint
+ * @param string $transition
+ */
+void Level_spawn_transition(const std::string& sector, const std::string& spawnpoint, const std::string& transition);
+
+
 /**
  * Sets the default start spawnpoint of the level.
  * @param string $sector

--- a/src/scripting/level.hpp
+++ b/src/scripting/level.hpp
@@ -74,7 +74,7 @@ void Level_spawn(const std::string& sector, const std::string& spawnpoint);
    If that spawnpoint doesn't exist either, Tux will simply end up at the origin (top-left 0, 0).
  * @param string $sector
  * @param string $spawnpoint
- * @param string $transition
+ * @param string $transition Valid transitions are ""circle"" and ""fade"". If any other value is specified, no transition effect is drawn.
  */
 void Level_spawn_transition(const std::string& sector, const std::string& spawnpoint, const std::string& transition);
 

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -13066,6 +13066,40 @@ static SQInteger Level_spawn_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Level_spawn_transition_wrapper(HSQUIRRELVM vm)
+{
+  const SQChar* arg0;
+  if(SQ_FAILED(sq_getstring(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a string"));
+    return SQ_ERROR;
+  }
+  const SQChar* arg1;
+  if(SQ_FAILED(sq_getstring(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a string"));
+    return SQ_ERROR;
+  }
+
+  const SQChar* arg2;
+  if(SQ_FAILED(sq_getstring(vm, 4, &arg2))) {
+    sq_throwerror(vm, _SC("Argument 3 not a string"));
+    return SQ_ERROR;
+  }
+
+  try {
+    scripting::Level_spawn_transition(arg0, arg1, arg2);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'Level_spawn_transition'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Level_set_start_point_wrapper(HSQUIRRELVM vm)
 {
   const SQChar* arg0;
@@ -14515,6 +14549,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".ss");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'Level_spawn'");
+  }
+
+  sq_pushstring(v, "Level_spawn_transition", -1);
+  sq_newclosure(v, &Level_spawn_transition_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".sss");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'Level_spawn_transition'");
   }
 
   sq_pushstring(v, "Level_set_start_point", -1);

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -49,6 +49,7 @@
 #include "worldmap/worldmap.hpp"
 
 static const float FADE_TIME = 1.0f;
+static const float SAFE_TIME = 1.0f;
 
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics,
                          bool preserve_music) :
@@ -539,7 +540,7 @@ GameSession::update(float dt_sec, const Controller& controller)
       for (auto* p : m_currentsector->get_players())
       {
         // Make all players temporarily safe after spawning
-        p->make_temporarily_safe();
+        p->make_temporarily_safe(SAFE_TIME);
       }
     }
 

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -50,6 +50,8 @@
 
 static const float SAFE_TIME = 1.0f;
 static const int SHRINKFADE_LAYER = LAYER_LIGHTMAP - 1;
+static const float TELEPORT_FADE_TIME = 1.0f;
+
 
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics,
                          bool preserve_music) :

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -67,7 +67,7 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_activated_checkpoint(),
   m_newsector(),
   m_newspawnpoint(),
-  m_spawn_fade_type(FadeType::NONE),
+  m_spawn_fade_type(ScreenFade::FadeType::NONE),
   m_spawn_fade_point(0.0f, 0.0f),
   m_spawn_fade_timer(),
   m_spawn_with_invincibilty(false),
@@ -496,7 +496,7 @@ GameSession::update(float dt_sec, const Controller& controller)
   check_end_conditions();
 
   // Respawning in new sector?
-  if (!m_newsector.empty() && !m_newspawnpoint.empty() && (m_spawn_fade_timer.check() || m_spawn_fade_type == FadeType::NONE)) {
+  if (!m_newsector.empty() && !m_newspawnpoint.empty() && (m_spawn_fade_timer.check() || m_spawn_fade_type == ScreenFade::FadeType::NONE)) {
     auto sector = m_level->get_sector(m_newsector);
     std::string current_music = m_currentsector->get_singleton_by_type<MusicObject>().get_music();
     if (sector == nullptr) {
@@ -517,22 +517,21 @@ GameSession::update(float dt_sec, const Controller& controller)
 
     switch (m_spawn_fade_type)
     {
-    case FadeType::FADE:
-    {
-      ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEIN, FADE_TIME));
-      break;
-    }
-    case FadeType::CIRCLE:
-    {
-      const Vector spawn_point_position = sector->get_spawn_point_position(m_newspawnpoint);
-      const Vector shrinkpos = spawn_point_position - sector->get_camera().get_translation();
+      case ScreenFade::FadeType::FADE:
+      {
+        ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEIN, FADE_TIME));
+        break;
+      }
+      case ScreenFade::FadeType::CIRCLE:
+      {
+        const Vector spawn_point_position = sector->get_spawn_point_position(m_newspawnpoint);
+        const Vector shrinkpos = spawn_point_position - sector->get_camera().get_translation();
 
-      ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, FADE_TIME, ShrinkFade::FADEIN));
-      break;
-    }
-    case FadeType::NONE:
-    default:
-      break;
+        ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, FADE_TIME, ShrinkFade::FADEIN));
+        break;
+      }
+      default:
+        break;
     }
 
     if (m_spawn_with_invincibilty)
@@ -669,8 +668,8 @@ GameSession::respawn(const std::string& sector, const std::string& spawnpoint)
 void
 GameSession::respawn_with_fade(const std::string& sector,
                                const std::string& spawnpoint,
-                               const FadeType fade_type,
-                               const Vector fade_point,
+                               const ScreenFade::FadeType fade_type,
+                               const Vector& fade_point,
                                const bool make_invincible)
 {
   respawn(sector, spawnpoint);
@@ -683,22 +682,21 @@ GameSession::respawn_with_fade(const std::string& sector,
 
   switch (m_spawn_fade_type)
   {
-  case FadeType::FADE:
-  {
-    ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, FADE_TIME));
-    break;
-  }
-  case FadeType::CIRCLE:
-  {
-    const bool is_fade_point_valid = fade_point.x != 0.0f && fade_point.y != 0.0f;
-    const Vector shrinkpos = (is_fade_point_valid ? fade_point : get_fade_point()) - Sector::current()->get_camera().get_translation();
+    case ScreenFade::FadeType::FADE:
+    {
+      ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, FADE_TIME));
+      break;
+    }
+    case ScreenFade::FadeType::CIRCLE:
+    {
+      const bool is_fade_point_valid = fade_point.x != 0.0f && fade_point.y != 0.0f;
+      const Vector shrinkpos = (is_fade_point_valid ? fade_point : get_fade_point()) - Sector::current()->get_camera().get_translation();
 
-    ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, FADE_TIME, ShrinkFade::FADEOUT));
-    break;
-  }
-  case FadeType::NONE:
-  default:
-    break;
+      ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, FADE_TIME, ShrinkFade::FADEOUT));
+      break;
+    }
+    default:
+      break;
   }
 
 }

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -301,7 +301,7 @@ GameSession::on_escape_press(bool force_quick_respawn)
 Vector
 GameSession::get_fade_point() const
 {
-  if (m_level->m_is_in_cutscene)
+  if (m_level->m_is_in_cutscene || m_currentsector->get_camera().get_mode() == Camera::Mode::MANUAL)
   {
     return m_currentsector->get_camera().get_center();
   }

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -301,18 +301,32 @@ GameSession::on_escape_press(bool force_quick_respawn)
 Vector
 GameSession::get_fade_point() const
 {
-  // Get first player that is alive
-  // Should work for single player without problems,
-  // but for multiplayer a proper handling needs to be done
-  for (const auto& player : m_currentsector->get_players())
+  if (m_level->m_is_in_cutscene)
   {
-    if (!player->is_dead() && !player->is_dying())
+    return m_currentsector->get_camera().get_center();
+  }
+  else
+  {
+    // Get "middle" of all alive players
+    Vector position(0.0f, 0.0f);
+    size_t alive_players = 0U;
+
+    for (const auto* player : m_currentsector->get_players())
     {
-      return player->get_bbox().get_middle();
+      if (!player->is_dead() && !player->is_dying())
+      {
+        position += player->get_bbox().get_middle();
+        alive_players++;
+      }
+    }
+
+    if (alive_players > 0U)
+    {
+      return position / alive_players;
     }
   }
 
-  return Vector(0.0f, 0.f);
+  return m_currentsector->get_camera().get_center();
 }
 
 void

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -32,7 +32,6 @@
 #include "object/spawnpoint.hpp"
 #include "sdk/integration.hpp"
 #include "supertux/fadetoblack.hpp"
-#include "supertux/shrinkfade.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/level.hpp"
 #include "supertux/level_parser.hpp"
@@ -42,6 +41,7 @@
 #include "supertux/savegame.hpp"
 #include "supertux/screen_manager.hpp"
 #include "supertux/sector.hpp"
+#include "supertux/shrinkfade.hpp"
 #include "util/file_system.hpp"
 #include "video/compositor.hpp"
 #include "video/drawing_context.hpp"
@@ -70,7 +70,7 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_spawn_fade_type(ScreenFade::FadeType::NONE),
   m_spawn_fade_point(0.0f, 0.0f),
   m_spawn_fade_timer(),
-  m_spawn_with_invincibilty(false),
+  m_spawn_with_invincibility(false),
   m_best_level_statistics(statistics),
   m_savegame(savegame),
   m_play_time(0),
@@ -118,7 +118,7 @@ GameSession::reset_level()
   clear_respawn_points();
   m_activated_checkpoint = nullptr;
   m_pause_target_timer = false;
-  m_spawn_with_invincibilty = false;
+  m_spawn_with_invincibility = false;
 }
 
 int
@@ -149,7 +149,7 @@ GameSession::restart_level(bool after_death, bool preserve_music)
   m_game_pause   = false;
   m_end_sequence = nullptr;
   m_endsequence_timer.stop();
-  m_spawn_with_invincibilty = false;
+  m_spawn_with_invincibility = false;
 
   InputManager::current()->reset();
 
@@ -294,7 +294,7 @@ GameSession::on_escape_press(bool force_quick_respawn)
   if (!m_level->m_suppress_pause_menu) {
     toggle_pause();
   } else {
-	  abort_level();
+    abort_level();
   }
 }
 
@@ -345,9 +345,9 @@ GameSession::get_fade_point(const Vector& position) const
     }
   }
 
-  fade_point = (fade_point - m_currentsector->get_camera().get_translation()) * m_currentsector->get_camera().get_current_scale();
+  const Camera& camera = m_currentsector->get_camera();
 
-  return fade_point;
+  return (fade_point - camera.get_translation()) * camera.get_current_scale();
 }
 
 void
@@ -575,7 +575,7 @@ GameSession::update(float dt_sec, const Controller& controller)
       // Give back control to the player
       p->activate();
 
-      if (m_spawn_with_invincibilty)
+      if (m_spawn_with_invincibility)
       {
         // Make all players temporarily safe after spawning
         p->make_temporarily_safe(SAFE_TIME);
@@ -701,7 +701,7 @@ GameSession::respawn(const std::string& sector, const std::string& spawnpoint)
 {
   m_newsector = sector;
   m_newspawnpoint = spawnpoint;
-  m_spawn_with_invincibilty = false;
+  m_spawn_with_invincibility = false;
 }
 
 void
@@ -715,7 +715,7 @@ GameSession::respawn_with_fade(const std::string& sector,
 
   m_spawn_fade_type = fade_type;
   m_spawn_fade_point = fade_point;
-  m_spawn_with_invincibilty = make_invincible;
+  m_spawn_with_invincibility = make_invincible;
 
   bool transition_takes_time = false;
 
@@ -921,7 +921,7 @@ GameSession::start_sequence(Player* caller, Sequence seq, const SequenceData* da
     lt.stop();
   }
 }
-void 
+void
 GameSession::set_target_timer_paused(bool paused)
 {
   m_pause_target_timer = paused;

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -49,6 +49,7 @@
 #include "worldmap/worldmap.hpp"
 
 static const float SAFE_TIME = 1.0f;
+static const int SHRINKFADE_LAYER = LAYER_LIGHTMAP - 1;
 
 GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics,
                          bool preserve_music) :
@@ -68,7 +69,6 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_newsector(),
   m_newspawnpoint(),
   m_spawn_fade_type(ScreenFade::FadeType::NONE),
-  m_spawn_fade_point(0.0f, 0.0f),
   m_spawn_fade_timer(),
   m_spawn_with_invincibility(false),
   m_best_level_statistics(statistics),
@@ -226,7 +226,7 @@ GameSession::restart_level(bool after_death, bool preserve_music)
   if (m_levelintro_shown)
   {
     const Vector shrinkpos = get_fade_point();
-    ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, ShrinkFade::FADEIN));
+    ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, SHRINKFADE_LAYER,  ShrinkFade::FADEIN));
   }
 
   if (!preserve_music)
@@ -466,7 +466,7 @@ GameSession::setup()
   else
   {
     const Vector shrinkpos = get_fade_point();
-    ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, ShrinkFade::FADEIN));
+    ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, SHRINKFADE_LAYER, ShrinkFade::FADEIN));
   }
 
 
@@ -562,7 +562,7 @@ GameSession::update(float dt_sec, const Controller& controller)
         const Vector spawn_point_position = sector->get_spawn_point_position(m_newspawnpoint);
         const Vector shrinkpos = get_fade_point(spawn_point_position);
 
-        ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, ShrinkFade::FADEIN));
+        ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, SHRINKFADE_LAYER, ShrinkFade::FADEIN));
         break;
       }
       default:
@@ -714,7 +714,6 @@ GameSession::respawn_with_fade(const std::string& sector,
   respawn(sector, spawnpoint);
 
   m_spawn_fade_type = fade_type;
-  m_spawn_fade_point = fade_point;
   m_spawn_with_invincibility = make_invincible;
 
   bool transition_takes_time = false;
@@ -730,7 +729,7 @@ GameSession::respawn_with_fade(const std::string& sector,
     case ScreenFade::FadeType::CIRCLE:
     {
       const Vector shrinkpos = get_fade_point(fade_point);
-      ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, ShrinkFade::FADEOUT));
+      ScreenManager::current()->set_screen_fade(std::make_unique<ShrinkFade>(shrinkpos, TELEPORT_FADE_TIME, SHRINKFADE_LAYER, ShrinkFade::FADEOUT));
       transition_takes_time = true;
       break;
     }

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -142,6 +142,7 @@ private:
   void on_escape_press(bool force_quick_respawn);
 
   Vector get_fade_point() const;
+  Vector get_fade_point(const Vector& position) const;
 
 public:
   bool reset_button;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -76,6 +76,13 @@ private:
   };
 
 public:
+  enum class FadeType
+  {
+    NONE,
+    FADE,
+    CIRCLE
+  };
+
   GameSession(const std::string& levelfile, Savegame& savegame, Statistics* statistics = nullptr,
               bool preserve_music = false);
 
@@ -88,6 +95,7 @@ public:
   /** ends the current level */
   void finish(bool win = true);
   void respawn(const std::string& sectorname, const std::string& spawnpointname);
+  void respawn_with_fade(const std::string& sectorname, const std::string& spawnpointname, const FadeType fade_type, const Vector fade_point);
   void reset_level();
 
   void set_start_point(const std::string& sectorname,
@@ -135,6 +143,8 @@ private:
 
   void on_escape_press(bool force_quick_respawn);
 
+  Vector get_fade_point() const;
+
 public:
   bool reset_button;
   bool reset_checkpoint_button;
@@ -164,6 +174,9 @@ private:
   // the sector and spawnpoint we should spawn after this frame
   std::string m_newsector;
   std::string m_newspawnpoint;
+  FadeType m_spawn_fade_type;
+  Vector m_spawn_fade_point;
+  Timer m_spawn_fade_timer;
 
   Statistics* m_best_level_statistics;
   Savegame& m_savegame;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -31,10 +31,10 @@
 #include "squirrel/squirrel_util.hpp"
 #include "supertux/game_object.hpp"
 #include "supertux/player_status.hpp"
+#include "supertux/screen_fade.hpp"
 #include "supertux/sequence.hpp"
 #include "supertux/timer.hpp"
 #include "video/surface_ptr.hpp"
-#include "supertux/screen_fade.hpp"
 
 class CodeController;
 class DrawingContext;
@@ -178,7 +178,7 @@ private:
   ScreenFade::FadeType m_spawn_fade_type;
   Vector m_spawn_fade_point;
   Timer m_spawn_fade_timer;
-  bool m_spawn_with_invincibilty;
+  bool m_spawn_with_invincibility;
 
   Statistics* m_best_level_statistics;
   Savegame& m_savegame;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -150,8 +150,6 @@ public:
 
   bool m_prevent_death; /**< true if players should enter ghost mode instead of dying */
 
-  static constexpr float TELEPORT_FADE_TIME = 1.0f; /**< Duration of teleport fade animation */
-
 private:
   std::unique_ptr<Level> m_level;
   SurfacePtr m_statistics_backdrop;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -95,7 +95,11 @@ public:
   /** ends the current level */
   void finish(bool win = true);
   void respawn(const std::string& sectorname, const std::string& spawnpointname);
-  void respawn_with_fade(const std::string& sectorname, const std::string& spawnpointname, const FadeType fade_type, const Vector fade_point);
+  void respawn_with_fade(const std::string& sectorname,
+                         const std::string& spawnpointname,
+                         const FadeType fade_type,
+                         const Vector fade_point,
+                         const bool make_invincible = false);
   void reset_level();
 
   void set_start_point(const std::string& sectorname,
@@ -177,6 +181,7 @@ private:
   FadeType m_spawn_fade_type;
   Vector m_spawn_fade_point;
   Timer m_spawn_fade_timer;
+  bool m_spawn_with_invincibilty;
 
   Statistics* m_best_level_statistics;
   Savegame& m_savegame;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -149,6 +149,8 @@ public:
 
   bool m_prevent_death; /**< true if players should enter ghost mode instead of dying */
 
+  static constexpr float TELEPORT_FADE_TIME = 1.0f; /**< Duration of teleport fade animation */
+
 private:
   std::unique_ptr<Level> m_level;
   SurfacePtr m_statistics_backdrop;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -34,6 +34,7 @@
 #include "supertux/sequence.hpp"
 #include "supertux/timer.hpp"
 #include "video/surface_ptr.hpp"
+#include "supertux/screen_fade.hpp"
 
 class CodeController;
 class DrawingContext;
@@ -76,13 +77,6 @@ private:
   };
 
 public:
-  enum class FadeType
-  {
-    NONE,
-    FADE,
-    CIRCLE
-  };
-
   GameSession(const std::string& levelfile, Savegame& savegame, Statistics* statistics = nullptr,
               bool preserve_music = false);
 
@@ -97,8 +91,8 @@ public:
   void respawn(const std::string& sectorname, const std::string& spawnpointname);
   void respawn_with_fade(const std::string& sectorname,
                          const std::string& spawnpointname,
-                         const FadeType fade_type,
-                         const Vector fade_point,
+                         const ScreenFade::FadeType fade_type,
+                         const Vector &fade_point,
                          const bool make_invincible = false);
   void reset_level();
 
@@ -178,7 +172,7 @@ private:
   // the sector and spawnpoint we should spawn after this frame
   std::string m_newsector;
   std::string m_newspawnpoint;
-  FadeType m_spawn_fade_type;
+  ScreenFade::FadeType m_spawn_fade_type;
   Vector m_spawn_fade_point;
   Timer m_spawn_fade_timer;
   bool m_spawn_with_invincibilty;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -176,7 +176,6 @@ private:
   std::string m_newsector;
   std::string m_newspawnpoint;
   ScreenFade::FadeType m_spawn_fade_type;
-  Vector m_spawn_fade_point;
   Timer m_spawn_fade_timer;
   bool m_spawn_with_invincibility;
 

--- a/src/supertux/screen_fade.hpp
+++ b/src/supertux/screen_fade.hpp
@@ -27,6 +27,13 @@ class DrawingContext;
 class ScreenFade
 {
 public:
+  enum class FadeType
+  {
+    NONE,
+    FADE,
+    CIRCLE
+  };
+
   virtual ~ScreenFade() {}
 
   /** returns true if the effect is completed */

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -159,10 +159,7 @@ ScreenManager::push_screen(std::unique_ptr<Screen> screen, std::unique_ptr<Scree
 {
   log_debug << "ScreenManager::push_screen(): " << screen.get() << std::endl;
   assert(screen);
-  if (g_config->transitions_enabled)
-  {
-    m_screen_fade = std::move(screen_fade);
-  }
+  set_screen_fade(std::move(screen_fade));
   m_actions.emplace_back(Action::PUSH_ACTION, std::move(screen));
 }
 
@@ -170,10 +167,7 @@ void
 ScreenManager::pop_screen(std::unique_ptr<ScreenFade> screen_fade)
 {
   log_debug << "ScreenManager::pop_screen(): stack_size: " << m_screen_stack.size() << std::endl;
-  if (g_config->transitions_enabled)
-  {
-    m_screen_fade = std::move(screen_fade);
-  }
+  set_screen_fade(std::move(screen_fade));
   m_actions.emplace_back(Action::POP_ACTION);
 }
 
@@ -195,10 +189,7 @@ ScreenManager::quit(std::unique_ptr<ScreenFade> screen_fade)
   g_config->save();
 #endif
 
-  if (g_config->transitions_enabled)
-  {
-    m_screen_fade = std::move(screen_fade);
-  }
+  set_screen_fade(std::move(screen_fade));
   m_actions.emplace_back(Action::QUIT_ACTION);
 }
 

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -182,7 +182,6 @@ Sector::get_spawn_point(const std::string& spawnpoint)
   return sp;
 }
 
-
 Vector
 Sector::get_spawn_point_position(const std::string& spawnpoint)
 {

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -187,13 +187,9 @@ Sector::get_spawn_point_position(const std::string& spawnpoint)
 {
   SpawnPointMarker* sp = get_spawn_point(spawnpoint);
   if (sp)
-  {
     return sp->get_pos();
-  }
   else
-  {
     return Vector(0.0f, 0.0f);
-  }
 }
 
 void

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -168,8 +168,8 @@ Sector::finish_construction(bool editable)
   m_fully_constructed = true;
 }
 
-void
-Sector::activate(const std::string& spawnpoint)
+SpawnPointMarker*
+Sector::get_spawn_point(const std::string& spawnpoint)
 {
   SpawnPointMarker* sp = nullptr;
   for (auto& spawn_point : get_objects_by_type<SpawnPointMarker>()) {
@@ -178,6 +178,29 @@ Sector::activate(const std::string& spawnpoint)
       break;
     }
   }
+
+  return sp;
+}
+
+
+Vector
+Sector::get_spawn_point_position(const std::string& spawnpoint)
+{
+  SpawnPointMarker* sp = get_spawn_point(spawnpoint);
+  if (sp)
+  {
+    return sp->get_pos();
+  }
+  else
+  {
+    return Vector(0.0f, 0.0f);
+  }
+}
+
+void
+Sector::activate(const std::string& spawnpoint)
+{
+  SpawnPointMarker* sp = get_spawn_point(spawnpoint);
 
   if (!sp) {
     if (!m_level.is_worldmap())

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -47,6 +47,7 @@ class Size;
 class TextObject;
 class TileMap;
 class Writer;
+class SpawnPointMarker;
 
 /** Represents one of (potentially) multiple, separate parts of a Level.
     Sectors contain GameObjects, e.g. Badguys and Players. */
@@ -151,6 +152,8 @@ public:
   DisplayEffect& get_effect() const;
   TextObject& get_text_object() const { return m_text_object; }
 
+  Vector get_spawn_point_position(const std::string& spawnpoint);
+
 private:
   uint32_t collision_tile_attributes(const Rectf& dest, const Vector& mov) const;
 
@@ -162,6 +165,8 @@ private:
   /** Convert tiles into their corresponding GameObjects (e.g.
       bonusblocks, add light to lava tiles) */
   void convert_tiles2gameobject();
+
+  SpawnPointMarker* get_spawn_point(const std::string& spawnpoint);
 
 private:
   Level& m_level; // Parent level

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -44,10 +44,10 @@ class Player;
 class ReaderMapping;
 class Rectf;
 class Size;
+class SpawnPointMarker;
 class TextObject;
 class TileMap;
 class Writer;
-class SpawnPointMarker;
 
 /** Represents one of (potentially) multiple, separate parts of a Level.
     Sectors contain GameObjects, e.g. Badguys and Players. */

--- a/src/supertux/shrinkfade.cpp
+++ b/src/supertux/shrinkfade.cpp
@@ -44,7 +44,7 @@ ShrinkFade::draw(DrawingContext& context)
   float progress = m_accum_time / m_fade_time;
   float diameter = 2 * m_initial_size * (m_direction == FADEOUT ? (1.0f - progress) : progress);
   context.color().draw_inverse_ellipse(m_dest, Vector(1.1f * diameter, diameter),
-                                         Color(0, 0, 0), LAYER_GUI - 11);
+                                         Color(0, 0, 0), LAYER_LIGHTMAP - 1);
 }
 
 bool

--- a/src/supertux/shrinkfade.cpp
+++ b/src/supertux/shrinkfade.cpp
@@ -44,7 +44,7 @@ ShrinkFade::draw(DrawingContext& context)
   float progress = m_accum_time / m_fade_time;
   float diameter = 2 * m_initial_size * (m_direction == FADEOUT ? (1.0f - progress) : progress);
   context.color().draw_inverse_ellipse(m_dest, Vector(1.1f * diameter, diameter),
-                                         Color(0, 0, 0), LAYER_GUI - 5);
+                                         Color(0, 0, 0), LAYER_GUI - 11);
 }
 
 bool

--- a/src/supertux/shrinkfade.cpp
+++ b/src/supertux/shrinkfade.cpp
@@ -21,11 +21,12 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
-ShrinkFade::ShrinkFade(const Vector& dest_, float fade_time_) :
+ShrinkFade::ShrinkFade(const Vector& dest_, float fade_time_, Direction direction_) :
   m_dest(dest_),
   m_fade_time(fade_time_),
   m_accum_time(0),
-  m_initial_size(static_cast<float>(SCREEN_HEIGHT > SCREEN_WIDTH ? SCREEN_HEIGHT : SCREEN_WIDTH))
+  m_initial_size(static_cast<float>(SCREEN_HEIGHT > SCREEN_WIDTH ? SCREEN_HEIGHT : SCREEN_WIDTH)),
+  m_direction(direction_)
 {
 }
 
@@ -41,7 +42,7 @@ void
 ShrinkFade::draw(DrawingContext& context)
 {
   float progress = m_accum_time / m_fade_time;
-  float diameter = 2 * m_initial_size * (1.0f - progress);
+  float diameter = 2 * m_initial_size * (m_direction == FADEOUT ? (1.0f - progress) : progress);
   context.color().draw_inverse_ellipse(m_dest, Vector(1.1f * diameter, diameter),
                                          Color(0, 0, 0), LAYER_GUI + 1);
 }

--- a/src/supertux/shrinkfade.cpp
+++ b/src/supertux/shrinkfade.cpp
@@ -21,12 +21,13 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
-ShrinkFade::ShrinkFade(const Vector& dest_, float fade_time_, Direction direction_) :
-  m_dest(dest_),
-  m_fade_time(fade_time_),
+ShrinkFade::ShrinkFade(const Vector& dest, float fade_time, int draw_layer, Direction direction) :
+  m_draw_layer(draw_layer),
+  m_dest(dest),
+  m_fade_time(fade_time),
   m_accum_time(0),
   m_initial_size(static_cast<float>(SCREEN_HEIGHT > SCREEN_WIDTH ? SCREEN_HEIGHT : SCREEN_WIDTH)),
-  m_direction(direction_)
+  m_direction(direction)
 {
 }
 
@@ -44,7 +45,7 @@ ShrinkFade::draw(DrawingContext& context)
   float progress = m_accum_time / m_fade_time;
   float diameter = 2 * m_initial_size * (m_direction == FADEOUT ? (1.0f - progress) : progress);
   context.color().draw_inverse_ellipse(m_dest, Vector(1.1f * diameter, diameter),
-                                         Color(0, 0, 0), LAYER_LIGHTMAP - 1);
+                                         Color(0, 0, 0), m_draw_layer);
 }
 
 bool

--- a/src/supertux/shrinkfade.cpp
+++ b/src/supertux/shrinkfade.cpp
@@ -44,7 +44,7 @@ ShrinkFade::draw(DrawingContext& context)
   float progress = m_accum_time / m_fade_time;
   float diameter = 2 * m_initial_size * (m_direction == FADEOUT ? (1.0f - progress) : progress);
   context.color().draw_inverse_ellipse(m_dest, Vector(1.1f * diameter, diameter),
-                                         Color(0, 0, 0), LAYER_GUI + 1);
+                                         Color(0, 0, 0), LAYER_GUI - 5);
 }
 
 bool

--- a/src/supertux/shrinkfade.hpp
+++ b/src/supertux/shrinkfade.hpp
@@ -24,7 +24,8 @@
 class ShrinkFade final : public ScreenFade
 {
 public:
-  ShrinkFade(const Vector& point, float fade_time);
+  enum Direction { FADEOUT, FADEIN };
+  ShrinkFade(const Vector& point, float fade_time, Direction = FADEOUT);
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
@@ -36,6 +37,7 @@ private:
   float m_fade_time;
   float m_accum_time;
   float m_initial_size;
+  Direction m_direction;
 
 private:
   ShrinkFade(const ShrinkFade&) = delete;

--- a/src/supertux/shrinkfade.hpp
+++ b/src/supertux/shrinkfade.hpp
@@ -25,6 +25,8 @@ class ShrinkFade final : public ScreenFade
 {
 public:
   enum Direction { FADEOUT, FADEIN };
+
+public:
   ShrinkFade(const Vector& point, float fade_time, Direction = FADEOUT);
 
   virtual void update(float dt_sec) override;

--- a/src/supertux/shrinkfade.hpp
+++ b/src/supertux/shrinkfade.hpp
@@ -27,7 +27,7 @@ public:
   enum Direction { FADEOUT, FADEIN };
 
 public:
-  ShrinkFade(const Vector& point, float fade_time, Direction = FADEOUT);
+  ShrinkFade(const Vector& point, float fade_time, int draw_layer, Direction = FADEOUT);
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
@@ -35,6 +35,7 @@ public:
   virtual bool done() const override;
 
 private:
+  const int m_draw_layer;
   Vector m_dest;
   float m_fade_time;
   float m_accum_time;

--- a/src/supertux/shrinkfade.hpp
+++ b/src/supertux/shrinkfade.hpp
@@ -19,6 +19,7 @@
 
 #include "math/vector.hpp"
 #include "supertux/screen_fade.hpp"
+#include "video/layer.hpp"
 
 /** Shrinks a rectangle screen towards a specific position */
 class ShrinkFade final : public ScreenFade
@@ -27,7 +28,7 @@ public:
   enum Direction { FADEOUT, FADEIN };
 
 public:
-  ShrinkFade(const Vector& point, float fade_time, int draw_layer, Direction = FADEOUT);
+  ShrinkFade(const Vector& point, float fade_time, int draw_layer = LAYER_GUI + 1, Direction = FADEOUT);
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -29,12 +29,10 @@
 #include "supertux/flip_level_transformer.hpp"
 #include "util/reader_mapping.hpp"
 
-
 static const float STAY_OPEN_TIME = 1.0f;
 static const float LOCK_WARN_TIME = 0.5f;
 static const float CENTER_EPSILON = 5.0f;
 static const float WALK_SPEED = 100.0f;
-
 
 Door::Door(const ReaderMapping& mapping) :
   SpritedTrigger(mapping, "images/objects/door/door.sprite"),

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -188,17 +188,13 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
     case CLOSED:
       break;
     case OPENING:
-      break;
-    case OPEN:
     {
-      // If door is open and was touched by a player, teleport the player.
+      // If door is opening and was touched by a player, teleport the player.
       Player* player = dynamic_cast<Player*> (&other);
 
       if (player) {
-        // Restart the stay open time to allow the fade transition to fisish
         if (!m_transition_triggered)
         {
-          m_stay_open_timer.start(STAY_OPEN_TIME);
           m_transition_triggered = true;
 
           if (!m_script.empty()) {
@@ -218,8 +214,9 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
           }
         }
       }
+      break;
     }
-    break;
+    case OPEN:
     case CLOSING:
     case LOCKED:
     case UNLOCKING:

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -206,6 +206,10 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
           }
 
           if (!m_target_sector.empty() ) {
+            // Do not allow the player to move away during fade animation...
+            player->deactivate();
+            // ... but make him safe for this time
+            player->make_temporarily_safe(GameSession::TELEPORT_FADE_TIME);
             GameSession::current()->respawn_with_fade(m_target_sector,
                                                       m_target_spawnpoint,
                                                       ScreenFade::FadeType::CIRCLE,

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -154,7 +154,7 @@ Door::update(float )
     }
     else
     {
-      m_triggering_player->walk(0.0);
+      m_triggering_player->walk(0.0f);
       m_triggering_player = nullptr;
     }
   }

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -206,7 +206,11 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
           }
 
           if (!m_target_sector.empty() ) {
-            GameSession::current()->respawn_with_fade(m_target_sector, m_target_spawnpoint, GameSession::FadeType::CIRCLE, get_bbox().get_middle());
+            GameSession::current()->respawn_with_fade(m_target_sector,
+                                                      m_target_spawnpoint,
+                                                      GameSession::FadeType::CIRCLE,
+                                                      get_bbox().get_middle(),
+                                                      true);
           }
         }
       }

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -225,10 +225,9 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
           }
           if (!m_target_sector.empty())
           {
-            // Disable controls, make Tux temporarily safe and initiate screen fade
+            // Disable controls, GameSession will make safe Tux during fade animation.
             // Controls will be reactivated after spawn
             m_triggering_player->deactivate();
-            m_triggering_player->make_temporarily_safe(GameSession::TELEPORT_FADE_TIME);
             GameSession::current()->respawn_with_fade(m_target_sector,
                                                       m_target_spawnpoint,
                                                       ScreenFade::FadeType::CIRCLE,

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -208,7 +208,7 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
           if (!m_target_sector.empty() ) {
             GameSession::current()->respawn_with_fade(m_target_sector,
                                                       m_target_spawnpoint,
-                                                      GameSession::FadeType::CIRCLE,
+                                                      ScreenFade::FadeType::CIRCLE,
                                                       get_bbox().get_middle(),
                                                       true);
           }

--- a/src/trigger/door.cpp
+++ b/src/trigger/door.cpp
@@ -29,34 +29,39 @@
 #include "supertux/flip_level_transformer.hpp"
 #include "util/reader_mapping.hpp"
 
+
+static const float STAY_OPEN_TIME = 1.0f;
+static const float LOCK_WARN_TIME = 0.5f;
+
 Door::Door(const ReaderMapping& mapping) :
   SpritedTrigger(mapping, "images/objects/door/door.sprite"),
-  state(CLOSED),
-  target_sector(),
-  target_spawnpoint(),
-  script(),
-  lock_sprite(SpriteManager::current()->create("images/objects/door/door_lock.sprite")),
-  stay_open_timer(),
-  unlocking_timer(),
-  lock_warn_timer(),
+  m_state(CLOSED),
+  m_target_sector(),
+  m_target_spawnpoint(),
+  m_script(),
+  m_lock_sprite(SpriteManager::current()->create("images/objects/door/door_lock.sprite")),
+  m_stay_open_timer(),
+  m_unlocking_timer(),
+  m_lock_warn_timer(),
   m_locked(),
-  lock_color(Color::WHITE)
+  m_lock_color(Color::WHITE),
+  m_transition_triggered(false)
 {
-  mapping.get("sector", target_sector);
-  mapping.get("spawnpoint", target_spawnpoint);
-  mapping.get("script", script);
+  mapping.get("sector", m_target_sector);
+  mapping.get("spawnpoint", m_target_spawnpoint);
+  mapping.get("script", m_script);
   mapping.get("locked", m_locked);
 
-  state = m_locked ? DoorState::LOCKED : DoorState::CLOSED;
+  m_state = m_locked ? DoorState::LOCKED : DoorState::CLOSED;
 
   set_action("closed");
 
   std::vector<float> vColor;
   if (mapping.get("lock-color", vColor))
-    lock_color = Color(vColor);
+    m_lock_color = Color(vColor);
   else
-    lock_color = Color::WHITE;
-  lock_sprite->set_color(lock_color);
+    m_lock_color = Color::WHITE;
+  m_lock_sprite->set_color(m_lock_color);
 
   SoundManager::current()->preload("sounds/door.wav");
   // TODO: Add proper sounds.
@@ -69,11 +74,11 @@ Door::get_settings()
 {
   ObjectSettings result = SpritedTrigger::get_settings();
 
-  result.add_script(_("Script"), &script, "script");
-  result.add_text(_("Sector"), &target_sector, "sector");
-  result.add_text(_("Spawn point"), &target_spawnpoint, "spawnpoint");
+  result.add_script(_("Script"), &m_script, "script");
+  result.add_text(_("Sector"), &m_target_sector, "sector");
+  result.add_text(_("Spawn point"), &m_target_spawnpoint, "spawnpoint");
   result.add_bool(_("Locked?"), &m_locked, "locked");
-  result.add_color(_("Lock Color"), &lock_color, "lock-color", Color::WHITE);
+  result.add_color(_("Lock Color"), &m_lock_color, "lock-color", Color::WHITE);
 
   result.reorder({"sector", "lock-color", "locked", "spawnpoint", "name", "x", "y"});
 
@@ -85,49 +90,50 @@ Door::after_editor_set()
 {
   SpritedTrigger::after_editor_set();
 
-  lock_sprite->set_color(lock_color);
+  m_lock_sprite->set_color(m_lock_color);
 }
 
 void
 Door::update(float )
 {
-  switch (state) {
+  switch (m_state) {
     case CLOSED:
       break;
     case OPENING:
       // If door has finished opening, start timer and keep door open.
       if (m_sprite->animation_done()) {
-        state = OPEN;
+        m_state = OPEN;
         set_action("open");
-        stay_open_timer.start(1.0);
+        m_stay_open_timer.start(STAY_OPEN_TIME);
+        m_transition_triggered = false;
       }
       break;
     case OPEN:
       // If door was open long enough, start closing it.
-      if (stay_open_timer.check()) {
-        state = CLOSING;
+      if (m_stay_open_timer.check()) {
+        m_state = CLOSING;
         set_action("closing", 1);
       }
       break;
     case CLOSING:
       // If door has finished closing, keep it shut.
       if (m_sprite->animation_done()) {
-        state = CLOSED;
+        m_state = CLOSED;
         set_action("closed");
       }
       break;
     case LOCKED:
-      if (lock_warn_timer.check()) {
-        lock_warn_timer.stop();
+      if (m_lock_warn_timer.check()) {
+        m_lock_warn_timer.stop();
       }
       break;
     case UNLOCKING:
-      if (unlocking_timer.check())
+      if (m_unlocking_timer.check())
       {
         Sector::get().add<SpriteParticle>("images/objects/door/door_lock.sprite",
-          "default", get_bbox().get_middle(), ANCHOR_MIDDLE, Vector(0.f, -300.f), Vector(0.f, 1000.f), LAYER_OBJECTS - 2, true, lock_color);
-        unlocking_timer.stop();
-        state = DoorState::CLOSED;
+          "default", get_bbox().get_middle(), ANCHOR_MIDDLE, Vector(0.f, -300.f), Vector(0.f, 1000.f), LAYER_OBJECTS - 2, true, m_lock_color);
+        m_unlocking_timer.stop();
+        m_state = DoorState::CLOSED;
       }
       break;
   }
@@ -138,26 +144,25 @@ Door::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), m_col.m_bbox.p1(), LAYER_BACKGROUNDTILES+1, m_flip);
 
-  if (state == DoorState::LOCKED || state == DoorState::UNLOCKING)
+  if (m_state == DoorState::LOCKED || m_state == DoorState::UNLOCKING)
   {
     Vector shake_delta = Vector(static_cast<float>(graphicsRandom.rand(-8, 8)), static_cast<float>(graphicsRandom.rand(-8, 8)));
-    float shake_strength = lock_warn_timer.started() ? lock_warn_timer.get_timeleft() : 0.f;
-    lock_sprite->draw(context.color(), get_bbox().get_middle() -
-      (Vector(lock_sprite->get_width() / 2, lock_sprite->get_height() / 2) + (shake_delta*shake_strength)), LAYER_BACKGROUNDTILES + 1, m_flip);
+    float shake_strength = m_lock_warn_timer.started() ? m_lock_warn_timer.get_timeleft() : 0.f;
+    m_lock_sprite->draw(context.color(), get_bbox().get_middle() -
+      (Vector(m_lock_sprite->get_width() / 2, m_lock_sprite->get_height() / 2) + (shake_delta*shake_strength)), LAYER_BACKGROUNDTILES + 1, m_flip);
   }
 }
 
 void
 Door::event(Player& , EventType type)
 {
-  switch (state) {
+  switch (m_state) {
     case CLOSED:
       // If door was activated, start opening it.
       if (type == EVENT_ACTIVATE) {
-        state = OPENING;
+        m_state = OPENING;
         SoundManager::current()->play("sounds/door.wav", get_pos());
         set_action("opening", 1);
-        ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEOUT, 1.0f));
       }
       break;
     case OPENING:
@@ -168,10 +173,10 @@ Door::event(Player& , EventType type)
       break;
     case LOCKED:
       SoundManager::current()->play("sounds/locked.ogg", get_pos());
-      lock_warn_timer.start(0.5f);
+      m_lock_warn_timer.start(LOCK_WARN_TIME);
       break;
     case UNLOCKING:
-      state = CLOSED;
+      m_state = CLOSED;
       break;
   }
 }
@@ -179,7 +184,7 @@ Door::event(Player& , EventType type)
 HitResponse
 Door::collision(GameObject& other, const CollisionHit& hit_)
 {
-  switch (state) {
+  switch (m_state) {
     case CLOSED:
       break;
     case OPENING:
@@ -190,15 +195,19 @@ Door::collision(GameObject& other, const CollisionHit& hit_)
       Player* player = dynamic_cast<Player*> (&other);
 
       if (player) {
-        state = CLOSING;
-        set_action("closing", 1);
-        if (!script.empty()) {
-          Sector::get().run_script(script, "Door");
-        }
+        // Restart the stay open time to allow the fade transition to fisish
+        if (!m_transition_triggered)
+        {
+          m_stay_open_timer.start(STAY_OPEN_TIME);
+          m_transition_triggered = true;
 
-        if (!target_sector.empty()) {
-          GameSession::current()->respawn(target_sector, target_spawnpoint);
-          ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEIN, 1.0f));
+          if (!m_script.empty()) {
+            Sector::get().run_script(m_script, "Door");
+          }
+
+          if (!m_target_sector.empty() ) {
+            GameSession::current()->respawn_with_fade(m_target_sector, m_target_spawnpoint, GameSession::FadeType::CIRCLE, get_bbox().get_middle());
+          }
         }
       }
     }
@@ -224,8 +233,8 @@ Door::unlock()
 {
   m_locked = false;
   SoundManager::current()->play("sounds/turnkey.ogg", get_pos());
-  unlocking_timer.start(1.f);
-  state = DoorState::UNLOCKING;
+  m_unlocking_timer.start(1.f);
+  m_state = DoorState::UNLOCKING;
 }
 
 /* EOF */

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -69,6 +69,7 @@ private:
   bool m_locked;
   Color m_lock_color;
   bool m_transition_triggered;
+  Player* m_triggering_player;
 
 private:
   Door(const Door&) = delete;

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -45,7 +45,7 @@ public:
   bool is_locked() const { return m_locked; }
   void unlock();
 
-  Color get_lock_color() const { return lock_color; }
+  Color get_lock_color() const { return m_lock_color; }
 
 private:
   enum DoorState {
@@ -58,16 +58,17 @@ private:
   };
 
 private:
-  DoorState state; /**< current state of the door */
-  std::string target_sector; /**< target sector to teleport to */
-  std::string target_spawnpoint; /**< target spawnpoint to teleport to */
-  std::string script;
-  SpritePtr lock_sprite;
-  Timer stay_open_timer; /**< time until door will close again */
-  Timer unlocking_timer;
-  Timer lock_warn_timer;
+  DoorState m_state; /**< current state of the door */
+  std::string m_target_sector; /**< target sector to teleport to */
+  std::string m_target_spawnpoint; /**< target spawnpoint to teleport to */
+  std::string m_script;
+  SpritePtr m_lock_sprite;
+  Timer m_stay_open_timer; /**< time until door will close again */
+  Timer m_unlocking_timer;
+  Timer m_lock_warn_timer;
   bool m_locked;
-  Color lock_color;
+  Color m_lock_color;
+  bool m_transition_triggered;
 
 private:
   Door(const Door&) = delete;

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -349,7 +349,7 @@ WorldMapSector::update(float dt_sec)
           // update state and savegame
           m_parent.save_state();
           ScreenManager::current()->push_screen(std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics()),
-                                                std::make_unique<ShrinkFade>(shrinkpos, 1.0f));
+                                                std::make_unique<ShrinkFade>(shrinkpos, 1.0f, LAYER_LIGHTMAP - 1));
 
           m_parent.m_in_level = true;
         } catch(std::exception& e) {


### PR DESCRIPTION
Provides the following changes to door and teleport transitions:
- ShrinkFade is now used as fade effect instead of FadeToBlack
- Player controls are disabled while fading out to prevent Tux from walking away the door while it opens
- Tux walks automatically in front of door if up key is pressed and Tux is not directly in front of the door
- Tux cannot be hurt by enemies while controls are disabled
- Added some time of invincibility when spawning at the target door
- Added scripting support for Level.spawn_transition

Default fade effect when entering a GameSession is now the ShrinkFade effect.

Fixes #2409
Fixes #2649