### PR TITLE
`Canvas::get_pixel`: Use a virtual colorspace

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -170,7 +170,7 @@ BadGuy::draw(DrawingContext& context)
 
       if (m_glowing)
       {
-        m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+        m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
       }
     }
   }

--- a/src/badguy/bomb.cpp
+++ b/src/badguy/bomb.cpp
@@ -92,7 +92,7 @@ Bomb::draw(DrawingContext& context)
   m_exploding_sprite->set_action("exploding");
   m_exploding_sprite->set_blend(Blend::ADD);
   m_exploding_sprite->draw(context.light(),
-    get_pos() + Vector(get_bbox().get_width() / 2, get_bbox().get_height() / 2), m_layer, m_flip);
+    get_pos() + Vector(get_bbox().get_width() / 2, get_bbox().get_height() / 2), m_layer, m_flip, ColorSpace::LIGHTSPRITES);
   BadGuy::draw(context);
 }
 

--- a/src/badguy/dive_mine.cpp
+++ b/src/badguy/dive_mine.cpp
@@ -123,7 +123,7 @@ DiveMine::draw(DrawingContext& context)
   m_ticking_glow->draw(context.light(),
                        Vector(m_col.m_bbox.get_left() + m_col.m_bbox.get_width() / 2,
                               m_col.m_bbox.get_top() - 8.f),
-                       m_layer, m_flip);
+                       m_layer, m_flip, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/badguy/ghosttree.cpp
+++ b/src/badguy/ghosttree.cpp
@@ -223,7 +223,7 @@ GhostTree::draw(DrawingContext& context)
   } else {
     context.set_alpha(0.5f);
   }
-  glow_sprite->draw(context.light(), get_pos(), m_layer);
+  glow_sprite->draw(context.light(), get_pos(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
   context.pop_transform();
 }
 

--- a/src/badguy/goldbomb.cpp
+++ b/src/badguy/goldbomb.cpp
@@ -287,7 +287,7 @@ GoldBomb::draw(DrawingContext& context)
   {
     m_exploding_sprite->set_blend(Blend::ADD);
     m_exploding_sprite->draw(context.light(),
-      get_pos() + Vector(get_bbox().get_width() / 2, get_bbox().get_height() / 2), m_layer, m_flip);
+      get_pos() + Vector(get_bbox().get_width() / 2, get_bbox().get_height() / 2), m_layer, m_flip, ColorSpace::LIGHTSPRITES);
   }
   WalkingBadguy::draw(context);
 }

--- a/src/badguy/haywire.cpp
+++ b/src/badguy/haywire.cpp
@@ -233,7 +233,7 @@ Haywire::draw(DrawingContext& context)
   {
     m_exploding_sprite->set_blend(Blend::ADD);
     m_exploding_sprite->draw(context.light(),
-      get_pos()+Vector(get_bbox().get_width()/2, get_bbox().get_height()/2), m_layer, m_flip);
+      get_pos()+Vector(get_bbox().get_width()/2, get_bbox().get_height()/2), m_layer, m_flip, ColorSpace::LIGHTSPRITES);
   }
   WalkingBadguy::draw(context);
 }

--- a/src/badguy/kugelblitz.cpp
+++ b/src/badguy/kugelblitz.cpp
@@ -152,7 +152,7 @@ void
 Kugelblitz::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), m_layer);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/badguy/treewillowisp.cpp
+++ b/src/badguy/treewillowisp.cpp
@@ -106,7 +106,7 @@ void
 TreeWillOWisp::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), m_layer);
