### PR TITLE
Update snail behavior to be more consistent

### DIFF
--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -212,7 +212,7 @@ Snail::active_update(float dt_sec)
 
     case STATE_KICKED:
       m_physic.set_velocity_x(m_physic.get_velocity_x() * powf(0.99f, dt_sec/0.02f));
-      if (fabsf(m_physic.get_velocity_x()) < walk_speed) be_normal();
+      if (on_ground() && (fabsf(m_physic.get_velocity_x()) < walk_speed)) be_normal();
       break;
 
     case STATE_GRABBED:

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -327,7 +327,7 @@ Snail::collision_player(Player& player, const CollisionHit& hit)
       m_dir = Direction::LEFT;
     }
     player.kick();
-    be_kicked(true);
+    be_kicked(false);
     return FORCE_MOVE;
   }
 
@@ -371,7 +371,7 @@ Snail::collision_squished(GameObject& object)
           m_dir = Direction::LEFT;
         }
       }
-      be_kicked(true);
+      be_kicked(false);
       break;
 
     default:

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -48,7 +48,7 @@ Snail::Snail(const ReaderMapping& reader) :
   parse_type(reader);
 
   walk_speed = 80;
-  set_ledge_behavior(LedgeBehavior::NORMAL);
+  set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/iceblock_bump.wav");
   SoundManager::current()->preload("sounds/stomp.wav");
   SoundManager::current()->preload("sounds/kick.wav");

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -326,6 +326,7 @@ Snail::collision_player(Player& player, const CollisionHit& hit)
     } else if (hit.right) {
       m_dir = Direction::LEFT;
     }
+    SoundManager::current()->play("sounds/kick.wav", get_pos());
     player.kick();
     be_kicked(false);
     return FORCE_MOVE;
@@ -409,6 +410,7 @@ Snail::ungrab(MovingObject& object, Direction dir_)
 
     if (player)
     {
+      SoundManager::current()->play("sounds/kick.wav", get_pos());
       if (!player->is_swimming() && !player->is_water_jumping())
       {
         switch (dir_)

--- a/src/badguy/snail.cpp
+++ b/src/badguy/snail.cpp
@@ -260,7 +260,7 @@ Snail::collision_solid(const CollisionHit& hit)
           m_dir = (m_dir == Direction::LEFT) ? Direction::RIGHT : Direction::LEFT;
           set_action("flat", m_dir, /* loops = */ -1);
 
-          m_physic.set_velocity_x(-m_physic.get_velocity_x());
+          m_physic.set_velocity(-m_physic.get_velocity_x(), -std::abs(m_physic.get_velocity_x()));
         }
       }
       [[fallthrough]];
@@ -327,7 +327,7 @@ Snail::collision_player(Player& player, const CollisionHit& hit)
       m_dir = Direction::LEFT;
     }
     player.kick();
-    be_kicked(false);
+    be_kicked(true);
     return FORCE_MOVE;
   }
 
@@ -404,19 +404,49 @@ Snail::ungrab(MovingObject& object, Direction dir_)
 {
   if (!m_frozen)
   {
-    if (dir_ == Direction::UP) {
-      be_flat();
-    }
-    else {
-      if (dir_ != Direction::DOWN) {
-        m_dir = dir_;
-      } else {
-        const Player* player = dynamic_cast<Player*>(&object);
-        if(player) {
+    const Player* player = dynamic_cast<Player*>(&object);
+    const Owl* owl = dynamic_cast<Owl*>(&object);
+
+    if (player)
+    {
+      if (!player->is_swimming() && !player->is_water_jumping())
+      {
+        switch (dir_)
+        {
+        case Direction::UP:
+          if (std::abs(player->get_velocity().x) < 4.f) {
+            be_flat();
+            m_physic.set_velocity_y(SNAIL_KICK_SPEED_Y);
+          }
+          else {
+            be_kicked(true);
+          }
+          break;
+        case Direction::LEFT:
+        case Direction::RIGHT:
+          m_dir = dir_;
+          be_kicked(false);
+          break;
+        case Direction::DOWN:
           m_dir = player->m_dir;
+          be_kicked(false);
+          m_physic.set_velocity_y(500.f);
+          break;
+        default:
+          break;
         }
       }
-      be_kicked(dynamic_cast<Owl*>(&object) ? false : true);
+      else
+      {
+        float swimangle = player->get_swimming_angle();
+        m_col.m_bbox.move(Vector(std::cos(swimangle) * 48.f, std::sin(swimangle) * 48.f));
+        be_kicked(false);
+        m_physic.set_velocity(SNAIL_KICK_SPEED * 1.5f * Vector(std::cos(swimangle), std::sin(swimangle)));
+        m_dir = m_physic.get_velocity_x() > 0.f ? Direction::RIGHT : Direction::LEFT;
+      }
+    }
+    else if (owl) {
+      be_kicked(false);
     }
   }
   else


### PR DESCRIPTION
This PR makes snail behavior more consistent.  It now works like this:
- Throwing the snail now throws it just like every other object in the game.
- Kicking the snail by any means makes it bounce up and spin (may need changing).
- A snail hitting a wall while spinning makes it also bounce up (may need changing).
- Throwing a snail while swimming makes it spin in the direction it was thrown .
Known issues:
- [x] Throwing a snail in water straight up or down makes it return to normal immediately.  This is because the game makes the snail return to normal if its x speed is less than its walking speed, but may just need to be changed to the absolute value of its speed overall.

Fixes #2845.