### PR TITLE
Update PhysFS to 3.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/SuperTux/sexp-cpp.git
 [submodule "external/physfs"]
 	path = external/physfs
-	url = https://github.com/SuperTux/physfs.git
+	url = https://github.com/icculus/physfs.git
 [submodule "external/SDL_ttf"]
 	path = external/SDL_ttf
 	url = https://github.com/SuperTux/SDL_ttf


### PR DESCRIPTION
We have been on some rather old-ish version of PhysFS since quite a while. Even though we support building against locally installed versions of PhysFS; I feel like updating to the latest release version can have benefits.