### PR TITLE
Fix crusher issues

### DIFF
--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -137,12 +137,16 @@ Crusher::collision(GameObject& other, const CollisionHit& hit)
   }
 
   auto* badguy = dynamic_cast<BadGuy*>(&other);
-  if (badguy && m_state == CRUSHING) {
+  if (badguy && m_state == CRUSHING && ((!m_sideways && hit.bottom) ||
+    (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) || (hit.right && m_physic.get_velocity_x() > 0.f)))))
+  {
     badguy->kill_fall();
   }
 
   auto* rock = dynamic_cast<Rock*>(&other);
-  if (rock && !rock->is_grabbed() && ((hit.bottom && !m_sideways) || (m_sideways && (hit.left || hit.right))) && m_state == CRUSHING) {
+  if (rock && !rock->is_grabbed() && m_state == CRUSHING && ((!m_sideways && hit.bottom) ||
+    (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) || (hit.right && m_physic.get_velocity_x() > 0.f)))))
+  {
     SoundManager::current()->play("sounds/brick.wav", get_pos());
     m_physic.reset();
     set_state(RECOVERING);

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -138,14 +138,16 @@ Crusher::collision(GameObject& other, const CollisionHit& hit)
 
   auto* badguy = dynamic_cast<BadGuy*>(&other);
   if (badguy && m_state == CRUSHING && ((!m_sideways && hit.bottom) ||
-    (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) || (hit.right && m_physic.get_velocity_x() > 0.f)))))
+      (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) ||
+                      (hit.right && m_physic.get_velocity_x() > 0.f)))))
   {
     badguy->kill_fall();
   }
 
   auto* rock = dynamic_cast<Rock*>(&other);
   if (rock && !rock->is_grabbed() && m_state == CRUSHING && ((!m_sideways && hit.bottom) ||
-    (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) || (hit.right && m_physic.get_velocity_x() > 0.f)))))
+      (m_sideways && ((hit.left && m_physic.get_velocity_x() < 0.f) ||
+                      (hit.right && m_physic.get_velocity_x() > 0.f)))))
   {
     SoundManager::current()->play("sounds/brick.wav", get_pos());
     m_physic.reset();

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -142,7 +142,7 @@ Crusher::collision(GameObject& other, const CollisionHit& hit)
   }
 
   auto* rock = dynamic_cast<Rock*>(&other);
