### PR TITLE
Index by base classes in GameObjectManager::m_objects_by_type_index

### DIFF
--- a/src/badguy/angrystone.hpp
+++ b/src/badguy/angrystone.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Angry Stone"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(AngryStone)); }
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -68,6 +68,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "BadGuy"; }
   static std::string display_name() { return _("Badguy"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Portable)).add(typeid(BadGuy)); }
 
   virtual std::string get_overlay_size() const { return "1x1"; }
 

--- a/src/badguy/bomb.hpp
+++ b/src/badguy/bomb.hpp
@@ -25,6 +25,7 @@ class Bomb final : public BadGuy
 {
 public:
   Bomb(const Vector& pos, Direction dir, const std::string& custom_sprite = "images/creatures/mr_bomb/bomb.sprite" );
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Bomb)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/badguy/bouncing_snowball.hpp
+++ b/src/badguy/bouncing_snowball.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bouncing Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(BouncingSnowball)); }
 
   virtual GameObjectTypes get_types() const override;
   virtual std::string get_default_sprite_name() const override;

--- a/src/badguy/captainsnowball.hpp
+++ b/src/badguy/captainsnowball.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Captain Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(CaptainSnowball)); }
   virtual bool is_snipable() const override { return true; }
 
   bool might_climb(int width, int height) const;

--- a/src/badguy/corrupted_granito.hpp
+++ b/src/badguy/corrupted_granito.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Corrupted Granito"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(CorruptedGranito)); }
   virtual bool is_snipable() const override { return true; }
   virtual bool is_flammable() const override { return m_type != GRANITO; }
 

--- a/src/badguy/corrupted_granito_big.hpp
+++ b/src/badguy/corrupted_granito_big.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Corrupted Big Granito"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(CorruptedGranitoBig)); }
 
   virtual bool is_snipable()  const override { return false; }
   virtual bool is_freezable() const override { return false; }

--- a/src/badguy/crusher.hpp
+++ b/src/badguy/crusher.hpp
@@ -70,6 +70,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Crusher"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Crusher)); }
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
@@ -115,6 +116,7 @@ class CrusherRoot : public MovingSprite
 {
 public:
   CrusherRoot(Vector position, Crusher::Direction direction, float delay, int layer);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(CrusherRoot)); }
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;

--- a/src/badguy/crystallo.hpp
+++ b/src/badguy/crystallo.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Crystallo"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Crystallo)); }
 
   virtual void active_update(float dt_sec) override;
   virtual bool is_flammable() const override;

--- a/src/badguy/dart.hpp
+++ b/src/badguy/dart.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Dart"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Dart)); }
 
   virtual bool is_flammable() const override;
 

--- a/src/badguy/darttrap.hpp
+++ b/src/badguy/darttrap.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Dart Trap"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyBadguy::get_class_types().add(typeid(DartTrap)); }
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override;

--- a/src/badguy/dispenser.hpp
+++ b/src/badguy/dispenser.hpp
@@ -66,6 +66,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Dispenser"; }
   static std::string display_name() { return _("Dispenser"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Dispenser)); }
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override;

--- a/src/badguy/dive_mine.hpp
+++ b/src/badguy/dive_mine.hpp
@@ -49,6 +49,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Dive Mine"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(DiveMine)); }
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;

--- a/src/badguy/fish_chasing.hpp
+++ b/src/badguy/fish_chasing.hpp
@@ -33,6 +33,7 @@ public:
   static std::string display_name() { return _("Chasing Fish"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "2x2"; }
+  virtual GameObjectClasses get_class_types() const override { return FishSwimming::get_class_types().add(typeid(FishChasing)); }
   virtual ObjectSettings get_settings() override;
 
   std::string get_default_sprite_name() const override;

--- a/src/badguy/fish_harmless.hpp
+++ b/src/badguy/fish_harmless.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Harmless Fish"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return FishSwimming::get_class_types().add(typeid(FishHarmless)); }
   virtual std::string get_overlay_size() const override { return "1x1"; }
 
   GameObjectTypes get_types() const override { return {}; }

--- a/src/badguy/fish_jumping.hpp
+++ b/src/badguy/fish_jumping.hpp
@@ -40,6 +40,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Jumping Fish"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(FishJumping)); }
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;

--- a/src/badguy/fish_swimming.hpp
+++ b/src/badguy/fish_swimming.hpp
@@ -40,6 +40,7 @@ public:
   static std::string display_name() { return _("Swimming Fish"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "2x1"; }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(FishSwimming)); }
   virtual ObjectSettings get_settings() override;
 
   virtual GameObjectTypes get_types() const override;

--- a/src/badguy/flame.hpp
+++ b/src/badguy/flame.hpp
@@ -46,6 +46,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Flame"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Flame)); }
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/flyingsnowball.hpp
+++ b/src/badguy/flyingsnowball.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Flying Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(FlyingSnowBall)); }
   virtual bool is_snipable() const override { return true; }
 
 protected:

--- a/src/badguy/ghosttree.hpp
+++ b/src/badguy/ghosttree.hpp
@@ -42,6 +42,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Ghost Tree"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(GhostTree)); }
 
   virtual void on_flip(float height) override;
 

--- a/src/badguy/ghoul.hpp
+++ b/src/badguy/ghoul.hpp
@@ -30,6 +30,7 @@ public:
   static std::string display_name() { return _("Ghoul"); }
   std::string get_class_name() const override { return class_name(); }
   std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Ghoul)); }
   bool is_freezable() const override;
   bool is_flammable() const override;
   virtual bool is_snipable() const override { return true; }

--- a/src/badguy/goldbomb.hpp
+++ b/src/badguy/goldbomb.hpp
@@ -49,6 +49,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Gold Bomb"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(GoldBomb)); }
   virtual bool is_snipable() const override { return true; }
 
   virtual void stop_looping_sounds() override;

--- a/src/badguy/granito.hpp
+++ b/src/badguy/granito.hpp
@@ -51,6 +51,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Granito"; }
   static std::string display_name() { return _("Granito"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Granito)); }
 
   virtual bool is_snipable() const override { return false; }
   virtual bool is_freezable() const override { return false; }

--- a/src/badguy/granito_big.hpp
+++ b/src/badguy/granito_big.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "GranitoBig"; }
   static std::string display_name() { return _("Big Granito"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Granito::get_class_types().add(typeid(GranitoBig)); }
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override;

--- a/src/badguy/granito_giant.hpp
+++ b/src/badguy/granito_giant.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Giant Granito"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(GranitoGiant)); }
 
   virtual void kill_fall() override;
 

--- a/src/badguy/haywire.hpp
+++ b/src/badguy/haywire.hpp
@@ -45,6 +45,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Haywire"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Haywire)); }
   virtual bool is_snipable() const override { return true; }
 
   inline bool is_exploding() const { return m_is_exploding; }

--- a/src/badguy/igel.hpp
+++ b/src/badguy/igel.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Igel"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Igel)); }
 
   virtual bool is_freezable() const override { return true; }
   virtual void unfreeze(bool melt = true) override;

--- a/src/badguy/jumpy.hpp
+++ b/src/badguy/jumpy.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Jumpy"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Jumpy)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/badguy/kamikazesnowball.hpp
+++ b/src/badguy/kamikazesnowball.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Kamikaze Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(KamikazeSnowball)); }
   virtual bool is_snipable() const override { return true; }
 
 protected:
