### PR TITLE
Don't play worldmap music when Tux is on a level that's set to auto-play

### DIFF
--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -105,9 +105,6 @@ WorldMapSector::setup()
 {
   BIND_WORLDMAP_SECTOR(*this);
 
-  auto& music_object = get_singleton_by_type<MusicObject>();
-  music_object.play_music(MusicType::LEVEL_MUSIC);
-
   ScreenManager::current()->set_screen_fade(std::make_unique<FadeToBlack>(FadeToBlack::FADEIN, 1.0f));
 
   // If we specified a fade tilemap, let's fade it:
@@ -148,6 +145,15 @@ WorldMapSector::setup()
 
   if (!m_init_script.empty())
     m_squirrel_environment->run_script(m_init_script, "WorldMapSector::init");
+
+  // Check if Tux is on an auto-playing level.
+  // No need to play music in that case.
+  LevelTile* level = at_object<LevelTile>();
+  if(level && level->is_auto_play() && !level->is_solved())
+    return;
+
+  auto& music_object = get_singleton_by_type<MusicObject>();
+  music_object.play_music(MusicType::LEVEL_MUSIC);
 }
 
 void


### PR DESCRIPTION
Pretty trivial, but since I'm still learning how to do Pull Requests, I guess this is a good chance. Whenever someone mentions "put it in a pull request", I understand "Squash master down to one single commit and force-push that".

Anyway.
I noticed on the WASM build that when Tux is on an auto-playing level, we have the worldmap music overlapping the music of the auto-playing level at first.

I think this can be avoided.