### PR TITLE
Separate `StreamLineBuffer` from `ConsoleBuffer`

### DIFF
--- a/src/supertux/console.hpp
+++ b/src/supertux/console.hpp
@@ -17,39 +17,35 @@
 #ifndef HEADER_SUPERTUX_SUPERTUX_CONSOLE_HPP
 #define HEADER_SUPERTUX_SUPERTUX_CONSOLE_HPP
 
-#include <list>
-#include <sstream>
 #include <vector>
 
 #include <simplesquirrel/vm.hpp>
 
 #include "util/currenton.hpp"
+#include "util/stream_buffer.hpp"
 #include "video/font_ptr.hpp"
 #include "video/surface_ptr.hpp"
 
 class Console;
-class ConsoleStreamBuffer;
 class DrawingContext;
 
-class ConsoleBuffer final : public Currenton<ConsoleBuffer>
+class ConsoleBuffer final : public Currenton<ConsoleBuffer>,
+                            public StreamLineBuffer
 {
 public:
   static std::ostream output; /**< stream of characters to output to the console. Do not forget to send std::endl or to flush the stream. */
-  static ConsoleStreamBuffer s_outputBuffer; /**< stream buffer used by output stream */
+  static StreamBuffer<ConsoleBuffer> s_outputBuffer; /**< stream buffer used by output stream */
 
-public:
-  std::list<std::string> m_lines; /**< backbuffer of lines sent to the console. New lines get added to front. */
+private:
   Console* m_console;
 
 public:
   ConsoleBuffer();
 
-  void addLines(const std::string& s); /**< display a string of (potentially) multiple lines in the console */
-  void addLine(const std::string& s); /**< display a line in the console */
-
-  void flush(ConsoleStreamBuffer& buffer); /**< act upon changes in a ConsoleStreamBuffer */
-
   void set_console(Console* console);
+
+protected:
+  int add_line(const std::string& s) override; /**< display a line in the console */
 
 private:
   ConsoleBuffer(const ConsoleBuffer&) = delete;
@@ -119,18 +115,6 @@ private:
 private:
   Console(const Console&) = delete;
   Console & operator=(const Console&) = delete;
-};
-
-class ConsoleStreamBuffer final : public std::stringbuf
-{
-public:
-  virtual int sync() override
-  {
-    int result = std::stringbuf::sync();
-    if (ConsoleBuffer::current())
-      ConsoleBuffer::current()->flush(*this);
-    return result;
-  }
 };
 
 #endif

--- a/src/util/stream_buffer.cpp
+++ b/src/util/stream_buffer.cpp
@@ -1,0 +1,81 @@
+//  SuperTux
+//  Copyright (C) 2006 Christoph Sommer <christoph.sommer@2006.expires.deltadevelopment.de>
+//                2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "util/stream_buffer.hpp"
+
+#include "video/font.hpp"
+
+StreamLineBuffer::StreamLineBuffer() :
+  m_lines()
+{
+}
+
+StreamLineBuffer::~StreamLineBuffer()
+{
+}
+
+void
+StreamLineBuffer::add_lines(const std::string& s)
+{
+  std::istringstream iss(s);
+  std::string line;
+  while (std::getline(iss, line, '\n'))
+  {
+    add_line(line);
+  }
+}
+
+int
+StreamLineBuffer::add_line(const std::string& s_)
+{
+  std::string s = s_;
+
+  // Wrap long lines.
+  std::string overflow;
+  int line_count = 0;
+  do
+  {
+    m_lines.push_front(Font::wrap_to_chars(s, 99, &overflow));
+    line_count += 1;
+    s = overflow;
+  } while (s.length() > 0);
+
+  // Trim scrollback buffer.
+  while (m_lines.size() >= 1000)
+  {
+    m_lines.pop_back();
+  }
+
+  return line_count;
+}
+
+void
+StreamLineBuffer::flush(std::stringbuf& buffer)
+{
+  std::string s = buffer.str();
+  if ((s.length() > 0) && ((s[s.length()-1] == '\n') || (s[s.length()-1] == '\r')))
+  {
+    while ((s[s.length()-1] == '\n') || (s[s.length()-1] == '\r'))
+    {
+      s.erase(s.length()-1);
+    }
+    add_lines(s);
+    buffer.str("");
+  }
+}
+
+/* EOF */

--- a/src/util/stream_buffer.hpp
+++ b/src/util/stream_buffer.hpp
@@ -1,0 +1,63 @@
+//  SuperTux
+//  Copyright (C) 2006 Christoph Sommer <christoph.sommer@2006.expires.deltadevelopment.de>
+//                2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_UTIL_STREAM_BUFFER_HPP
+#define HEADER_SUPERTUX_UTIL_STREAM_BUFFER_HPP
+
+#include <list>
+#include <sstream>
+#include <string>
+
+template<class C>
+class StreamBuffer final : public std::stringbuf
+{
+public:
+  virtual int sync() override
+  {
+    int result = std::stringbuf::sync();
+    if (C::current())
+      C::current()->flush(*this);
+    return result;
+  }
+};
+
+class StreamLineBuffer
+{
+public:
+  StreamLineBuffer();
+  virtual ~StreamLineBuffer();
+
+  void add_lines(const std::string& s); /**< add (potentially) multiple lines to the backbuffer */
+
+  void flush(std::stringbuf& buffer); /**< act upon changes in a stream buffer */
+
+  const std::list<std::string>& get_lines() const { return m_lines; }
+
+protected:
+  virtual int add_line(const std::string& s); /**< add a line to the backbuffer */
+
+protected:
+  std::list<std::string> m_lines; /**< backbuffer of lines. New lines get added to the front. */
+
+private:
+  StreamLineBuffer(const StreamLineBuffer&) = delete;
+  StreamLineBuffer& operator=(const StreamLineBuffer&) = delete;
+};
+
+#endif
+
+/* EOF */


### PR DESCRIPTION
Moves the line buffering functionality of `ConsoleBuffer` to a base class.

This simplifies the code a little bit, as well as allows using the line buffering functionality of `ConsoleBuffer` separately, if needed.

(I thought I'd need this to implement a feature, however, turns out I don't. It could still be implemented as a code improvement, though.)