-  if (rock && !rock->is_grabbed() && hit.bottom && m_state == CRUSHING) {
+  if (rock && !rock->is_grabbed() && ((hit.bottom && !m_sideways) || (m_sideways && (hit.left || hit.right))) && m_state == CRUSHING) {
     SoundManager::current()->play("sounds/brick.wav", get_pos());
     m_physic.reset();
     set_state(RECOVERING);

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -28,6 +28,7 @@
 #include "object/camera.hpp"
 #include "object/particles.hpp"
 #include "object/player.hpp"
+#include "object/rock.hpp"
 #include "sprite/sprite.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "supertux/flip_level_transformer.hpp"
@@ -138,6 +139,14 @@ Crusher::collision(GameObject& other, const CollisionHit& hit)
   auto* badguy = dynamic_cast<BadGuy*>(&other);
   if (badguy && m_state == CRUSHING) {
     badguy->kill_fall();
+  }
+
+  auto* rock = dynamic_cast<Rock*>(&other);
+  if (rock && !rock->is_grabbed() && hit.bottom && m_state == CRUSHING) {
+    SoundManager::current()->play("sounds/brick.wav", get_pos());
+    m_physic.reset();
+    set_state(RECOVERING);
+    return ABORT_MOVE;
   }
 
   const auto* heavy_coin = dynamic_cast<HeavyCoin*>(&other);

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -328,7 +328,7 @@ Crusher::update(float dt_sec)
   switch (m_state)
   {
   case IDLE:
-    m_start_position = get_pos();
+    //m_start_position = get_pos();
     if (found_victim())
     {
       set_state(CRUSHING);
@@ -360,9 +360,11 @@ Crusher::update(float dt_sec)
   case RECOVERING:
     if (returned_down || returned_up || returned_left || returned_right)
     {
-      set_pos(Vector(m_sideways ? m_start_position.x : get_pos().x,
-        m_sideways ? get_pos().y : m_start_position.y));
-      m_physic.set_velocity(0.f, 0.f);
+      m_physic.reset();
+      // we have to offset the crusher when we bring it back to its original position because otherwise it will gain an ugly offset. #JustPhysicErrorThings
+      set_pos(Vector(m_sideways ? m_start_position.x + (2.6f * (m_side_dir == Direction::LEFT ? -1.f : 1.f)) : get_pos().x,
+        m_sideways ? get_pos().y : m_start_position.y + (2.6f * (m_flip ? -1.f : 1.f))));
+
       if (m_ic_size == LARGE)
         m_cooldown_timer = PAUSE_TIME_LARGE;
       else

--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -642,14 +642,14 @@ CollisionSystem::update()
     }
   }
 
-  // Part 3: COLGROUP_MOVING vs COLGROUP_MOVING
+  // Part 3: COLGROUP_MOVING vs COLGROUP_MOVING.
   for (auto i = m_objects.begin(); i != m_objects.end(); ++i)
   {
     auto object = *i;
 
-    if ((object->get_group() != COLGROUP_MOVING
-      && object->get_group() != COLGROUP_MOVING_STATIC)
-       || !object->is_valid())
+    if (!object->is_valid() ||
+        (object->get_group() != COLGROUP_MOVING &&
+         object->get_group() != COLGROUP_MOVING_STATIC))
       continue;
 
     for (auto i2 = i+1; i2 != m_objects.end(); ++i2) {

--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -33,6 +33,7 @@
 namespace {
 
 const float MAX_SPEED = 16.0f;
+static const float FORGIVENESS = 256.f; // 16.f * 16.f - half a tile by half a tile.
 
 } // namespace
 
@@ -419,12 +420,11 @@ CollisionSystem::collision_static(collision::Constraints* constraints,
   // Collision with other (static) objects.
   for (auto* static_object : m_objects)
   {
-    float static_size = static_object->get_bbox().get_width() * static_object->get_bbox().get_height();
-    float object_size = object.get_bbox().get_width() * object.get_bbox().get_height();
-    float forgiveness = 16.f * 16.f;
+    const float static_size = static_object->get_bbox().get_width() * static_object->get_bbox().get_height();
+    const float object_size = object.get_bbox().get_width() * object.get_bbox().get_height();
     // let's skip this if two colgroup_moving_static's connect and our object is somewhat larger than the static object.
     if ((object.get_group() == COLGROUP_MOVING_STATIC && static_object->get_group() == COLGROUP_MOVING_STATIC) &&
-      (object_size > static_size + forgiveness)) {
+      (object_size > static_size + FORGIVENESS)) {
       return;
     }
     if ((

--- a/src/collision/collision_system.cpp
+++ b/src/collision/collision_system.cpp
@@ -419,6 +419,14 @@ CollisionSystem::collision_static(collision::Constraints* constraints,
   // Collision with other (static) objects.
   for (auto* static_object : m_objects)
   {
+    float static_size = static_object->get_bbox().get_width() * static_object->get_bbox().get_height();
+    float object_size = object.get_bbox().get_width() * object.get_bbox().get_height();
+    float forgiveness = 16.f * 16.f;
+    // let's skip this if two colgroup_moving_static's connect and our object is somewhat larger than the static object.
+    if ((object.get_group() == COLGROUP_MOVING_STATIC && static_object->get_group() == COLGROUP_MOVING_STATIC) &&
+      (object_size > static_size + forgiveness)) {
+      return;
+    }
     if ((
           static_object->get_group() == COLGROUP_STATIC ||
           static_object->get_group() == COLGROUP_MOVING_STATIC
@@ -634,13 +642,13 @@ CollisionSystem::update()
     }
   }
 
-  // Part 3: COLGROUP_MOVING vs COLGROUP_MOVING.
+  // Part 3: COLGROUP_MOVING vs COLGROUP_MOVING
   for (auto i = m_objects.begin(); i != m_objects.end(); ++i)
   {
     auto object = *i;
 
     if ((object->get_group() != COLGROUP_MOVING
-        && object->get_group() != COLGROUP_MOVING_STATIC)
+      && object->get_group() != COLGROUP_MOVING_STATIC)
        || !object->is_valid())
       continue;
 

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -151,7 +151,7 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
 
   auto crusher = dynamic_cast<Crusher*> (&other);
   if (crusher) {
-    return CONTINUE;
+    return FORCE_MOVE;
   }
 
   // Don't fall further if we are on a rock which is on the ground.

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -151,11 +151,7 @@ Rock::collision(GameObject& other, const CollisionHit& hit)
 
   auto crusher = dynamic_cast<Crusher*> (&other);
   if (crusher) {
-    auto state = crusher->get_state();
-    if(state == Crusher::CrusherState::RECOVERING ||
-       state == Crusher::CrusherState::IDLE) {
-        return ABORT_MOVE;
-       }
+    return CONTINUE;
   }
 
   // Don't fall further if we are on a rock which is on the ground.


### PR DESCRIPTION
This PR aims to fix some icecrusher issues.  Please test it, it might have some issues.  

- [x] Fix, or add a workaround, for the weird offset experienced whenever a crusher returns to its position.
- [x] Fix the part of the game where crushers would be weighed down by things that are obviously too small for them.

KNOWN ISSUES:
- [x] Rocks can be shoved into the floor by Crushers.

Fixes #1880.
Fixes #2038.