@@ -63,6 +64,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Leafshot"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return KamikazeSnowball::get_class_types().add(typeid(LeafShot)); }
 
   virtual bool is_snipable() const override { return true; }
 

--- a/src/badguy/kugelblitz.hpp
+++ b/src/badguy/kugelblitz.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Kugelblitz"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Kugelblitz)); }
 
   void explode();
 

--- a/src/badguy/livefire.hpp
+++ b/src/badguy/livefire.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Walking Flame"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(LiveFire)); }
 
 private:
   std::string death_sound;
@@ -70,6 +71,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Sleeping Flame"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return LiveFire::get_class_types().add(typeid(LiveFireAsleep)); }
 
 private:
   LiveFireAsleep(const LiveFireAsleep&) = delete;
@@ -88,6 +90,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Dormant Flame"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return LiveFire::get_class_types().add(typeid(LiveFireDormant)); }
 
 private:
   LiveFireDormant(const LiveFireDormant&) = delete;

--- a/src/badguy/mole.hpp
+++ b/src/badguy/mole.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mole"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Mole)); }
 
   virtual bool is_snipable() const override { return true; }
 

--- a/src/badguy/mole_rock.hpp
+++ b/src/badguy/mole_rock.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mole's rock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(MoleRock)); }
 
 protected:
   const BadGuy* parent; /**< collisions with this BadGuy will be ignored */

--- a/src/badguy/mrbomb.hpp
+++ b/src/badguy/mrbomb.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mr. Bomb"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(MrBomb)); }
   virtual bool is_snipable() const override { return true; }
 
   GameObjectTypes get_types() const override;

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -48,6 +48,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mr. Iceblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(MrIceBlock)); }
 
   virtual bool is_snipable() const override { return ice_state != ICESTATE_KICKED; }
   virtual bool is_freezable() const override;

--- a/src/badguy/mrtree.hpp
+++ b/src/badguy/mrtree.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mr. Tree"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(MrTree)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/badguy/owl.hpp
+++ b/src/badguy/owl.hpp
@@ -44,6 +44,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Owl"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Owl)); }
 
   virtual ObjectSettings get_settings() override;
   virtual bool is_snipable() const override { return true; }

--- a/src/badguy/plant.hpp
+++ b/src/badguy/plant.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Plant"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Plant)); }
 
 protected:
   enum PlantState {

--- a/src/badguy/rcrystallo.hpp
+++ b/src/badguy/rcrystallo.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Roof Crystallo"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(RCrystallo)); }
 
   virtual void active_update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/badguy/root.hpp
+++ b/src/badguy/root.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Root"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Root)); }
 
   virtual bool is_flammable() const override { return false; }
   virtual bool is_freezable() const override { return false; }

--- a/src/badguy/root_sapling.hpp
+++ b/src/badguy/root_sapling.hpp
@@ -40,6 +40,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Root Sapling"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(RootSapling)); }
 
   virtual void on_flip(float height) override;
 

--- a/src/badguy/scrystallo.hpp
+++ b/src/badguy/scrystallo.hpp
@@ -30,6 +30,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Sleeping Crystallo"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(SCrystallo)); }
 
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;

--- a/src/badguy/short_fuse.hpp
+++ b/src/badguy/short_fuse.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Short Fuse"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(ShortFuse)); }
 
 protected:
   virtual HitResponse collision_player (Player& player, const CollisionHit& hit) override;

--- a/src/badguy/skydive.hpp
+++ b/src/badguy/skydive.hpp
@@ -42,6 +42,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Skydive"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(SkyDive)); }
   virtual bool is_snipable() const override { return true; }
 
 protected:

--- a/src/badguy/smartball.hpp
+++ b/src/badguy/smartball.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mrs. Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(SmartBall)); }
 
   virtual bool is_snipable() const override { return true; }
   virtual bool is_freezable() const override;

--- a/src/badguy/smartblock.hpp
+++ b/src/badguy/smartblock.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mrs. Iceblock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+    virtual GameObjectClasses get_class_types() const override { return MrIceBlock::get_class_types().add(typeid(SmartBlock)); }
 
   GameObjectTypes get_types() const override { return {}; }
 

--- a/src/badguy/snail.hpp
+++ b/src/badguy/snail.hpp
@@ -42,6 +42,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Snail"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Snail)); }
 
   virtual GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/badguy/snowball.hpp
+++ b/src/badguy/snowball.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Mr. Snowball"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(SnowBall)); }
 
   virtual bool is_snipable() const override { return true; }
   virtual bool is_freezable() const override;

--- a/src/badguy/snowman.hpp
+++ b/src/badguy/snowman.hpp
@@ -28,6 +28,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Snowman"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Snowman)); }
 
 protected:
   void loose_head();

--- a/src/badguy/spiky.hpp
+++ b/src/badguy/spiky.hpp
@@ -30,6 +30,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Spiky"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Spiky)); }
 
 private:
   Spiky(const Spiky&) = delete;

--- a/src/badguy/sspiky.hpp
+++ b/src/badguy/sspiky.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Sleeping Spiky"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(SSpiky)); }
   virtual void after_editor_set() override;
 
 protected:

--- a/src/badguy/stalactite.hpp
+++ b/src/badguy/stalactite.hpp
@@ -41,6 +41,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Stalactite"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyBadguy::get_class_types().add(typeid(Stalactite)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/stumpy.hpp
+++ b/src/badguy/stumpy.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Stumpy"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(Stumpy)); }
 
 protected:
   enum MyState {

--- a/src/badguy/tarantula.hpp
+++ b/src/badguy/tarantula.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Tarantula"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Tarantula)); }
   virtual bool is_snipable() const override;
 
   virtual GameObjectTypes get_types() const override;

--- a/src/badguy/toad.hpp
+++ b/src/badguy/toad.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Toad"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Toad)); }
   virtual bool is_snipable() const override { return true; }
 
 protected:

--- a/src/badguy/totem.hpp
+++ b/src/badguy/totem.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Totem"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Totem)); }
   virtual bool is_snipable() const override { return true; }
 
 protected:

--- a/src/badguy/treewillowisp.hpp
+++ b/src/badguy/treewillowisp.hpp
@@ -27,6 +27,7 @@ class TreeWillOWisp final : public BadGuy
 public:
   TreeWillOWisp(GhostTree* tree, const Vector& pos, float radius, float speed);
   ~TreeWillOWisp() override;
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(TreeWillOWisp)); }
 
   virtual void activate() override;
   virtual void active_update(float dt_sec) override;

