### PR TITLE
Fix some fallblock issues

### DIFF
--- a/src/object/fallblock.hpp
+++ b/src/object/fallblock.hpp
@@ -41,9 +41,9 @@ public:
   static std::string display_name() { return _("Falling Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
 
+protected:
   virtual void on_flip(float height) override;
 
-protected:
   enum State
   {
     IDLE,


### PR DESCRIPTION
There existed an issue where the fallblock would not properly convey that it was going to fall, and I fixed that in this PR.  Also, enemies are properly squished by fallblocks.  
NOTE: This PR removes the feature where bumpers would cling to fallblocks.  This is because the feature is re-added in a more consistent way in PR #2846.  
NOTE 2: I think the fallblock needs a new, unique graphic.  Maybe when it is drawn it can be added to this PR.  