### PR TITLE
Reset spawn fade type when using Level.spawn()

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -705,6 +705,7 @@ GameSession::respawn(const std::string& sector, const std::string& spawnpoint)
   m_newsector = sector;
   m_newspawnpoint = spawnpoint;
   m_spawn_with_invincibility = false;
+  m_spawn_fade_type = ScreenFade::FadeType::NONE;
 }
 
 void


### PR DESCRIPTION
Resolves an issue that Level.spawn() script won't work after a door has been used. The fade type needs to be reset to NONE to match the condition for respawning via Level.spawn(). By using a door it is set to a CIRCLE and that makes the respawn logic to require the fade timer to be finished, but Level.spawn() does not start this timer.

Fixes #2956
Fixes #2959