### PR TITLE
Fix sporadic crash on worldmap select

### DIFF
--- a/src/worldmap/camera.cpp
+++ b/src/worldmap/camera.cpp
@@ -31,7 +31,8 @@ const float CAMERA_PAN_TIME_MAX = 0.52213f;
 
 namespace worldmap {
 
-Camera::Camera() :
+Camera::Camera(WorldMapSector& worldmap_sector) :
+  m_worldmap_sector(worldmap_sector),
   m_camera_offset(0.0f, 0.0f),
   m_pan_startpos(0.0f, 0.0f),
   m_pan_time_full(0),
@@ -82,7 +83,7 @@ Camera::pan()
 Vector
 Camera::get_camera_pos_for_tux() const
 {
-  auto& tux = WorldMapSector::current()->get_singleton_by_type<Tux>();
+  auto& tux = m_worldmap_sector.get_singleton_by_type<Tux>();
 
   Vector camera_offset_(0.0f, 0.0f);
   Vector tux_pos = tux.get_pos();
@@ -94,8 +95,6 @@ Camera::get_camera_pos_for_tux() const
 void
 Camera::clamp_camera_position(Vector& c) const
 {
-  auto& worldmap_sector = *WorldMapSector::current();
-
   if (c.x < 0) {
     c.x = 0;
   }
@@ -104,20 +103,20 @@ Camera::clamp_camera_position(Vector& c) const
     c.y = 0;
   }
 
-  if (c.x > worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH)) {
-    c.x = worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH);
+  if (c.x > m_worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH)) {
+    c.x = m_worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH);
   }
 
-  if (c.y > worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT)) {
-    c.y = worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT);
+  if (c.y > m_worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT)) {
+    c.y = m_worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT);
   }
 
-  if (worldmap_sector.get_width() < static_cast<float>(SCREEN_WIDTH)) {
-    c.x = (worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH)) / 2.0f;
+  if (m_worldmap_sector.get_width() < static_cast<float>(SCREEN_WIDTH)) {
+    c.x = (m_worldmap_sector.get_width() - static_cast<float>(SCREEN_WIDTH)) / 2.0f;
   }
 
-  if (worldmap_sector.get_height() < static_cast<float>(SCREEN_HEIGHT)) {
-    c.y = (worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT)) / 2.0f;
+  if (m_worldmap_sector.get_height() < static_cast<float>(SCREEN_HEIGHT)) {
+    c.y = (m_worldmap_sector.get_height() - static_cast<float>(SCREEN_HEIGHT)) / 2.0f;
   }
 }
 

--- a/src/worldmap/camera.hpp
+++ b/src/worldmap/camera.hpp
@@ -22,10 +22,12 @@
 
 namespace worldmap {
 
+class WorldMapSector;
+
 class Camera
 {
 public:
-  Camera();
+  explicit Camera(WorldMapSector& worldmap_sector);
 
   void update(float dt_sec);
 
@@ -39,6 +41,7 @@ private:
   void clamp_camera_position(Vector& c) const;
 
 private:
+  WorldMapSector& m_worldmap_sector;
   Vector m_camera_offset;
 
   /** variables to track panning to a spawn point */

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -62,7 +62,7 @@ WorldMapSector::current()
 WorldMapSector::WorldMapSector(WorldMap& parent) :
   Base::Sector("worldmap"),
   m_parent(parent),
-  m_camera(new Camera),
+  m_camera(new Camera(*this)),
   m_tux(&add<Tux>(&parent)),
   m_spawnpoints(),
   m_initial_fade_tilemap(),


### PR DESCRIPTION
Fixes nullptr dereferencing when a new WorldMap has been allocated, but no sector has been setup yet

Fixes #2920 