### PR TITLE
Fix egg not showing shade sprite when placed on its own.

### DIFF
--- a/src/object/powerup.cpp
+++ b/src/object/powerup.cpp
@@ -110,6 +110,11 @@ PowerUp::initialize()
   SoundManager::current()->preload("sounds/fire-flower.wav");
   SoundManager::current()->preload("sounds/gulp.wav");
 
+  if(m_type == EGG) {
+    shadesprite = SpriteManager::current()->create("images/powerups/egg/egg.sprite");
+    shadesprite->set_action("shadow");
+  }
+
   // Older levels utilize hardcoded behaviour from the chosen sprite
   if (get_version() == 1)
   {
@@ -289,6 +294,9 @@ PowerUp::draw(DrawingContext& context)
   // Stars and herrings are brighter.
   if (m_type == STAR || m_type == HERRING)
     m_sprite->draw(context.color(), get_pos(), m_layer, m_flip);
+
+  if (m_type == EGG)
+    shadesprite->draw(context.color(), get_pos(), m_layer, m_flip);
 
   lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -69,6 +69,7 @@ private:
   std::string script;
   bool no_physics;
   SpritePtr lightsprite;
+  SpritePtr shadesprite;
 
 private:
   PowerUp(const PowerUp&) = delete;


### PR DESCRIPTION

To put it simply heres what it looked like before...
![image](https://github.com/user-attachments/assets/55d5ce15-bb4a-44b2-a808-168c852fcdf1)

...and heres what it looks like now.
![image](https://github.com/user-attachments/assets/e0dd6264-7d5d-4822-889b-e7c2f0801328)

I noticed a Bonus Island level used a powerup on its own so I decided to take a whirl at fixing it for 0.7.