### PR TITLE
Use external/glm fallback when system GLM not found

### DIFF
--- a/mk/cmake/SuperTux/ProvideGlm.cmake
+++ b/mk/cmake/SuperTux/ProvideGlm.cmake
@@ -6,6 +6,23 @@ endif()
 
 if(USE_SYSTEM_GLM)
   find_package(glm QUIET)
+
+  if(NOT glm_FOUND)
+    # fallback for old glm version in UBPorts
+    find_path(GLM_INCLUDE_DIR
+      NAMES glm/glm.hpp
+      PATHS ${GLM_ROOT_DIR}/include)
+    if(NOT GLM_INCLUDE_DIR)
+      message(STATUS "Could NOT find glm, using external/glm fallback")
+      set(USE_SYSTEM_GLM OFF)
+    else()
+      message(STATUS "Found glm: ${GLM_INCLUDE_DIR}")
+      add_library(LibGlm INTERFACE IMPORTED)
+      set_target_properties(LibGlm PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${GLM_INCLUDE_DIR}"
+        INTERFACE_COMPILE_DEFINITIONS "GLM_ENABLE_EXPERIMENTAL")
+    endif()
+  endif()
 endif()
 
 if(NOT USE_SYSTEM_GLM)
@@ -56,20 +73,6 @@ elseif(glm_FOUND)
       INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:glm,INTERFACE_INCLUDE_DIRECTORIES>"
       INTERFACE_COMPILE_DEFINITIONS "GLM_ENABLE_EXPERIMENTAL")
   endif()
-else()
-  # fallback for old glm version in UBPorts
-  find_path(GLM_INCLUDE_DIR
-    NAMES glm/glm.hpp
-    PATHS ${GLM_ROOT_DIR}/include)
-  if(NOT GLM_INCLUDE_DIR)
-    message(FATAL_ERROR "glm library missing")
-  endif()
-
-  message(STATUS "Found glm: ${GLM_INCLUDE_DIR}")
-  add_library(LibGlm INTERFACE IMPORTED)
-  set_target_properties(LibGlm PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${GLM_INCLUDE_DIR}"
-    INTERFACE_COMPILE_DEFINITIONS "GLM_ENABLE_EXPERIMENTAL")
 endif()
 
 # EOF #


### PR DESCRIPTION
Basically, what I wrote in the title above.

This will use the GLM fallback in external/glm if system GLM could not be found.

If anyone has any ideas on how to improve the code even further go right ahead.