--- a/src/badguy/viciousivy.hpp
+++ b/src/badguy/viciousivy.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Vicious Ivy"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(ViciousIvy)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/badguy/walking_badguy.hpp
+++ b/src/badguy/walking_badguy.hpp
@@ -52,6 +52,7 @@ public:
                 const std::string& walk_right_action,
                 int layer = LAYER_OBJECTS,
                 const std::string& light_sprite_name = "images/objects/lightmap_light/lightmap_light-medium.sprite");
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(WalkingBadguy)); }
 
   virtual void initialize() override;
   virtual void active_update(float dt_sec) override;

--- a/src/badguy/walking_candle.hpp
+++ b/src/badguy/walking_candle.hpp
@@ -40,6 +40,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Walking Candle"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(WalkingCandle)); }
 
 private:
   Color lightcolor;

--- a/src/badguy/walkingleaf.hpp
+++ b/src/badguy/walkingleaf.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Walking Leaf"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WalkingBadguy::get_class_types().add(typeid(WalkingLeaf)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/badguy/willowisp.hpp
+++ b/src/badguy/willowisp.hpp
@@ -68,6 +68,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "WillOWisp"; }
   static std::string display_name() { return _("Will o' Wisp"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(WillOWisp)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void move_to(const Vector& pos) override;

--- a/src/badguy/yeti.hpp
+++ b/src/badguy/yeti.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Yeti"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Yeti)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/badguy/yeti_stalactite.hpp
+++ b/src/badguy/yeti_stalactite.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Yeti's Stalactite"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Stalactite::get_class_types().add(typeid(YetiStalactite)); }
 
   void start_shaking();
   bool is_hanging() const;

--- a/src/badguy/zeekling.hpp
+++ b/src/badguy/zeekling.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Zeekling"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Zeekling)); }
   virtual bool is_snipable() const override { return true; }
 
 private:

--- a/src/editor/bezier_marker.hpp
+++ b/src/editor/bezier_marker.hpp
@@ -26,6 +26,7 @@ class BezierMarker final : public MarkerObject
 {
 public:
   BezierMarker(Path::Node* node, Vector* bezier_pos);
+  virtual GameObjectClasses get_class_types() const override { return MarkerObject::get_class_types().add(typeid(BezierMarker)); }
 
   virtual void move_to(const Vector& pos) override;
   virtual Vector get_point_vector() const override;

--- a/src/editor/marker_object.hpp
+++ b/src/editor/marker_object.hpp
@@ -28,6 +28,7 @@ class MarkerObject : public MovingObject
 public:
   MarkerObject(const Vector& pos);
   MarkerObject();
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(MarkerObject)); }
 
   virtual void update(float dt_sec) override {}
   virtual void draw(DrawingContext& context) override;

--- a/src/editor/node_marker.hpp
+++ b/src/editor/node_marker.hpp
@@ -25,6 +25,7 @@ class NodeMarker final : public MarkerObject
 {
 public:
   NodeMarker(std::vector<Path::Node>::iterator node_iterator, size_t id_, UID before, UID after);
+  virtual GameObjectClasses get_class_types() const override { return MarkerObject::get_class_types().add(typeid(NodeMarker)); }
 
   virtual void move_to(const Vector& pos) override;
   virtual void editor_delete() override;

--- a/src/editor/resize_marker.hpp
+++ b/src/editor/resize_marker.hpp
@@ -32,6 +32,7 @@ public:
 
 public:
   ResizeMarker(MovingObject* obj, Side vert, Side horz);
+  virtual GameObjectClasses get_class_types() const override { return MarkerObject::get_class_types().add(typeid(ResizeMarker)); }
 
   void move_to(const Vector& pos) override;
   Vector get_point_vector() const override;

--- a/src/object/ambient_light.hpp
+++ b/src/object/ambient_light.hpp
@@ -37,6 +37,7 @@ public:
   static std::string display_name() { return _("Ambient Light"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/ambient_light.png"; }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(AmbientLight)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/ambient_sound.hpp
+++ b/src/object/ambient_sound.hpp
@@ -50,6 +50,7 @@ public:
   static std::string display_name() { return _("Ambient Sound"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(AmbientSound)); }
 
   virtual void draw(DrawingContext& context) override;
 

--- a/src/object/background.hpp
+++ b/src/object/background.hpp
@@ -50,6 +50,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Background"; }
   static std::string display_name() { return _("Background"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Background)); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/background.png";

--- a/src/object/bicycle_platform.hpp
+++ b/src/object/bicycle_platform.hpp
@@ -28,6 +28,7 @@ class BicyclePlatformChild : public MovingSprite
 
 public:
   BicyclePlatformChild(const ReaderMapping& reader, float angle_offset, BicyclePlatform& parent);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(BicyclePlatformChild)); }
 
   virtual void update(float dt_sec) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
@@ -66,6 +67,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bicycle Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(BicyclePlatform)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void editor_delete() override;

--- a/src/object/block.hpp
+++ b/src/object/block.hpp
@@ -30,6 +30,8 @@ public:
   Block(const Vector& pos, const std::string& sprite_file);
   Block(const ReaderMapping& mapping, const std::string& sprite_file);
 
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Block)); }
+
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -61,6 +61,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bonus Block"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Block::get_class_types().add(typeid(BonusBlock)); }
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;

--- a/src/object/bouncy_coin.hpp
+++ b/src/object/bouncy_coin.hpp
@@ -27,6 +27,7 @@ class BouncyCoin final : public GameObject
 public:
   BouncyCoin(const Vector& pos, bool emerge = false,
              const std::string& sprite_path = "images/objects/coin/coin.sprite");
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(BouncyCoin)); }
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual bool is_saveable() const override {

--- a/src/object/brick.hpp
+++ b/src/object/brick.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Brick"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Block::get_class_types().add(typeid(Brick)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
@@ -69,6 +70,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Heavy Brick"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Brick::get_class_types().add(typeid(HeavyBrick)); }
 
   GameObjectTypes get_types() const override { return {}; }
 

--- a/src/object/bullet.hpp
+++ b/src/object/bullet.hpp
@@ -31,6 +31,8 @@ class Bullet final : public MovingObject
 public:
   Bullet(const Vector& pos, const Vector& xm, Direction dir, BonusType type, Player& player);
 
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Bullet)); }
+
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual void collision_solid(const CollisionHit& hit) override;

