### PR TITLE
Use higher precision timing in main loop

### DIFF
--- a/src/supertux/constants.hpp
+++ b/src/supertux/constants.hpp
@@ -19,10 +19,9 @@
 
 #include <string>
 
-// the engine will be run with a logical framerate of 64fps.
-// We chose 64fps here because it is a power of 2, so 1/64 gives an "even"
-// binary fraction...
-static const float LOGICAL_FPS = 64.0;
+// the engine will be run with a logical framerate of 66.666fps, corresponding
+// to a 15 msec gap between steps. Warning: changing this may affect physics
+static const float LOGICAL_FPS = 1000.0f / 15.0f;
 
 // SHIFT_DELTA is used for sliding over 1-tile gaps and collision detection
 static const float SHIFT_DELTA = 7.0f;

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -18,6 +18,7 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_SCREEN_MANAGER_HPP
 #define HEADER_SUPERTUX_SUPERTUX_SCREEN_MANAGER_HPP
 
+#include <chrono>
 #include <memory>
 #include <SDL.h>
 
@@ -78,9 +79,8 @@ private:
   std::unique_ptr<ControllerHUD> m_controller_hud;
   MobileController m_mobile_controller;
 
-  Uint32 last_ticks;
-  Uint32 elapsed_ticks;
-  const Uint32 ms_per_step;
+  std::chrono::steady_clock::time_point last_time;
+  float elapsed_time;
   const float seconds_per_step;
   std::unique_ptr<FPS_Stats> m_fps_statistics;
 


### PR DESCRIPTION
Currently, because inverse frame rates are rounded to milliseconds in `src/supertux/screen_manager.cpp`, the only possible logical frame rates are 1/0.016 = 62.5fps, 1/0.015 = 66.66fps, 1/0.014 = 71.43fps, etc. (The current value `LOGICAL_FPS=64.f` gets rounded to 66.66.). 

This PR makes it possible to change the logical FPS to arbitrary values (like 120fps, if we want a multiple of the most common monitor refresh rate). It should also very slightly reduce jitter from time measurements on high frame rate displays.