-  m_sprite->draw(context.light(), get_pos(), m_layer);
+  m_sprite->draw(context.light(), get_pos(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/math/circle.cpp
+++ b/src/math/circle.cpp
@@ -1,0 +1,57 @@
+//  SuperTux
+//  Copyright (C) 2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "math/circle.hpp"
+
+#include "math/rectf.hpp"
+
+Circle::Circle(const Vector& center, float radius) :
+  m_center(center),
+  m_radius(radius)
+{
+}
+
+bool
+Circle::contains(const Vector& point) const
+{
+  const float distance = powf(point.x - m_center.x, 2) + powf(point.y - m_center.y, 2);
+  return distance <= powf(m_radius, 2);
+}
+
+/*
+bool
+Circle::overlaps(const Rectf& rect) const
+{
+  const Vector distance = m_center - m_rect.p1();
+
+  // Circle is far enough away from the rectangle
+  if (distance.x > rect.get_width() / 2 + m_radius ||
+      distance.y > rect.get_height() / 2 + m_radius)
+    return false;
+
+  // Circle is close enough to the rectangle
+  if (distance.x <= rect.get_width() / 2 ||
+      distance.y <= rect.get_height() / 2)
+    return true;
+
+  // Check if circle intersects with the corner of the rectangle
+  const float distance_sq = (distance.x - rect.get_width() / 2) ^ 2 +
+                            (distance.y - rect.get_height() / 2) ^ 2;
+  return distance_sq <= m_radius ^ 2;
+}
+*/
+
+/* EOF */

--- a/src/math/circle.hpp
+++ b/src/math/circle.hpp
@@ -1,5 +1,5 @@
 //  SuperTux
-//  Copyright (C) 2006 Matthias Braun <matze@braunis.de>
+//  Copyright (C) 2024 Vankata453
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -14,33 +14,28 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "object/light.hpp"
+#ifndef HEADER_SUPERTUX_MATH_CIRCLE_HPP
+#define HEADER_SUPERTUX_MATH_CIRCLE_HPP
 
-#include "sprite/sprite.hpp"
-#include "sprite/sprite_manager.hpp"
+#include "math/vector.hpp"
 
-Light::Light(const Vector& center, const Color& color_) :
-  position(center),
-  color(color_),
-  sprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light.sprite"))
+class Rectf;
+
+class Circle final
 {
-}
+public:
+  Circle(const Vector& center, float radius = 0.f);
 
-Light::~Light()
-{
-}
+  bool contains(const Vector& point) const;
+  //bool overlaps(const Rectf& rect) const;
 
-void
-Light::update(float )
-{
-}
+  const Vector& get_center() const { return m_center; }
 
-void
-Light::draw(DrawingContext& context)
-{
-  sprite->set_color(color);
-  sprite->set_blend(Blend::ADD);
-  sprite->draw(context.light(), position, 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
-}
+private:
+  Vector m_center;
+  float m_radius;
+};
+
+#endif
 
 /* EOF */

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -688,7 +688,7 @@ BonusBlock::draw(DrawingContext& context)
   {
     Vector pos = get_pos() + (m_col.m_bbox.get_size().as_vector() - Vector(static_cast<float>(m_lightsprite->get_width()),
                                                                    static_cast<float>(m_lightsprite->get_height()))) / 2.0f;
-    context.light().draw_surface(m_lightsprite, pos, 10);
+    context.light().draw_surface(m_lightsprite, pos, 10, ColorSpace::LIGHTSPRITES);
   }
 }
 

--- a/src/object/bullet.cpp
+++ b/src/object/bullet.cpp
@@ -93,7 +93,7 @@ Bullet::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), get_pos(), LAYER_OBJECTS);
   if (type == FIRE_BONUS){
-    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
   }
 }
 

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -92,10 +92,10 @@ Candle::draw(DrawingContext& context)
     // draw approx. 1 in 10 frames darker. Makes the candle flicker.
     if (graphicsRandom.rand(10) != 0 || !flicker) {
       // context.color().draw_surface(candle_light_1, pos, layer);
-      candle_light_1->draw(context.light(), m_col.m_bbox.get_middle(), m_layer);
+      candle_light_1->draw(context.light(), m_col.m_bbox.get_middle(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
     } else {
       // context.color().draw_surface(candle_light_2, pos, layer);
-      candle_light_2->draw(context.light(), m_col.m_bbox.get_middle(), m_layer);
+      candle_light_2->draw(context.light(), m_col.m_bbox.get_middle(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
     }
   }
 }

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -167,7 +167,7 @@ void
 Explosion::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS+40);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 HitResponse

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -66,7 +66,7 @@ Firefly::draw(DrawingContext& context)
 
   if (m_sprite_name.find("torch", 0) != std::string::npos && (activated ||
         m_sprite->get_action() == "ringing")) {
-    m_sprite_light->draw(context.light(), m_col.m_bbox.get_middle() + (m_flip == NO_FLIP ? -TORCH_LIGHT_OFFSET : TORCH_LIGHT_OFFSET), 0);
+    m_sprite_light->draw(context.light(), m_col.m_bbox.get_middle() + (m_flip == NO_FLIP ? -TORCH_LIGHT_OFFSET : TORCH_LIGHT_OFFSET), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
   }
 }
 

--- a/src/object/flower.cpp
+++ b/src/object/flower.cpp
@@ -66,7 +66,7 @@ void
 Flower::draw(DrawingContext& context)
 {
   sprite->draw(context.color(), get_pos(), LAYER_OBJECTS, flip);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 HitResponse

--- a/src/object/growup.cpp
+++ b/src/object/growup.cpp
@@ -59,7 +59,7 @@ GrowUp::draw(DrawingContext& context)
     return;
 
   shadesprite->draw(context.color(), get_pos(), m_layer);
-  lightsprite->draw(context.light(), get_bbox().get_middle(), 0);
+  lightsprite->draw(context.light(), get_bbox().get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/object/key.cpp
+++ b/src/object/key.cpp
@@ -181,7 +181,7 @@ void
 Key::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
-  m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), m_layer+1);
+  m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), m_layer+1, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 ObjectSettings

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -92,7 +92,7 @@ Lantern::draw(DrawingContext& context){
   //Draw the Sprite.
   MovingSprite::draw(context);
   //Let there be light.
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 HitResponse Lantern::collision(GameObject& other, const CollisionHit& hit) {

--- a/src/object/lit_object.cpp
+++ b/src/object/lit_object.cpp
@@ -52,7 +52,7 @@ void
 LitObject::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), m_layer - 1, m_flip);