--- a/src/object/bumper.hpp
+++ b/src/object/bumper.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Bumper"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyObject::get_class_types().add(typeid(Bumper)); }
 
   virtual void after_editor_set() override;
   virtual void on_flip(float height) override;

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -67,6 +67,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Camera"; }
   static std::string display_name() { return _("Camera"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Camera)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/candle.hpp
+++ b/src/object/candle.hpp
@@ -42,6 +42,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Candle"; }
   static std::string display_name() { return _("Candle"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Candle)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/circleplatform.hpp
+++ b/src/object/circleplatform.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Circular Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(CirclePlatform)); }
 
 private:
   virtual void initialize();

--- a/src/object/cloud_particle_system.hpp
+++ b/src/object/cloud_particle_system.hpp
@@ -49,6 +49,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "CloudParticleSystem"; }
   static std::string display_name() { return _("Cloud Particles"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem::get_class_types().add(typeid(CloudParticleSystem)); }
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -43,6 +43,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Coin"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Coin)); }
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
@@ -96,6 +97,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Heavy Coin"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Coin::get_class_types().add(typeid(HeavyCoin)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/coin_explode.hpp
+++ b/src/object/coin_explode.hpp
@@ -25,6 +25,7 @@ class CoinExplode final : public GameObject
 public:
   CoinExplode(const Vector& pos, bool count_stats = true,
               const std::string& sprite_path = "images/objects/coin/coin.sprite");
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(CoinExplode)); }
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual bool is_saveable() const override {

--- a/src/object/coin_rain.hpp
+++ b/src/object/coin_rain.hpp
@@ -27,6 +27,7 @@ class CoinRain final : public GameObject
 public:
   CoinRain(const Vector& pos, bool emerge=false, bool count_stats = true,
            const std::string& sprite_path = "images/objects/coin/coin.sprite");
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(CoinRain)); }
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual bool is_saveable() const override {

--- a/src/object/conveyor_belt.hpp
+++ b/src/object/conveyor_belt.hpp
@@ -46,6 +46,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "ConveyorBelt"; }
   static std::string display_name() { return _("Conveyor Belt"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(ConveyorBelt)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -53,6 +53,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "CustomParticleSystem"; }
   static std::string display_name() { return _("Custom Particles"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem_Interactive::get_class_types().add(typeid(CustomParticleSystem)); }
   virtual void save(Writer& writer) override;
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/custom_particle_system_file.hpp
+++ b/src/object/custom_particle_system_file.hpp
@@ -38,6 +38,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Custom Particles from file"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return CustomParticleSystem::get_class_types().add(typeid(CustomParticleSystemFile)); }
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override {

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -48,6 +48,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Decal"; }
   static std::string display_name() { return _("Decal"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Decal)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/display_effect.hpp
+++ b/src/object/display_effect.hpp
@@ -34,6 +34,7 @@ public:
 public:
   DisplayEffect(const std::string& name = "");
   ~DisplayEffect() override;
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(DisplayEffect)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/electrifier.hpp
+++ b/src/object/electrifier.hpp
@@ -35,6 +35,7 @@ public:
 public:
   Electrifier(TileChangeMap replacements, float seconds);
   Electrifier(uint32_t oldtile, uint32_t newtile, float seconds);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Electrifier)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/endsequence.hpp
+++ b/src/object/endsequence.hpp
@@ -27,6 +27,7 @@ class EndSequence : public GameObject
 public:
   EndSequence();
   ~EndSequence() override;
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(EndSequence)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/endsequence_fireworks.hpp
+++ b/src/object/endsequence_fireworks.hpp
@@ -25,6 +25,7 @@ class EndSequenceFireworks final : public EndSequence
 public:
   EndSequenceFireworks();
   ~EndSequenceFireworks() override;
+  virtual GameObjectClasses get_class_types() const override { return EndSequence::get_class_types().add(typeid(EndSequenceFireworks)); }
   virtual void draw(DrawingContext& context) override;
 
 protected:

--- a/src/object/endsequence_walk.hpp
+++ b/src/object/endsequence_walk.hpp
@@ -25,6 +25,7 @@ class EndSequenceWalk final : public EndSequence
 public:
   EndSequenceWalk();
   ~EndSequenceWalk() override;
+  virtual GameObjectClasses get_class_types() const override { return EndSequence::get_class_types().add(typeid(EndSequenceWalk)); }
   virtual void draw(DrawingContext& context) override;
 
 protected:

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Explosion"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Explosion)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/fallblock.hpp
+++ b/src/object/fallblock.hpp
@@ -40,6 +40,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Falling Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(FallBlock)); }
 
   virtual void on_flip(float height) override;
 

--- a/src/object/falling_coin.hpp
+++ b/src/object/falling_coin.hpp
@@ -26,6 +26,7 @@ class FallingCoin final : public GameObject
 {
 public:
   FallingCoin(const Vector& start_position, float x_vel);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(FallingCoin)); }
 
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;

--- a/src/object/firefly.hpp
+++ b/src/object/firefly.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Checkpoint"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Firefly)); }
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;

--- a/src/object/fireworks.hpp
+++ b/src/object/fireworks.hpp
@@ -26,6 +26,7 @@ class Fireworks final : public GameObject
 {
 public:
   Fireworks();
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Fireworks)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/floating_image.hpp
+++ b/src/object/floating_image.hpp
@@ -39,6 +39,7 @@ public:
   ~FloatingImage() override;
 
   virtual bool is_saveable() const override { return false; }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(FloatingImage)); }
   virtual std::string get_exposed_class_name() const override { return "FloatingImage"; }
 
   virtual void update(float dt_sec) override;

--- a/src/object/floating_text.hpp
+++ b/src/object/floating_text.hpp
@@ -28,6 +28,8 @@ class FloatingText final : public GameObject
 public:
   FloatingText(const Vector& pos, const std::string& text_);
   FloatingText(const Vector& pos, int s);  // use this for score, for instance
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(FloatingText)); }
+
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/flower.hpp
+++ b/src/object/flower.hpp
@@ -30,6 +30,7 @@ class Flower final : public MovingObject
 
 public:
   Flower(BonusType type, const std::string& custom_sprite = "");
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Flower)); }
 
   virtual bool is_saveable() const override { return false; }
 

--- a/src/object/ghost_particle_system.hpp
+++ b/src/object/ghost_particle_system.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Ghost Particles"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem::get_class_types().add(typeid(GhostParticleSystem)); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/ghostparticles.png";

--- a/src/object/gradient.hpp
+++ b/src/object/gradient.hpp
@@ -48,6 +48,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Gradient"; }
   static std::string display_name() { return _("Gradient"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Gradient)); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/gradient.png";

--- a/src/object/growup.hpp
+++ b/src/object/growup.hpp
@@ -25,6 +25,7 @@ class GrowUp final : public MovingSprite
 {
 public:
   GrowUp(const Vector& pos, Direction direction = Direction::RIGHT, const std::string& custom_sprite = "");
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(GrowUp)); }
 
   virtual bool is_saveable() const override { return false; }
 

