### PR TITLE
Remove unnecessary randomness of mole

### DIFF
--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -76,7 +76,7 @@ Mole::collision_squished(GameObject& )
 void
 Mole::throw_rock()
 {
-  float angle = math::radians(135.f - (float(cycle_num) * 30.f));
+  float angle = math::radians(135.f - (static_cast<float>(cycle_num) * 30.f));
 
   SoundManager::current()->play("sounds/dartfire.wav", get_pos());
   Sector::get().add<MoleRock>(m_col.m_bbox.get_middle(),

--- a/src/badguy/mole.cpp
+++ b/src/badguy/mole.cpp
@@ -35,7 +35,8 @@ Mole::Mole(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/mole/mole.sprite", LAYER_TILES-1),
   state(PRE_THROWING),
   timer(),
-  throw_timer()
+  throw_timer(),
+  cycle_num()
 {
   m_physic.enable_gravity(false);
   SoundManager::current()->preload("sounds/fall.wav");
@@ -75,14 +76,13 @@ Mole::collision_squished(GameObject& )
 void
 Mole::throw_rock()
 {
-  float angle;
-  float base_angle = (m_flip == NO_FLIP ? 90.0f : 270.0f);
-  angle = math::radians(gameRandom.randf(base_angle - 15.0f, base_angle + 15.0f));
-  float vx = cosf(angle) * THROW_VELOCITY;
-  float vy = -sinf(angle) * THROW_VELOCITY;
+  float angle = math::radians(135.f - (float(cycle_num) * 30.f));
 
   SoundManager::current()->play("sounds/dartfire.wav", get_pos());
-  Sector::get().add<MoleRock>(m_col.m_bbox.get_middle(), Vector(vx, vy), this);
+  Sector::get().add<MoleRock>(m_col.m_bbox.get_middle(),
+    THROW_VELOCITY * ((cycle_num == 0 || cycle_num == 3) ? 0.8f : 1.f) *
+    Vector(cosf(angle), sin(angle) * (m_flip == NO_FLIP ? -1.f : 1.f)), this);
+  cycle_num += 1;
 }
 
 void
@@ -142,6 +142,7 @@ Mole::set_state(MoleState new_state)
       throw_timer.start(THROW_INTERVAL);
       break;
     case POST_THROWING:
+      cycle_num = 0;
       set_action("idle");
       set_colgroup_active(COLGROUP_DISABLED);
       timer.start(MOLE_WAIT_TIME);

--- a/src/badguy/mole.hpp
+++ b/src/badguy/mole.hpp
@@ -61,6 +61,7 @@ private:
   MoleState state;
   Timer timer;
   Timer throw_timer;
+  int cycle_num;
 
 private:
   Mole(const Mole&) = delete;

--- a/src/badguy/zeekling.cpp
+++ b/src/badguy/zeekling.cpp
@@ -25,7 +25,7 @@
 
 Zeekling::Zeekling(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/zeekling/zeekling.sprite"),
-  speed(gameRandom.randf(150.0f)),
+  speed(gameRandom.randf(130.0f, 171.0f)),
   diveRecoverTimer(),
   state(FLYING),
   last_player(nullptr),

--- a/src/badguy/zeekling.cpp
+++ b/src/badguy/zeekling.cpp
@@ -19,13 +19,12 @@
 
 #include <math.h>
 
-#include "math/random.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
 
 Zeekling::Zeekling(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/zeekling/zeekling.sprite"),
-  speed(gameRandom.randf(130.0f, 171.0f)),
+  speed(150.f),
   diveRecoverTimer(),
   state(FLYING),
   last_player(nullptr),

--- a/src/badguy/zeekling.cpp
+++ b/src/badguy/zeekling.cpp
@@ -19,12 +19,13 @@
 
 #include <math.h>
 
+#include "math/random.hpp"
 #include "object/player.hpp"
 #include "sprite/sprite.hpp"
 
 Zeekling::Zeekling(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/zeekling/zeekling.sprite"),
-  speed(150.f),
+  speed(gameRandom.randf(150.0f)),
   diveRecoverTimer(),
   state(FLYING),
   last_player(nullptr),


### PR DESCRIPTION
Having some enemies with random behavior is so horrible for stuff like speedruns, or situations in which something should not be random.  There is an instance of randomness in badguys that literally does not need to exist, and I have removed it here.  That instance is this:
- Random throwing of rocks by moles has been changed to a certain pattern, which is still very similar to the old one.