-  m_light_sprite->draw(context.light(), get_pos() - m_light_offset, m_layer - 1, m_flip);
+  m_light_sprite->draw(context.light(), get_pos() - m_light_offset, m_layer - 1, m_flip, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/object/magicblock.cpp
+++ b/src/object/magicblock.cpp
@@ -189,7 +189,7 @@ void
 MagicBlock::draw(DrawingContext& context)
 {
   // Ask for update about lightmap at center of this block
-  context.light().get_pixel(m_center, m_light);
+  context.light().get_pixel(ColorSpace::LIGHTSPRITES, m_center, m_light);
 
   MovingSprite::draw(context);
   context.color().draw_filled_rect(m_col.m_bbox, m_color, m_layer);

--- a/src/object/powerup.cpp
+++ b/src/object/powerup.cpp
@@ -290,7 +290,7 @@ PowerUp::draw(DrawingContext& context)
   if (m_type == STAR || m_type == HERRING)
     m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
 
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 ObjectSettings

--- a/src/object/rublight.cpp
+++ b/src/object/rublight.cpp
@@ -140,7 +140,7 @@ RubLight::draw(DrawingContext& context)
     Color col = color.multiply_linearly(brightness);
     light->set_color(col);
     light->set_blend(Blend::ADD);
-    light->draw(context.light(), get_pos(), m_layer);
+    light->draw(context.light(), get_pos(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
   }
 
   m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);

--- a/src/object/spotlight.cpp
+++ b/src/object/spotlight.cpp
@@ -142,10 +142,10 @@ Spotlight::draw(DrawingContext& context)
 {
   if (m_enabled)
   {
-    light->set_color(color);
-    light->set_blend(Blend::ADD);
-    light->set_angle(angle);
-    light->draw(context.light(), m_col.m_bbox.p1(), m_layer);
+    m_light->set_color(m_color);
+    m_light->set_blend(Blend::ADD);
+    m_light->set_angle(m_angle);
+    m_light->draw(context.light(), m_col.m_bbox.p1(), m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
 
     //lightcone->set_angle(angle);
     //lightcone->draw(context.color(), position, m_layer);

--- a/src/object/sprite_particle.cpp
+++ b/src/object/sprite_particle.cpp
@@ -104,8 +104,8 @@ SpriteParticle::draw(DrawingContext& context)
   //Sparkles glow in the dark
   if (glow)
   {
-    sprite->draw(context.light(), position, drawing_layer);
-    lightsprite->draw(context.light(), position + Vector(12, 12), 0);
+    sprite->draw(context.light(), position, drawing_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
+    lightsprite->draw(context.light(), position + Vector(12, 12), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
   }
 
 }

--- a/src/object/star.cpp
+++ b/src/object/star.cpp
@@ -71,7 +71,7 @@ void
 Star::draw(DrawingContext& context)
 {
   MovingSprite::draw(context);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
 }
 
 void

--- a/src/object/torch.cpp
+++ b/src/object/torch.cpp
@@ -60,7 +60,7 @@ Torch::draw(DrawingContext& context)
     m_flame->draw(context.color(), pos, m_layer - 1, m_flip);
     m_flame->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
 
-    m_flame_light->draw(context.light(), pos, m_layer);
+    m_flame_light->draw(context.light(), pos, m_layer, NO_FLIP, ColorSpace::LIGHTSPRITES);
     m_flame_light->set_action(m_light_color.greyscale() >= 1.f ? "default" : "greyscale");
 
     m_flame_glow->draw(context.color(), pos, m_layer - 1, m_flip);

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -218,7 +218,7 @@ WeakBlock::draw(DrawingContext& context)
 
   if (m_type == HAY && (state != STATE_NORMAL))
   {
-    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+    lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0, NO_FLIP, ColorSpace::LIGHTSPRITES);
   }
 }
 

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -166,7 +166,7 @@ Sprite::update()
 
 void
 Sprite::draw(Canvas& canvas, const Vector& pos, int layer,
-             Flip flip)
+             Flip flip, ColorSpace::Type colorspace)
 {
   assert(m_action != nullptr);
   update();
@@ -183,7 +183,8 @@ Sprite::draw(Canvas& canvas, const Vector& pos, int layer,
                     m_angle,
                     m_color,
                     m_blend,
-                    layer);
+                    layer,
+                    colorspace);
 
   context.pop_transform();
 }

--- a/src/sprite/sprite.hpp
+++ b/src/sprite/sprite.hpp
@@ -38,7 +38,7 @@ public:
 
   /** Draw sprite, automatically calculates next frame */
   void draw(Canvas& canvas, const Vector& pos, int layer,
-            Flip flip = NO_FLIP);
+            Flip flip = NO_FLIP, ColorSpace::Type colorspace = ColorSpace::NONE);
 
   /** Set action (or state) */
   void set_action(const std::string& name, int loops = -1);

--- a/src/video/canvas.hpp
+++ b/src/video/canvas.hpp
@@ -19,6 +19,7 @@
 #define HEADER_SUPERTUX_VIDEO_CANVAS_HPP
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include <memory>
 #include <obstack.h>
@@ -27,6 +28,7 @@
 #include "math/vector.hpp"
 #include "video/blend.hpp"
 #include "video/color.hpp"
+#include "video/colorspace.hpp"
 #include "video/drawing_target.hpp"
 #include "video/font.hpp"
 #include "video/font_ptr.hpp"
@@ -49,13 +51,13 @@ public:
   Canvas(DrawingContext& context, obstack& obst);
   ~Canvas();
 
-  void draw_surface(const SurfacePtr& surface, const Vector& position, int layer);
+  void draw_surface(const SurfacePtr& surface, const Vector& position, int layer, ColorSpace::Type colorspace = ColorSpace::NONE);
   void draw_surface(const SurfacePtr& surface, const Vector& position, float angle, const Color& color, const Blend& blend,
-                    int layer);
+                    int layer, ColorSpace::Type colorspace = ColorSpace::NONE);
   void draw_surface_part(const SurfacePtr& surface, const Rectf& srcrect, const Rectf& dstrect,
-                         int layer, const PaintStyle& style = PaintStyle());
+                         int layer, const PaintStyle& style = PaintStyle(), ColorSpace::Type colorspace = ColorSpace::NONE);
   void draw_surface_scaled(const SurfacePtr& surface, const Rectf& dstrect,
-                           int layer, const PaintStyle& style = PaintStyle());
+                           int layer, const PaintStyle& style = PaintStyle(), ColorSpace::Type colorspace = ColorSpace::NONE);
   void draw_surface_batch(const SurfacePtr& surface,
                           std::vector<Rectf> srcrects,
                           std::vector<Rectf> dstrects,
@@ -82,8 +84,8 @@ public:
   void draw_line(const Vector& pos1, const Vector& pos2, const Color& color, int layer);
   void draw_triangle(const Vector& pos1, const Vector& pos2, const Vector& pos3, const Color& color, int layer);
 
-  /** on next update, set color to lightmap's color at position */
-  void get_pixel(const Vector& position, const std::shared_ptr<Color>& color_out);
+  /** on next update, set color to the color at the provided position in the colorspace */
+  void get_pixel(ColorSpace::Type colorspace, const Vector& position, const std::shared_ptr<Color>& color_out);
 
   void clear();
   void render(Renderer& renderer, Filter filter);
@@ -98,6 +100,7 @@ private:
   DrawingContext& m_context;
   obstack& m_obst;
   std::vector<DrawingRequest*> m_requests;
+  std::unordered_map<ColorSpace::Type, ColorSpace> m_colorspaces;
 
 private:
   Canvas(const Canvas&) = delete;

--- a/src/video/color.cpp
+++ b/src/video/color.cpp
@@ -18,6 +18,8 @@
 
 #include <assert.h>
 
+#include "math/util.hpp"
+
 const Color Color::BLACK(0.0, 0.0, 0.0);
 const Color Color::RED(1.0, 0.0, 0.0);
 const Color Color::GREEN(0.0, 1.0, 0.0);
@@ -40,9 +42,9 @@ Color::Color(float red_, float green_, float blue_, float alpha_) :
   blue(blue_),
   alpha(alpha_)
 {
-  assert(0 <= red   && red <= 1.0f);
-  assert(0 <= green && green <= 1.0f);
-  assert(0 <= blue  && blue <= 1.0f);
+  red = math::clamp(red, 0.f, 1.f);
+  green = math::clamp(green, 0.f, 1.f);
+  blue = math::clamp(blue, 0.f, 1.f);
 }
 
 Color::Color(const std::vector<float>& vals) :
@@ -65,9 +67,10 @@ Color::Color(const std::vector<float>& vals) :
     alpha = vals[3];
   else
     alpha = 1.0;
-  assert(0 <= red   && red <= 1.0f);
-  assert(0 <= green && green <= 1.0f);
-  assert(0 <= blue  && blue <= 1.0f);
+
+  red = math::clamp(red, 0.f, 1.f);
+  green = math::clamp(green, 0.f, 1.f);
+  blue = math::clamp(blue, 0.f, 1.f);
 }
 
 bool