--- a/src/object/hurting_platform.hpp
+++ b/src/object/hurting_platform.hpp
@@ -30,6 +30,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Hurting Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Platform::get_class_types().add(typeid(HurtingPlatform)); }
 
 private:
   HurtingPlatform(const HurtingPlatform&) = delete;

--- a/src/object/infoblock.hpp
+++ b/src/object/infoblock.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Info Block"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Block::get_class_types().add(typeid(InfoBlock)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/invisible_block.hpp
+++ b/src/object/invisible_block.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Invisible Block"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Block::get_class_types().add(typeid(InvisibleBlock)); }
 
   virtual void draw(DrawingContext& context) override;
   virtual bool collides(GameObject& other, const CollisionHit& hit) const override;

--- a/src/object/invisible_wall.hpp
+++ b/src/object/invisible_wall.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Invisible Wall"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(InvisibleWall)); }
 
   virtual bool has_variable_size() const override { return true; }
 

--- a/src/object/ispy.hpp
+++ b/src/object/ispy.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Ispy"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyObject::get_class_types().add(typeid(Ispy)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/key.hpp
+++ b/src/object/key.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Key"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Key)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/lantern.hpp
+++ b/src/object/lantern.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Lantern"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Rock::get_class_types().add(typeid(Lantern)); }
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override { return {}; }

--- a/src/object/level_time.hpp
+++ b/src/object/level_time.hpp
@@ -74,6 +74,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "LevelTime"; }
   static std::string display_name() { return _("Time Limit"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(LevelTime)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/light.hpp
+++ b/src/object/light.hpp
@@ -31,6 +31,8 @@ public:
     return false;
   }
 
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Light)); }
+
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
 

