### PR TITLE
Cache nfo filename locations

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -141,13 +141,15 @@ static PHYSFS_EnumerateCallbackResult remove_from_dictionary_path(void *data, co
 } // namespace
 
 AddonManager::AddonManager(const std::string& addon_directory,
-                           std::vector<Config::Addon>& addon_config) :
+                           std::vector<Config::Addon>& addon_config,
+                           std::map<std::string, std::string>& addon_nfo_filename_hints) :
   m_downloader(),
   m_addon_directory(addon_directory),
   m_cache_directory(FileSystem::join(m_addon_directory, "cache")),
   m_screenshots_cache_directory(FileSystem::join(m_cache_directory, "screenshots")),
   m_repository_url(ADDON_REPOSITORY_URL),
   m_addon_config(addon_config),
+  m_nfo_filename_hints(addon_nfo_filename_hints),
   m_installed_addons(),
   m_repository_addons(),
   m_initialized(false),
@@ -760,6 +762,12 @@ AddonManager::scan_for_archives() const
 std::string
 AddonManager::scan_for_info(const std::string& archive_os_path) const
 {
+  if(m_nfo_filename_hints.find(archive_os_path) != m_nfo_filename_hints.end() &&
+     PHYSFS_exists(m_nfo_filename_hints[archive_os_path].c_str()))
+  {
+    return m_nfo_filename_hints[archive_os_path];
+  }
+
   std::string nfoFilename = "";
   physfsutil::enumerate_files("/", [archive_os_path, &nfoFilename](const std::string& file) {
     if (StringUtil::has_suffix(file, ".nfo"))
@@ -781,6 +789,8 @@ AddonManager::scan_for_info(const std::string& archive_os_path) const
       }
     }
   });
+
+  m_nfo_filename_hints[archive_os_path] = nfoFilename;
 
   return nfoFilename;
 }

--- a/src/addon/addon_manager.hpp
+++ b/src/addon/addon_manager.hpp
@@ -45,6 +45,7 @@ private:
   const std::string m_screenshots_cache_directory;
   std::string m_repository_url;
   std::vector<Config::Addon>& m_addon_config;
+  std::map<std::string, std::string>& m_nfo_filename_hints;
 
   AddonMap m_installed_addons;
   AddonMap m_repository_addons;
@@ -56,7 +57,8 @@ private:
 
 public:
   AddonManager(const std::string& addon_directory,
-               std::vector<Config::Addon>& addon_config);
+               std::vector<Config::Addon>& addon_config,
+               std::map<std::string, std::string>& addon_nfo_filename_hints);
   ~AddonManager() override;
 
   void empty_cache_directory();

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -68,6 +68,7 @@ Config::Config() :
   mobile_controls(SDL_GetNumTouchDevices() > 0),
   m_mobile_controls_scale(1),
   addons(),
+  addon_nfo_filename_hints(),
   developer_mode(false),
   christmas_mode(false),
   transitions_enabled(true),
@@ -336,6 +337,16 @@ Config::load()
           addons.push_back({id, enabled});
         }
       }
+      else if(addon_node.get_name() == "addon_zip")
+      {
+        std::string filename, nfo_filename;
+        auto addon_zip = addon_node.get_mapping();
+        if (addon_zip.get("filename", filename) &&
+            addon_zip.get("nfo_filename", nfo_filename))
+        {
+          addon_nfo_filename_hints.insert({filename, nfo_filename});
+        }
+      }
       else
       {
         log_warning << "Unknown token in config file: " << addon_node.get_name() << std::endl;
@@ -469,6 +480,13 @@ Config::save()
     writer.write("id", addon.id);
     writer.write("enabled", addon.enabled);
     writer.end_list("addon");
+  }
+  for (const auto& addon : addon_nfo_filename_hints)
+  {
+    writer.start_list("addon_zip");
+    writer.write("filename", addon.first);
+    writer.write("nfo_filename", addon.second);
+    writer.end_list("addon_zip");
   }
   writer.end_list("addons");
 

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_SUPERTUX_GAMECONFIG_HPP
 
 #include <optional>
+#include <map>
 
 #include "control/joystick_config.hpp"
 #include "control/keyboard_config.hpp"
@@ -94,6 +95,7 @@ public:
     bool enabled;
   };
   std::vector<Addon> addons;
+  std::map<std::string, std::string> addon_nfo_filename_hints;
 
   bool developer_mode;
   bool christmas_mode;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -501,7 +501,7 @@ void
 Main::launch_game(const CommandLineArguments& args)
 {
   s_timelog.log("addons");
-  m_addon_manager.reset(new AddonManager("addons", g_config->addons));
+  m_addon_manager.reset(new AddonManager("addons", g_config->addons, g_config->addon_nfo_filename_hints));
 
   /** Add-ons or the user directory may have possibly overriden essential files,
       so re-mount the directories, containing those files. */


### PR DESCRIPTION
Well, I thought this would save some startup time but the effect is less than I thought it would be.

Anyway, instead of iterating over all files in each add-on to find the necessary .nfo file, I decided to cache the name of the file for each add-on in the config and then directly ask whether an nfo file can be found at that specific location.

Maybe if you have 1k add-ons installed this will make a noticeable difference.