--- a/src/video/colorspace.cpp
+++ b/src/video/colorspace.cpp
@@ -1,0 +1,56 @@
+//  SuperTux
+//  Copyright (C) 2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "video/colorspace.hpp"
+
+ColorSpace::ColorSpace() :
+  m_rects(),
+  m_circles()
+{
+}
+
+void
+ColorSpace::add(const Rectf& rect, const Color& color)
+{
+  m_rects.insert({ color, rect });
+}
+
+void
+ColorSpace::add(const Circle& circle, const Color& color)
+{
+  m_circles.insert({ color, circle });
+}
+
+Color
+ColorSpace::get_pixel(const Vector& point) const
+{
+  Color result(0.f, 0.f, 0.f);
+  
+  for (const auto& rect : m_rects)
+  {
+    if (rect.second.contains(point))
+      result = (result + rect.first).validate(); // Additive blending
+  }
+  for (const auto& circle : m_circles)
+  {
+    if (circle.second.contains(point))
+      result = (result + circle.first).validate(); // Additive blending
+  }
+
+  return result;
+}
+
+/* EOF */

--- a/src/video/colorspace.hpp
+++ b/src/video/colorspace.hpp
@@ -1,0 +1,52 @@
+//  SuperTux
+//  Copyright (C) 2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_VIDEO_COLORSPACE_HPP
+#define HEADER_SUPERTUX_VIDEO_COLORSPACE_HPP
+
+#include <map>
+
+#include "math/circle.hpp"
+#include "math/rectf.hpp"
+#include "video/color.hpp"
+
+/** A virtual colorspace, consisting of colored shapes,
+    where the color at a provided point can be gathered deterministically. */
+class ColorSpace final
+{
+public:
+  enum Type
+  {
+    NONE,
+    LIGHTSPRITES /* Colorspace of object light sprites */
+  };
+
+public:
+  ColorSpace();
+
+  void add(const Rectf& rect, const Color& color);
+  void add(const Circle& circle, const Color& color);
+
+  Color get_pixel(const Vector& point) const;
+
+private:
+  std::map<Color, Rectf> m_rects;
+  std::map<Color, Circle> m_circles;
+};
+
+#endif
+
+/* EOF */