--- a/src/object/lit_object.hpp
+++ b/src/object/lit_object.hpp
@@ -45,6 +45,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "LitObject"; }
   static std::string display_name() { return _("Lit object"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(LitObject)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/magicblock.hpp
+++ b/src/object/magicblock.hpp
@@ -41,6 +41,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Magic Tile"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(MagicBlock)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -57,6 +57,7 @@ public:
   static std::string class_name() { return "moving-sprite"; }
   virtual std::string get_class_name() const override { return class_name(); }
   virtual std::string get_exposed_class_name() const override { return "MovingSprite"; }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(MovingSprite)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/music_object.hpp
+++ b/src/object/music_object.hpp
@@ -41,6 +41,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Music"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(MusicObject)); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/music.png"; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/oneup.hpp
+++ b/src/object/oneup.hpp
@@ -25,6 +25,7 @@ class OneUp final : public MovingSprite
 {
 public:
   OneUp(const Vector& pos, Direction direction = Direction::RIGHT);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(OneUp)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/particle_zone.hpp
+++ b/src/object/particle_zone.hpp
@@ -37,6 +37,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Particle zone"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(ParticleZone)); }
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/particles.hpp
+++ b/src/object/particles.hpp
@@ -35,6 +35,7 @@ public:
             const float min_initial_velocity, const float max_initial_velocity,
             const Vector& acceleration, int number, Color color,
             int size, float life_time, int drawing_layer);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Particles)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/particlesystem.hpp
+++ b/src/object/particlesystem.hpp
@@ -63,6 +63,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "ParticleSystem"; }
   static std::string display_name() { return _("Particle system"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(ParticleSystem)); }
   virtual ObjectSettings get_settings() override;
 
   /**

--- a/src/object/particlesystem_interactive.hpp
+++ b/src/object/particlesystem_interactive.hpp
@@ -47,6 +47,7 @@ public:
   virtual std::string get_display_name() const override {
     return _("Interactive particle system");
   }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem::get_class_types().add(typeid(ParticleSystem_Interactive)); }
 
 protected:
   virtual int collision(Particle* particle, const Vector& movement);

--- a/src/object/path_gameobject.hpp
+++ b/src/object/path_gameobject.hpp
@@ -44,6 +44,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Path"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(PathGameObject)); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/path.png";

--- a/src/object/platform.hpp
+++ b/src/object/platform.hpp
@@ -53,6 +53,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Platform"; }
   static std::string display_name() { return _("Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Platform)); }
 
   virtual void editor_update() override;
 

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -89,6 +89,7 @@ public:
   virtual bool has_object_manager_priority() const override { return true; }
   virtual std::string get_exposed_class_name() const override { return "Player"; }
   virtual void remove_me() override;
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Player)); }
 
   int get_id() const { return m_id; }
   void set_id(int id);

--- a/src/object/pneumatic_platform.hpp
+++ b/src/object/pneumatic_platform.hpp
@@ -28,6 +28,7 @@ class PneumaticPlatformChild final : public MovingSprite
 public:
   PneumaticPlatformChild(const ReaderMapping& reader, bool left, PneumaticPlatform& parent);
   ~PneumaticPlatformChild() override;
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(PneumaticPlatformChild)); }
 
   virtual HitResponse collision(GameObject& other, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
@@ -64,6 +65,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Pneumatic Platform"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(PneumaticPlatform)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Powerup"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(PowerUp)); }
 
   std::vector<std::string> get_patches() const override;
   virtual ObjectSettings get_settings() override;

--- a/src/object/pulsing_light.hpp
+++ b/src/object/pulsing_light.hpp
@@ -27,6 +27,7 @@ class PulsingLight final : public Light
 public:
   PulsingLight(const Vector& center, float cycle_len = 5.0, float min_alpha = 0.0, float max_alpha = 1.0, const Color& color = Color(1.0, 1.0, 1.0, 1.0));
   ~PulsingLight() override;
+  virtual GameObjectClasses get_class_types() const override { return Light::get_class_types().add(typeid(PulsingLight)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/pushbutton.hpp
+++ b/src/object/pushbutton.hpp
@@ -31,6 +31,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Button"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyObject::get_class_types().add(typeid(PushButton)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/rain_particle_system.hpp
+++ b/src/object/rain_particle_system.hpp
@@ -48,6 +48,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "RainParticleSystem"; }
   static std::string display_name() { return _("Rain Particles"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem_Interactive::get_class_types().add(typeid(RainParticleSystem)); }
   virtual ObjectSettings get_settings() override;
 
   /**

--- a/src/object/rainsplash.hpp
+++ b/src/object/rainsplash.hpp
@@ -28,6 +28,7 @@ class RainSplash final : public GameObject
 public:
   RainSplash(const Vector& pos, bool vertical);
   ~RainSplash() override;
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(RainSplash)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/rock.hpp
+++ b/src/object/rock.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Rock"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Portable)).add(typeid(Rock)); }
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override;

--- a/src/object/rublight.hpp
+++ b/src/object/rublight.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Rublight"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(RubLight)); }
   virtual ObjectSettings get_settings() override;
 
   virtual void on_flip(float height) override;

--- a/src/object/rusty_trampoline.hpp
+++ b/src/object/rusty_trampoline.hpp
@@ -39,6 +39,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Rusty Trampoline"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Rock::get_class_types().add(typeid(RustyTrampoline)); }
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override { return {}; }

--- a/src/object/scripted_object.hpp
+++ b/src/object/scripted_object.hpp
@@ -45,6 +45,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "ScriptedObject"; }
   static std::string display_name() { return _("Scripted Object"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(ScriptedObject)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/shard.hpp
+++ b/src/object/shard.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Shard"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyObject::get_class_types().add(typeid(Shard)); }
 
 protected:
   Physic m_physic;

--- a/src/object/smoke_cloud.hpp
+++ b/src/object/smoke_cloud.hpp
@@ -26,6 +26,7 @@ class SmokeCloud final : public GameObject
 {
 public:
   SmokeCloud(const Vector& pos);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(SmokeCloud)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/snow_particle_system.hpp
+++ b/src/object/snow_particle_system.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Snow Particles"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return ParticleSystem::get_class_types().add(typeid(SnowParticleSystem)); }
   virtual ObjectSettings get_settings() override;
 
   virtual const std::string get_icon_path() const override

--- a/src/object/sound_object.hpp
+++ b/src/object/sound_object.hpp
@@ -40,6 +40,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "SoundObject"; }
   static std::string display_name() { return _("Sound"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(SoundObject)); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/sound.png"; }
 
   virtual ObjectSettings get_settings() override;

--- a/src/object/spawnpoint.hpp
+++ b/src/object/spawnpoint.hpp
@@ -47,6 +47,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Spawnpoint"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(SpawnPointMarker)); }
   virtual ObjectSettings get_settings() override;
 
   virtual int get_layer() const override { return LAYER_FOREGROUND1; }

--- a/src/object/specialriser.hpp
+++ b/src/object/specialriser.hpp
@@ -27,6 +27,7 @@ class SpecialRiser final : public MovingObject
 {
 public:
   SpecialRiser(const Vector& pos, std::unique_ptr<MovingObject> child, bool is_solid = false);
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(SpecialRiser)); }
   virtual bool is_saveable() const override {
     return false;
   }

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -58,6 +58,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Spotlight"; }
   static std::string display_name() { return _("Spotlight"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Spotlight)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/sprite_particle.hpp
+++ b/src/object/sprite_particle.hpp
@@ -37,6 +37,7 @@ public:
                  const Vector& position, AnchorPoint anchor,
                  const Vector& velocity, const Vector& acceleration,
                  int drawing_layer = LAYER_OBJECTS-1, bool notimeout = false, Color color = Color::WHITE);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(SpriteParticle)); }
   ~SpriteParticle() override;
 
 protected:

--- a/src/object/star.hpp
+++ b/src/object/star.hpp
@@ -26,6 +26,7 @@ class Star final : public MovingSprite
 {
 public:
   Star(const Vector& pos, Direction direction = Direction::RIGHT, const std::string& custom_sprite = "");
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Star)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/object/sticky_object.hpp
+++ b/src/object/sticky_object.hpp
@@ -31,6 +31,7 @@ public:
                int layer = LAYER_OBJECTS, CollisionGroup collision_group = COLGROUP_MOVING);
   StickyObject(const ReaderMapping& reader, const std::string& sprite_name,
                int layer = LAYER_OBJECTS, CollisionGroup collision_group = COLGROUP_MOVING);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(StickyObject)); }
 
   virtual void update(float dt_sec) override;
 
@@ -80,6 +81,7 @@ public:
                int layer = LAYER_OBJECTS, CollisionGroup collision_group = COLGROUP_MOVING);
   StickyBadguy(const ReaderMapping& reader, const std::string& sprite_name,
                int layer = LAYER_OBJECTS, CollisionGroup collision_group = COLGROUP_MOVING);
+  virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(StickyBadguy)); }
 
   virtual void sticky_update(float dt_sec);
 

--- a/src/object/text_array_object.hpp
+++ b/src/object/text_array_object.hpp
@@ -56,6 +56,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "TextArrayObject"; }
   static std::string display_name() { return _("Text array"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(TextArrayObject)); }
 
   virtual const std::string get_icon_path() const override {
     return "images/engine/editor/textarray.png";

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -51,6 +51,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "TextObject"; }
   static std::string display_name() { return _("Text"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(TextObject)); }
 
   virtual const std::string get_icon_path() const override { return "images/engine/editor/textarray.png"; }
 

--- a/src/object/textscroller.hpp
+++ b/src/object/textscroller.hpp
@@ -44,6 +44,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Text Scroller"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(TextScroller)); }
   virtual const std::string get_icon_path() const override { return "images/engine/editor/textscroller.png"; }
 
   void set_default_speed(float default_speed);

--- a/src/object/thunderstorm.hpp
+++ b/src/object/thunderstorm.hpp
@@ -51,6 +51,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Thunderstorm"; }
   static std::string display_name() { return _("Thunderstorm"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Thunderstorm)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -65,6 +65,7 @@ public:
   virtual const std::string get_icon_path() const override { return "images/engine/editor/tilemap.png"; }
   static std::string display_name() { return _("Tilemap"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(TileMap)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -46,6 +46,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Torch"; }
   static std::string display_name() { return _("Torch"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(Torch)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/object/trampoline.hpp
+++ b/src/object/trampoline.hpp
@@ -36,6 +36,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Trampoline"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return Rock::get_class_types().add(typeid(Trampoline)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/object/unstable_tile.hpp
+++ b/src/object/unstable_tile.hpp
@@ -41,6 +41,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Unstable Tile"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(UnstableTile)); }
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;

--- a/src/object/vertical_stripes.hpp
+++ b/src/object/vertical_stripes.hpp
@@ -28,6 +28,8 @@ public:
 	VerticalStripes();
 	~VerticalStripes() override;
 
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(VerticalStripes)); }
+
   virtual bool is_singleton() const override { return true; }
   virtual bool is_saveable() const override { return false; }
   virtual void update(float dt_sec) override;

--- a/src/object/water_drop.hpp
+++ b/src/object/water_drop.hpp
@@ -27,6 +27,8 @@ class WaterDrop final : public MovingSprite
 public:
   WaterDrop(const Vector& pos, const std::string& sprite_path_, const Vector& velocity);
 
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(WaterDrop)); }
+
   virtual void update(float dt_sec) override;
   virtual void collision_solid(const CollisionHit& hit) override;
   virtual HitResponse collision(GameObject& other, const CollisionHit& ) override;

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -35,6 +35,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Weak Tile"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(WeakBlock)); }
 
   std::vector<std::string> get_patches() const override;
   void update_version() override;

--- a/src/object/wind.hpp
+++ b/src/object/wind.hpp
@@ -42,6 +42,7 @@ public:
   virtual std::string get_exposed_class_name() const override { return "Wind"; }
   static std::string display_name() { return _("Wind"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Wind)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -109,6 +109,14 @@ GameObject::save()
   return save_stream.str();
 }
 
+GameObjectClasses
+GameObject::get_class_types() const {
+    GameObjectClasses g{};
+    // All class types except GameObject, since everything implements GameObject
+    // g.add(typeid(GameObject));
+    return g;
+}
+
 ObjectSettings
 GameObject::get_settings()
 {

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <typeindex>
 
 #include "editor/object_settings.hpp"
 #include "supertux/game_object_component.hpp"
@@ -46,6 +47,23 @@ struct GameObjectType
   const std::string name;
 };
 typedef std::vector<GameObjectType> GameObjectTypes;
+
+/**
+ A helper structure to list all the type_indexes of the classes in the
+ type hierarchy of a given class. This makes it easier to register e.g.
+ a MrIceblock in lists for MrIceBlock, WalkingBadguy, Badguy, Portable,
+ MovingSprite, MovingObject, and GameObject.
+ */
+struct GameObjectClasses
+{
+  std::vector<std::type_index> types;
+
+  GameObjectClasses& add(const std::type_info &info) {
+    std::type_index idx(info);
+    types.push_back(idx);
+    return *this;
+  }
+};
 
 /**
    This class is responsible for:
@@ -102,6 +120,9 @@ public:
    * @description Returns the display name of the object, translated to the user's locale.
    */
   virtual std::string get_display_name() const { return _("Unknown object"); }
