### PR TITLE
Remove duplicate declaration in .clang-format, fixes Windows builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/SuperTux/SDL_ttf
 [submodule "discord-sdk"]
 	path = external/discord-sdk
-	url = https://github.com/discord/discord-rpc
+	url = https://github.com/SuperTux/discord-rpc
 [submodule "external/fmt"]
 	path = external/fmt
 	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
I updated discord-sdk to latest upstream and applied a fix that removes the duplicate declaration that clang-format complains about. 