### PR TITLE
Add "Show Tile Ids In Editor" to debug menu.

### DIFF
--- a/src/editor/tilebox.cpp
+++ b/src/editor/tilebox.cpp
@@ -17,6 +17,7 @@
 
 #include "editor/tilebox.hpp"
 
+#include "supertux/debug.hpp"
 #include "editor/editor.hpp"
 #include "editor/object_info.hpp"
 #include "editor/tile_selection.hpp"
@@ -108,7 +109,7 @@ EditorTilebox::draw_tilegroup(DrawingContext& context)
     auto position = get_tile_coords(pos, false);
     m_editor.get_tileset()->get(tile_ID).draw(context.color(), position, LAYER_GUI - 9);
 
-    if (g_config->developer_mode && m_active_tilegroup->developers_group)
+    if (g_config->developer_mode && (m_active_tilegroup->developers_group || g_debug.show_tile_ids_in_editor) && tile_ID != 0)
     {
       // Display tile ID on top of tile:
       context.color().draw_text(Resources::console_font, std::to_string(tile_ID),

--- a/src/editor/tilebox.cpp
+++ b/src/editor/tilebox.cpp
@@ -17,12 +17,12 @@
 
 #include "editor/tilebox.hpp"
 
-#include "supertux/debug.hpp"
 #include "editor/editor.hpp"
 #include "editor/object_info.hpp"
 #include "editor/tile_selection.hpp"
 #include "editor/tip.hpp"
 #include "supertux/colorscheme.hpp"
+#include "supertux/debug.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/game_object_factory.hpp"
 #include "supertux/globals.hpp"
@@ -109,7 +109,7 @@ EditorTilebox::draw_tilegroup(DrawingContext& context)
     auto position = get_tile_coords(pos, false);
     m_editor.get_tileset()->get(tile_ID).draw(context.color(), position, LAYER_GUI - 9);
 
-    if (g_config->developer_mode && (m_active_tilegroup->developers_group || g_debug.show_tile_ids_in_editor) && tile_ID != 0)
+    if (g_config->developer_mode && (m_active_tilegroup->developers_group || g_debug.show_toolbox_tile_ids) && tile_ID != 0)
     {
       // Display tile ID on top of tile:
       context.color().draw_text(Resources::console_font, std::to_string(tile_ID),

--- a/src/supertux/debug.cpp
+++ b/src/supertux/debug.cpp
@@ -25,7 +25,7 @@ Debug::Debug() :
   show_collision_rects(false),
   show_worldmap_path(false),
   draw_redundant_frames(false),
-  show_tile_ids_in_editor(false),
+  show_toolbox_tile_ids(false),
   m_use_bitmap_fonts(false),
   m_game_speed_multiplier(1.0f)
 {

--- a/src/supertux/debug.cpp
+++ b/src/supertux/debug.cpp
@@ -25,6 +25,7 @@ Debug::Debug() :
   show_collision_rects(false),
   show_worldmap_path(false),
   draw_redundant_frames(false),
+  show_tile_ids_in_editor(false),
   m_use_bitmap_fonts(false),
   m_game_speed_multiplier(1.0f)
 {

--- a/src/supertux/debug.hpp
+++ b/src/supertux/debug.hpp
@@ -39,7 +39,7 @@ public:
   // vaguely measure the impact of code changes which should increase the FPS
   bool draw_redundant_frames;
 
-  bool show_tile_ids_in_editor;
+  bool show_toolbox_tile_ids;
 
 private:
   /** Use old bitmap fonts instead of TTF */

--- a/src/supertux/debug.hpp
+++ b/src/supertux/debug.hpp
@@ -39,6 +39,8 @@ public:
   // vaguely measure the impact of code changes which should increase the FPS
   bool draw_redundant_frames;
 
+  bool show_tile_ids_in_editor;
+
 private:
   /** Use old bitmap fonts instead of TTF */
   bool m_use_bitmap_fonts;

--- a/src/supertux/menu/debug_menu.cpp
+++ b/src/supertux/menu/debug_menu.cpp
@@ -71,6 +71,7 @@ DebugMenu::DebugMenu() :
   add_toggle(-1, _("Use Bitmap Fonts"),
              []{ return g_debug.get_use_bitmap_fonts(); },
              [](bool value){ g_debug.set_use_bitmap_fonts(value); });
+  add_toggle(-1, _("Show Tile Ids In Editor"), &g_debug.show_tile_ids_in_editor);
   add_entry(_("Dump Texture Cache"), []{ TextureManager::current()->debug_print(get_logging_instance()); });
 
   add_hl();

--- a/src/supertux/menu/debug_menu.cpp
+++ b/src/supertux/menu/debug_menu.cpp
@@ -71,7 +71,7 @@ DebugMenu::DebugMenu() :
   add_toggle(-1, _("Use Bitmap Fonts"),
              []{ return g_debug.get_use_bitmap_fonts(); },
              [](bool value){ g_debug.set_use_bitmap_fonts(value); });
-  add_toggle(-1, _("Show Tile Ids In Editor"), &g_debug.show_tile_ids_in_editor);
+  add_toggle(-1, _("Show Tile IDs in Editor Toolbox"), &g_debug.show_toolbox_tile_ids);
   add_entry(_("Dump Texture Cache"), []{ TextureManager::current()->debug_print(get_logging_instance()); });
 
   add_hl();


### PR DESCRIPTION
A feature I've wanted for a while, and also useful to people who work on tilesets frequently.