### PR TITLE
Generate builds with `RelWithDebInfo` instead of `Release`

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         # TODO: Add the OpenBSD, NetBSD and Solaris VMs whenever possible
         vm_os: [freebsd]
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         # FreeBSD does not have glbinding
         # glbiactions/checkout@v4
 

--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -34,14 +34,14 @@ jobs:
         arch: [32, 64]
         os: [ubuntu-20.04]
         compiler: [gcc, clang]
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         glbinding: [ON, OFF]
         exclude:
           - arch: 32
             glbinding: ON
         include:
           - os: ubuntu-20.04
-            build_type: Release
+            build_type: RelWithDebInfo
             compiler: gcc
             arch: 64
             glbinding: OFF

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,11 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12]
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         glbinding: [ON, OFF]
         include:
           - os: macos-12
-            build_type: Release
+            build_type: RelWithDebInfo
             glbinding: OFF
             release: ON
 

--- a/.github/workflows/ubuntu-touch.yml
+++ b/.github/workflows/ubuntu-touch.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         arch: [amd64, arm64, armhf]
         # glbinding is missing as it isn't available on Ubuntu 16.04
         opengl: [glew, sdl]

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: ["Release", "Debug"]
+        build_type: ["RelWithDebInfo", "Debug"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,14 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64, x86]
-        build_type: [Debug, Release]
+        build_type: [Debug, RelWithDebInfo]
         glbinding: [OFF] # [ON, OFF] # FIXME: Fix Windows glbinding builds
         include:
-          - build_type: Release
+          - build_type: RelWithDebInfo
             arch: x64
             glbinding: OFF
             release: ON
-          - build_type: Release
+          - build_type: RelWithDebInfo
             arch: x86
             glbinding: OFF
             release: ON


### PR DESCRIPTION
The resulting Windows builds should now be able to generate meaningful stacktraces.

Fixes #2945.