### PR TITLE
Do not show debug box for solid tiles in non-solid tilemaps

### DIFF
--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -478,7 +478,7 @@ TileMap::draw(DrawingContext& context)
       if (m_tiles[index] == 0) continue;
       const Tile& tile = m_tileset->get(m_tiles[index]);
 
-      if (g_debug.show_collision_rects) {
+	  if (g_debug.show_collision_rects && m_real_solid) {
         tile.draw_debug(context.color(), pos, LAYER_FOREGROUND1);
       }
 


### PR DESCRIPTION
When enabling the "show collision rects" feature, non-solid tilemaps would show the collision rectangles for solid tiles, even though the tilemap is non solid.