### PR TITLE
Set camera to manual in credits screen

### DIFF
--- a/data/levels/misc/credits.stl
+++ b/data/levels/misc/credits.stl
@@ -60,7 +60,7 @@ stop_music(0);")
     )
     (camera
       (name "Camera")
-      (mode "normal")
+      (mode "manual")
     )
     (decal
       (name "PENNY")


### PR DESCRIPTION
Since the shrinkfade effect is used when a game session is created, the fade point in the credits screen is somewhere in the lower left corner of the screen.
Setting the camera to manual mode will center the shrinkfade effect in the credits screen.