+  /** List notable classes in inheritance hierarchy of class. This makes it possible
+      to efficiently look up all objects deriving from a particular intermediate class */
+  virtual GameObjectClasses get_class_types() const;
 
   /** Version checking/updating, patch information */
   virtual std::vector<std::string> get_patches() const;

--- a/src/supertux/game_object_iterator.hpp
+++ b/src/supertux/game_object_iterator.hpp
@@ -35,24 +35,28 @@ public:
   {
     if (m_it != m_end)
     {
+      // A dynamic_cast is needed to perform sidecasts (a.k.a. crosscasts)
+      // T may be one of multiple base classes of the object and need not inherit GameObject
       m_object = dynamic_cast<T*>(*m_it);
-      if (!m_object)
-      {
-        skip_to_next();
-      }
+      assert(m_object);
     }
   }
 
   GameObjectIterator& operator++()
   {
-    skip_to_next();
+    ++m_it;
+    if (m_it != m_end)
+    {
+      m_object = dynamic_cast<T*>(*m_it);
+      assert(m_object);
+    }
     return *this;
   }
 
   GameObjectIterator operator++(int)
   {
     GameObjectIterator tmp(*this);
-    skip_to_next();
+    operator++();
     return tmp;
   }
 
@@ -80,24 +84,6 @@ public:
   bool operator!=(const GameObjectIterator& other) const
   {
     return !(*this == other);
-  }
-
-private:
-  void skip_to_next()
-  {
-    do
-    {
-      ++m_it;
-      if (m_it == m_end)
-      {
-        break;
-      }
-      else
-      {
-        m_object = dynamic_cast<T*>(*m_it);
-      }
-    }
-    while (!m_object);
   }
 
 private:

--- a/src/supertux/game_object_iterator.hpp
+++ b/src/supertux/game_object_iterator.hpp
@@ -25,7 +25,7 @@ template<typename T>
 class GameObjectIterator
 {
 public:
-  typedef std::vector<std::unique_ptr<GameObject> >::const_iterator Iterator;
+  typedef std::vector<GameObject* >::const_iterator Iterator;
 
 public:
   GameObjectIterator(Iterator it, Iterator end) :
@@ -35,7 +35,7 @@ public:
   {
     if (m_it != m_end)
     {
-      m_object = dynamic_cast<T*>(m_it->get());
+      m_object = dynamic_cast<T*>(*m_it);
       if (!m_object)
       {
         skip_to_next();
@@ -94,7 +94,7 @@ private:
       }
       else
       {
-        m_object = dynamic_cast<T*>(m_it->get());
+        m_object = dynamic_cast<T*>(*m_it);
       }
     }
     while (!m_object);
@@ -115,11 +115,13 @@ public:
   {}
 
   GameObjectIterator<T> begin() const {
-    return GameObjectIterator<T>(m_manager.get_objects().begin(), m_manager.get_objects().end());
+    auto& objects = m_manager.get_objects_by_type_index(typeid(T));
+    return GameObjectIterator<T>(objects.begin(), objects.end());
   }
 
   GameObjectIterator<T> end() const {
-    return GameObjectIterator<T>(m_manager.get_objects().end(), m_manager.get_objects().end());
+    auto& objects = m_manager.get_objects_by_type_index(typeid(T));
+    return GameObjectIterator<T>(objects.end(), objects.end());
   }
 
 private:

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -483,7 +483,9 @@ GameObjectManager::this_before_object_add(GameObject& object)
   }
 
   { // By type index:
-    m_objects_by_type_index[std::type_index(typeid(object))].push_back(&object);
+    for (const std::type_index& type : object.get_class_types().types) {
+      m_objects_by_type_index[type].push_back(&object);
+    }
   }
 
   save_object_change(object, true);
@@ -507,10 +509,12 @@ GameObjectManager::this_before_object_remove(GameObject& object)
   }
 
   { // By type index:
-    auto& vec = m_objects_by_type_index[std::type_index(typeid(object))];
-    auto it = std::find(vec.begin(), vec.end(), &object);
-    assert(it != vec.end());
-    vec.erase(it);
+    for (const std::type_index& type : object.get_class_types().types) {
+      auto& vec = m_objects_by_type_index[type];
+      auto it = std::find(vec.begin(), vec.end(), &object);
+      assert(it != vec.end());
+      vec.erase(it);
+    }
   }
 }
 

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -243,8 +243,8 @@ public:
   int get_object_count(std::function<bool(const T&)> predicate = nullptr) const
   {
     int total = 0;
-    for (const auto& obj : m_gameobjects) {
-      auto object = dynamic_cast<T*>(obj.get());
+    for (const auto& obj : get_objects_by_type_index(typeid(T))) {
+      auto object = static_cast<T*>(obj);
       if (object && (predicate == nullptr || predicate(*object)))
       {
         total += 1;

--- a/src/supertux/moving_object.hpp
+++ b/src/supertux/moving_object.hpp
@@ -46,6 +46,7 @@ public:
   MovingObject();
   MovingObject(const ReaderMapping& reader);
   ~MovingObject() override;
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(MovingObject)); }
 
   virtual void collision_solid(const CollisionHit& /*hit*/) override
   {

--- a/src/supertux/player_status_hud.hpp
+++ b/src/supertux/player_status_hud.hpp
@@ -34,6 +34,7 @@ private:
 
 public:
   PlayerStatusHUD(PlayerStatus& player_status);
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(PlayerStatusHUD)); }
 
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;

--- a/src/trigger/climbable.hpp
+++ b/src/trigger/climbable.hpp
@@ -46,6 +46,7 @@ public:
   static std::string display_name() { return _("Climbable"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return Trigger::get_class_types().add(typeid(Climbable)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/trigger/door.hpp
+++ b/src/trigger/door.hpp
@@ -30,6 +30,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Door"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return SpritedTrigger::get_class_types().add(typeid(Door)); }
 
   virtual ObjectSettings get_settings() override;
   virtual void after_editor_set() override;

--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -29,6 +29,7 @@ public:
   static std::string display_name() { return _("Script Trigger"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return Trigger::get_class_types().add(typeid(ScriptTrigger)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/trigger/secretarea_trigger.hpp
+++ b/src/trigger/secretarea_trigger.hpp
@@ -36,6 +36,7 @@ public:
   static std::string display_name() { return _("Secret Area"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return Trigger::get_class_types().add(typeid(SecretAreaTrigger)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/trigger/sequence_trigger.hpp
+++ b/src/trigger/sequence_trigger.hpp
@@ -31,6 +31,7 @@ public:
   static std::string display_name() { return _("Sequence Trigger"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return Trigger::get_class_types().add(typeid(SequenceTrigger)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/trigger/switch.hpp
+++ b/src/trigger/switch.hpp
@@ -29,6 +29,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Switch"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return StickyTrigger::get_class_types().add(typeid(Switch)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/trigger/text_area.hpp
+++ b/src/trigger/text_area.hpp
@@ -47,6 +47,7 @@ public:
   static std::string display_name() { return _("Text Area"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual bool has_variable_size() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return Trigger::get_class_types().add(typeid(TextArea)); }
 
 private:
   bool m_once;

--- a/src/trigger/trigger_base.hpp
+++ b/src/trigger/trigger_base.hpp
@@ -68,6 +68,7 @@ class Trigger : public MovingObject,
 {
 public:
   Trigger(const ReaderMapping& reader);
+  virtual GameObjectClasses get_class_types() const override { return MovingObject::get_class_types().add(typeid(Trigger)); }
 
   virtual void update(float) override
   {
@@ -91,6 +92,7 @@ class SpritedTrigger : public MovingSprite,
 {
 public:
   SpritedTrigger(const ReaderMapping& reader, const std::string& sprite_name);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(SpritedTrigger)); }
 
   virtual void update(float) override
   {
@@ -112,6 +114,7 @@ class StickyTrigger : public StickyObject,
 {
 public:
   StickyTrigger(const ReaderMapping& reader, const std::string& sprite_name);
+  virtual GameObjectClasses get_class_types() const override { return StickyObject::get_class_types().add(typeid(StickyTrigger)); }
 
   virtual void update(float dt_sec) override
   {

--- a/src/worldmap/level_tile.hpp
+++ b/src/worldmap/level_tile.hpp
@@ -35,6 +35,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Level"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WorldMapObject::get_class_types().add(typeid(LevelTile)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/worldmap/spawn_point.hpp
+++ b/src/worldmap/spawn_point.hpp
@@ -57,6 +57,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Spawn point"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WorldMapObject::get_class_types().add(typeid(SpawnPointObject)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/worldmap/special_tile.hpp
+++ b/src/worldmap/special_tile.hpp
@@ -35,6 +35,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Special Tile"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WorldMapObject::get_class_types().add(typeid(SpecialTile)); }
 
   virtual void draw_worldmap(DrawingContext& context) override;
 

--- a/src/worldmap/sprite_change.hpp
+++ b/src/worldmap/sprite_change.hpp
@@ -34,6 +34,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Sprite Change"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WorldMapObject::get_class_types().add(typeid(SpriteChange)); }
 
   virtual void draw_worldmap(DrawingContext& context) override;
 

--- a/src/worldmap/teleporter.hpp
+++ b/src/worldmap/teleporter.hpp
@@ -33,6 +33,7 @@ public:
   virtual std::string get_class_name() const override { return class_name(); }
   static std::string display_name() { return _("Teleporter"); }
   virtual std::string get_display_name() const override { return display_name(); }
+  virtual GameObjectClasses get_class_types() const override { return WorldMapObject::get_class_types().add(typeid(Teleporter)); }
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/worldmap/tux.hpp
+++ b/src/worldmap/tux.hpp
@@ -39,6 +39,7 @@ public:
   virtual void draw(DrawingContext& context) override;
   virtual void update(float dt_sec) override;
   virtual bool is_singleton() const override { return true; }
+  virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(Tux)); }
 
   void setup(); /**< called prior to first update */
 

--- a/src/worldmap/worldmap_object.hpp
+++ b/src/worldmap/worldmap_object.hpp
@@ -36,6 +36,7 @@ public:
   WorldMapObject(const ReaderMapping& mapping, const std::string& default_sprite);
   WorldMapObject(const ReaderMapping& mapping);
   WorldMapObject(const Vector& pos, const std::string& default_sprite);
+  virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(WorldMapObject)); }
 
   static std::string class_name() { return "worldmap-object"; }
   virtual std::string get_class_name() const override { return class_name(); }


### PR DESCRIPTION
Previously, the `m_objects_by_type_index` map only listed the objects by their (main) class. Finding all objects inheriting a given base class (like BadGuy, Portable, or PathObject) required scanning through the entire list of objects and trying a `dynamic_cast` on each. This PR changes the map to, for a given GameObject, record it in `m_objects_by_type_index` for all its notable intermediate base classes. Thus, for example, a Lantern is registered in the `m_objects_by_type_index` map for the lists for type indexes corresponding to Lantern, Rock, Portable, MovingSprite, and MovingObject. Now, one can efficiently look up all e.g. Portable objects by querying `m_objects_by_type_index[std::type_index(typeid(Portable))]`, and this will be fast even if the level has 10000 unrelated objects.

In practice, this PR significantly speeds up processing for the Player and Crusher classes, which no longer need to search through many unrelated objects when looking for e.g. other players, Bullets, Portables, Bricks, etc. (A test level that I made with many crushers and about 1000 coins, which used to lag, now runs quickly.)

The awkward part of this approach is identifying the various base classes of an object when it is time to register them in `GameObjectManager::this_before_object_add()`. This is done by adding a new virtual function to `GameObject`, which when called provides all the classes under which to record an object. Every class inheriting GameObject must then implement the method to add itself to its own list. (This is admittedly tedious, but the method body is only a very formulaic line.)

This supersedes but does not conflict with https://github.com/SuperTux/supertux/pull/2986 .