--- a/src/video/drawing_request.hpp
+++ b/src/video/drawing_request.hpp
@@ -25,6 +25,7 @@
 #include "math/vector.hpp"
 #include "video/blend.hpp"
 #include "video/color.hpp"
+#include "video/colorspace.hpp"
 #include "video/drawing_transform.hpp"
 #include "video/font.hpp"
 #include "video/gradient.hpp"
@@ -173,12 +174,14 @@ struct GetPixelRequest : public DrawingRequest
 {
   GetPixelRequest(const DrawingTransform& transform) :
     DrawingRequest(transform),
+    colorspace(ColorSpace::NONE),
     pos(0.0f, 0.0f),
     color_ptr()
   {}
 
   RequestType get_type() const override { return RequestType::GETPIXEL; }
 
+  ColorSpace::Type colorspace;
   Vector pos;
   std::shared_ptr<Color> color_ptr;
 

--- a/src/video/gl/gl_painter.cpp
+++ b/src/video/gl/gl_painter.cpp
@@ -472,43 +472,6 @@ GLPainter::clear(const Color& color)
 }
 
 void
-GLPainter::get_pixel(const GetPixelRequest& request) const
-{
-  assert_gl();
-
-  const Rect& rect = m_renderer.get_rect();
-  const Size& logical_size = m_renderer.get_logical_size();
-
-  float x = request.pos.x * static_cast<float>(rect.get_width()) / static_cast<float>(logical_size.width);
-  float y = request.pos.y * static_cast<float>(rect.get_height()) / static_cast<float>(logical_size.height);
-
-  x += static_cast<float>(rect.left);
-  y += static_cast<float>(rect.top);
-
-#if 0
-  // #ifndef USE_OPENGLES2
-  //
-  // FIXME: glFenceSync() causes crashes on Intel I965, so disable
-  // GLPixelRequest for now, it's not yet properly used anyway.
-  GLPixelRequest pixel_request(1, 1);
-  pixel_request.request(static_cast<int>(x), static_cast<int>(y));
-
-  *(request.color_ptr) = pixel_request.get_color();
-
-#else
-  float pixels[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-
-  // OpenGLES2 does not have PBOs, only GLES3 has.
-  glReadPixels(static_cast<GLint>(x), static_cast<GLint>(y),
-               1, 1, GL_RGB, GL_FLOAT, pixels);
-
-  *(request.color_ptr) = Color(pixels[0], pixels[1], pixels[2]);
-#endif
-
-  assert_gl();
-}
-
-void
 GLPainter::set_clip_rect(const Rect& clip_rect)
 {
   assert_gl();

--- a/src/video/gl/gl_painter.hpp
+++ b/src/video/gl/gl_painter.hpp
@@ -38,7 +38,6 @@ public:
   virtual void draw_triangle(const TriangleRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;

--- a/src/video/null/null_painter.cpp
+++ b/src/video/null/null_painter.cpp
@@ -71,12 +71,6 @@ NullPainter::clear(const Color& color)
 }
 
 void
-NullPainter::get_pixel(const GetPixelRequest& request) const
-{
-  log_info << "NullPainter::get_pixel()" << std::endl;
-}
-
-void
 NullPainter::set_clip_rect(const Rect& rect)
 {
   log_info << "NullPainter::set_clip_rect()" << std::endl;

--- a/src/video/null/null_painter.hpp
+++ b/src/video/null/null_painter.hpp
@@ -35,7 +35,6 @@ public:
   virtual void draw_triangle(const TriangleRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;

--- a/src/video/painter.hpp
+++ b/src/video/painter.hpp
@@ -47,7 +47,6 @@ public:
   virtual void draw_triangle(const TriangleRequest& request) = 0;
 
   virtual void clear(const Color& color) = 0;
-  virtual void get_pixel(const GetPixelRequest& request) const = 0;
 
   virtual void set_clip_rect(const Rect& rect) = 0;
   virtual void clear_clip_rect() = 0;

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -613,29 +613,4 @@ SDLPainter::clear_clip_rect()
   }
 }
 
-void
-SDLPainter::get_pixel(const GetPixelRequest& request) const
-{
-  const Rect& rect = m_renderer.get_rect();
-  const Size& logical_size = m_renderer.get_logical_size();
-
-  SDL_Rect srcrect;
-  srcrect.x = rect.left + static_cast<int>(request.pos.x * static_cast<float>(rect.get_width()) / static_cast<float>(logical_size.width));
-  srcrect.y = rect.top + static_cast<int>(request.pos.y * static_cast<float>(rect.get_height()) / static_cast<float>(logical_size.height));
-  srcrect.w = 1;
-  srcrect.h = 1;
-
-  Uint8 pixel[4];
-  int ret = SDL_RenderReadPixels(m_sdl_renderer, &srcrect,
-                                 SDL_PIXELFORMAT_RGB888,
-                                 pixel,
-                                 1);
-  if (ret != 0)
-  {
-    log_warning << "failed to read pixels: " << SDL_GetError() << std::endl;
-  }
-
-  *(request.color_ptr) = Color::from_rgb888(pixel[2], pixel[1], pixel[0]);
-}
-
 /* EOF */

--- a/src/video/sdl/sdl_painter.hpp
+++ b/src/video/sdl/sdl_painter.hpp
@@ -40,7 +40,6 @@ public:
   virtual void draw_triangle(const TriangleRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;


### PR DESCRIPTION
Virtual colorspaces, consisting of colored shapes, can now be used for the `get_pixel` API, instead of relying on the GPU.

**TODO:**

[ ] Detect, or allow to specify lightsprites as circles with a radius and border radius, making the light check more visually correct. [ ] Make sure the shape of every lightsprite, needed to be detected by the `get_pixel` API, is being added into the `LIGHTSPRITES` colorspace. [ ] More extensive testing.

Fixes #2661. Fixes #1939 (theoretically, should also be tested).