### PR TITLE
Speed up GameObjectManager::get_singleton_by_type

### DIFF
--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -116,10 +116,11 @@ public:
   template<class T>
   T& get_singleton_by_type() const
   {
-    const auto& range = get_objects_by_type<T>();
-    assert(range.begin() != range.end());
-    assert(range.begin()->is_singleton());
-    return *range.begin();
+    const auto& objs = get_objects_by_type_index(typeid(T));
+    assert(objs.size() == 1);
+    T* obj = static_cast<T*>(objs[0]);
+    assert(obj->is_singleton());
+    return *obj;
   }
 
   template<class T>


### PR DESCRIPTION
This mitigates a major cause of lag for me -- calls to `Sector::get_camera()` were _very_ slow on levels with many objects, because each call ended up scanning through the full list of objects. `Sector::get_camera()` gets called a lot, by every `BadGuy::is_offscreen()` and many times in `ParticleSystem::draw()`.  The fix is to look up the singleton objects using (ultimately) the `m_objects_by_type_index` map.

(SuperTux still has a bunch of other performance issues of this type; `GameObjectManager::get_object_count` and `GameObjectManager::get_objects_by_type` are other functions that are called too often and will search the full object list instead of using `m_objects_by_type_index` or an equivalent. Long term, I'd also recommend replacing `m_objects_by_type_index` with a vector indexed by an integer type ids.)