### PR TITLE
Always keep dispensers active

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -220,7 +220,7 @@ BadGuy::update(float dt_sec)
   }
 
   // Deactivate badguy, if off-screen and not falling down.
-  if (m_is_active_flag && is_offscreen() && m_physic.get_velocity_y() <= 0.f)
+  if (m_is_active_flag && is_offscreen() && m_physic.get_velocity_y() <= 0.f && !always_active())
   {
     deactivate();
     set_state(STATE_INACTIVE);

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -121,6 +121,8 @@ public:
     Returns false if enemy is spiky or too large */
   virtual bool is_snipable() const { return false; }
 
+  virtual bool always_active() const { return false; }
+
   bool is_frozen() const;
 
   bool is_in_water() const;

--- a/src/badguy/dispenser.hpp
+++ b/src/badguy/dispenser.hpp
@@ -45,6 +45,7 @@ public:
   virtual void unfreeze(bool melt = true) override;
   virtual bool is_freezable() const override;
   virtual bool is_flammable() const override;
+  virtual bool always_active() const override { return true; }
   virtual bool is_portable() const override;
 
   static std::string class_name() { return "dispenser"; }


### PR DESCRIPTION
Fixes #2837 

This PR makes dispensers active in terms of being an active/inactive badguy always.  This is beneficial for many reasons:
1) Dispensers don't really function as badguys anyway, moreso as other objects, which are always active.
2) It fixes the bug where dispensers scripting would break if you went away from the dispenser and then came back.
3) I believe it fixes an unreported issue where gravity-obeying dispensers would fall into the void if they were placed on moving platforms because the dispenser would load below/inside/off the moving platform because the platform was moving and the dispenser wasn't.

However, I know this could be considered kind of a cheap/non-optimal solution to the bug.  So if anyone has any better suggestions feel free to take a look at it.