### PR TITLE
Squirrel: Fix inaccessible class member variables, improvements

### DIFF
--- a/src/object/ambient_sound.hpp
+++ b/src/object/ambient_sound.hpp
@@ -64,13 +64,11 @@ public:
 #ifdef DOXYGEN_SCRIPTING
   /**
    * @scripting
-   * @deprecated Use ""get_x()"" instead!
    * @description Returns the ambient sound's X coordinate.
    */
   float get_pos_x() const;
   /**
    * @scripting
-   * @deprecated Use ""get_y()"" instead!
    * @description Returns the ambient sound's Y coordinate.
    */
   float get_pos_y() const;

--- a/src/object/ambient_sound.hpp
+++ b/src/object/ambient_sound.hpp
@@ -64,11 +64,13 @@ public:
 #ifdef DOXYGEN_SCRIPTING
   /**
    * @scripting
+   * @deprecated Use ""get_x()"" instead!
    * @description Returns the ambient sound's X coordinate.
    */
   float get_pos_x() const;
   /**
    * @scripting
+   * @deprecated Use ""get_y()"" instead!
    * @description Returns the ambient sound's Y coordinate.
    */
   float get_pos_y() const;

--- a/src/object/candle.cpp
+++ b/src/object/candle.cpp
@@ -157,6 +157,8 @@ Candle::register_class(ssq::VM& vm)
   cls.addFunc("puff_smoke", &Candle::puff_smoke);
   cls.addFunc("get_burning", &Candle::get_burning);
   cls.addFunc("set_burning", &Candle::set_burning);
+
+  cls.addVar("burning", &Candle::get_burning, &Candle::set_burning);
 }
 
 /* EOF */

--- a/src/object/candle.hpp
+++ b/src/object/candle.hpp
@@ -67,6 +67,10 @@ public:
   void set_burning(bool burning);
 
 private:
+  /**
+   * @scripting
+   * @description The burning state of the candle.
+   */
   bool burning; /**< true if candle is currently lighted */
   bool flicker; /**< true if candle light is to flicker */
   Color lightcolor; /**< determines color or light given off */

--- a/src/object/conveyor_belt.cpp
+++ b/src/object/conveyor_belt.cpp
@@ -172,6 +172,12 @@ ConveyorBelt::set_speed(float target_speed)
   m_speed = target_speed;
 }
 
+float
+ConveyorBelt::get_speed() const
+{
+  return m_speed;
+}
+
 
 void
 ConveyorBelt::register_class(ssq::VM& vm)
@@ -183,6 +189,9 @@ ConveyorBelt::register_class(ssq::VM& vm)
   cls.addFunc("move_left", &ConveyorBelt::move_left);
   cls.addFunc("move_right", &ConveyorBelt::move_right);
   cls.addFunc("set_speed", &ConveyorBelt::set_speed);
+  cls.addFunc("get_speed", &ConveyorBelt::get_speed);
+
+  cls.addVar("speed", &ConveyorBelt::get_speed, &ConveyorBelt::set_speed);
 }
 
 /* EOF */

--- a/src/object/conveyor_belt.hpp
+++ b/src/object/conveyor_belt.hpp
@@ -58,30 +58,35 @@ public:
   /** @name Scriptable Methods */
   /**
    * @scripting
-   * Starts the conveyor belt.
+   * @description Starts the conveyor belt.
    */
   void start();
   /**
    * @scripting
-   * Stops the conveyor belt.
+   * @description Stops the conveyor belt.
    */
   void stop();
   /**
    * @scripting
-   * Makes the conveyor shift objects to the left.
+   * @description Makes the conveyor shift objects to the left.
    */
   void move_left();
   /**
    * @scripting
-   * Makes the conveyor shift objects to the right.
+   * @description Makes the conveyor shift objects to the right.
    */
   void move_right();
   /**
    * @scripting
-   * Change the shifting speed of the conveyor.
+   * @description Change the shifting speed of the conveyor.
    * @param float $target_speed
    */
   void set_speed(float target_speed);
+  /**
+   * @scripting
+   * @description Returns the shifting speed of the conveyor.
+   */
+  float get_speed() const;
 
 private:
   void update_hitbox() override;
@@ -90,6 +95,10 @@ private:
   bool m_running;
   Direction m_dir;
   int m_length;
+  /**
+   * @scripting
+   * @description The shifting speed of the conveyor.
+   */
   float m_speed;
 
   float m_frame;

--- a/src/object/custom_particle_system.hpp
+++ b/src/object/custom_particle_system.hpp
@@ -110,12 +110,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""max_amount"" property instead!
    */
   int get_max_amount() const;
   /**
    * @scripting
-   * @deprecated Use the ""max_amount"" property instead!
    * @param int $amount
    */
   void set_max_amount(int amount);
@@ -177,24 +175,20 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""cover_screen"" property instead!
    */
   bool get_cover_screen() const;
   /**
    * @scripting
-   * @deprecated Use the ""cover_screen"" property instead!
    * @param bool $cover
    */
   void set_cover_screen(bool cover);
 
   /**
    * @scripting
-   * @deprecated Use the ""delay"" property instead!
    */
   float get_delay() const;
   /**
    * @scripting
-   * @deprecated Use the ""delay"" property instead!
    * @param float $delay
    */
   void set_delay(float delay);
@@ -214,12 +208,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_lifetime"" property instead!
    */
   float get_lifetime() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_lifetime"" property instead!
    * @param float $lifetime
    */
   void set_lifetime(float lifetime);
@@ -239,12 +231,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_lifetime_variation"" property instead!
    */
   float get_lifetime_variation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_lifetime_variation"" property instead!
    * @param float $lifetime_variation
    */
   void set_lifetime_variation(float lifetime_variation);
@@ -264,12 +254,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_birth_time"" property instead!
    */
   float get_birth_time() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_birth_time"" property instead!
    * @param float $birth_time
    */
   void set_birth_time(float birth_time);
@@ -289,12 +277,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_birth_time_variation"" property instead!
    */
   float get_birth_time_variation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_birth_time_variation"" property instead!
    * @param float $birth_time_variation
    */
   void set_birth_time_variation(float birth_time_variation);
@@ -314,12 +300,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_death_time"" property instead!
    */
   float get_death_time() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_death_time"" property instead!
    * @param float $death_time
    */
   void set_death_time(float death_time);
@@ -339,12 +323,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_death_time_variation"" property instead!
    */
   float get_death_time_variation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_death_time_variation"" property instead!
    * @param float $death_time_variation
    */
   void set_death_time_variation(float death_time_variation);
@@ -364,12 +346,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_x"" property instead!
    */
   float get_speed_x() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_x"" property instead!
    * @param float $speed_x
    */
   void set_speed_x(float speed_x);
@@ -389,12 +369,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_y"" property instead!
    */
   float get_speed_y() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_y"" property instead!
    * @param float $speed_y
    */
   void set_speed_y(float speed_y);
@@ -414,12 +392,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_variation_x"" property instead!
    */
   float get_speed_variation_x() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_variation_x"" property instead!
    * @param float $speed_variation_x
    */
   void set_speed_variation_x(float speed_variation_x);
@@ -439,12 +415,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_variation_y"" property instead!
    */
   float get_speed_variation_y() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_speed_variation_y"" property instead!
    * @param float $speed_variation_y
    */
   void set_speed_variation_y(float speed_variation_y);
@@ -464,12 +438,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_acceleration_x"" property instead!
    */
   float get_acceleration_x() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_acceleration_x"" property instead!
    * @param float $acceleration_x
    */
   void set_acceleration_x(float acceleration_x);
@@ -489,12 +461,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_acceleration_y"" property instead!
    */
   float get_acceleration_y() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_acceleration_y"" property instead!
    * @param float $acceleration_y
    */
   void set_acceleration_y(float acceleration_y);
@@ -514,12 +484,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_friction_x"" property instead!
    */
   float get_friction_x() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_friction_x"" property instead!
    * @param float $friction_x
    */
   void set_friction_x(float friction_x);
@@ -539,12 +507,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_friction_y"" property instead!
    */
   float get_friction_y() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_friction_y"" property instead!
    * @param float $friction_y
    */
   void set_friction_y(float friction_y);
@@ -564,12 +530,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_feather_factor"" property instead!
    */
   float get_feather_factor() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_feather_factor"" property instead!
    * @param float $feather_factor
    */
   void set_feather_factor(float feather_factor);
@@ -589,12 +553,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation"" property instead!
    */
   float get_rotation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation"" property instead!
    * @param float $rotation
    */
   void set_rotation(float rotation);
@@ -614,12 +576,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_variation"" property instead!
    */
   float get_rotation_variation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_variation"" property instead!
    * @param float $rotation_variation
    */
   void set_rotation_variation(float rotation_variation);
@@ -639,12 +599,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_speed"" property instead!
    */
   float get_rotation_speed() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_speed"" property instead!
    * @param float $rotation_speed
    */
   void set_rotation_speed(float rotation_speed);
@@ -664,12 +622,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_speed_variation"" property instead!
    */
   float get_rotation_speed_variation() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_speed_variation"" property instead!
    * @param float $rotation_speed_variation
    */
   void set_rotation_speed_variation(float rotation_speed_variation);
@@ -689,12 +645,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_acceleration"" property instead!
    */
   float get_rotation_acceleration() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_acceleration"" property instead!
    * @param float $rotation_acceleration
    */
   void set_rotation_acceleration(float rotation_acceleration);
@@ -714,12 +668,10 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_decceleration"" property instead!
    */
   float get_rotation_decceleration() const;
   /**
    * @scripting
-   * @deprecated Use the ""particle_rotation_decceleration"" property instead!
    * @param float $rotation_decceleration
    */
   void set_rotation_decceleration(float rotation_decceleration);

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -67,7 +67,6 @@ public:
 #ifdef DOXYGEN_SCRIPTING
   /**
    * @scripting
-   * @deprecated Use ""set_sprite()"" instead!
    * @description Changes the decal sprite.
    * @param string $sprite
    */

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -67,6 +67,7 @@ public:
 #ifdef DOXYGEN_SCRIPTING
   /**
    * @scripting
+   * @deprecated Use ""set_sprite()"" instead!
    * @description Changes the decal sprite.
    * @param string $sprite
    */

--- a/src/object/display_effect.cpp
+++ b/src/object/display_effect.cpp
@@ -204,6 +204,8 @@ DisplayEffect::register_class(ssq::VM& vm)
   cls.addFunc("is_black", &DisplayEffect::is_black);
   cls.addFunc("sixteen_to_nine", &DisplayEffect::sixteen_to_nine);
   cls.addFunc("four_to_three", &DisplayEffect::four_to_three);
+
+  cls.addVar("black", &DisplayEffect::black);
 }
 
 /* EOF */

--- a/src/object/display_effect.hpp
+++ b/src/object/display_effect.hpp
@@ -100,6 +100,11 @@ private:
   float border_fading;
   float border_size;
 
+  /**
+   * @scripting
+   * @description Determines whether the screen has been blackened.
+                  Equivalent to ""set_black()"" and ""is_black()"".
+   */
   bool black;
   bool borders;
 

--- a/src/object/floating_image.cpp
+++ b/src/object/floating_image.cpp
@@ -199,6 +199,7 @@ FloatingImage::register_class(ssq::VM& vm)
 
   cls.addVar("layer", &FloatingImage::m_layer);
   cls.addVar("visible", &FloatingImage::m_visible);
+  cls.addVar("anchor_point", &FloatingImage::get_anchor_point, &FloatingImage::set_anchor_point);
 }
 
 /* EOF */

--- a/src/object/floating_image.hpp
+++ b/src/object/floating_image.hpp
@@ -47,14 +47,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""layer"" property instead!
    * @description Sets the layer of the floating image.
    * @param int $layer
    */
   void set_layer(int layer);
   /**
    * @scripting
-   * @deprecated Use the ""layer"" property instead!
    * @description Returns the layer the floating image is on.
    */
   int get_layer() const;
@@ -102,14 +100,12 @@ public:
   int get_anchor_point() const;
   /**
    * @scripting
-   * @deprecated Use the ""visible"" property instead!
    * @description Sets the visibility of the floating image.
    * @param bool $visible
    */
   void set_visible(bool visible);
   /**
    * @scripting
-   * @deprecated Use the ""visible"" property instead!
    * @description Returns the visibility state of the floating image.
    */
   bool get_visible() const;
@@ -155,6 +151,14 @@ private:
   Vector m_pos;
   float m_fading;
   float m_fadetime;
+
+#ifdef DOXYGEN_SCRIPTING
+  /**
+   * @scripting
+   * @description The current anchor point.
+   */
+  int m_anchor_point;
+#endif
 };
 
 #endif

--- a/src/object/level_time.cpp
+++ b/src/object/level_time.cpp
@@ -166,6 +166,8 @@ LevelTime::register_class(ssq::VM& vm)
   cls.addFunc("stop", &LevelTime::stop);
   cls.addFunc("get_time", &LevelTime::get_time);
   cls.addFunc("set_time", &LevelTime::set_time);
+
+  cls.addVar("time", &LevelTime::get_time, &LevelTime::set_time);
 }
 
 /* EOF */

--- a/src/object/level_time.hpp
+++ b/src/object/level_time.hpp
@@ -85,6 +85,14 @@ private:
   bool running;
   float time_left;
 
+#ifdef DOXYGEN_SCRIPTING
+  /**
+   * @scripting
+   * @description The number of seconds left on the clock.
+   */
+  float m_time;
+#endif
+
 private:
   LevelTime(const LevelTime&) = delete;
   LevelTime& operator=(const LevelTime&) = delete;

--- a/src/object/lit_object.cpp
+++ b/src/object/lit_object.cpp
@@ -98,7 +98,7 @@ LitObject::on_flip(float height)
   FlipLevelTransformer::transform_flip(m_flip);
 }
 
-std::string
+const std::string&
 LitObject::get_light_action() const
 {
   return m_light_sprite->get_action();
@@ -118,6 +118,8 @@ LitObject::register_class(ssq::VM& vm)
 
   cls.addFunc("get_light_action", &LitObject::get_light_action);
   cls.addFunc("set_light_action", &LitObject::set_light_action);
+
+  cls.addVar("light_action", &LitObject::get_light_action, &LitObject::set_light_action);
 }
 
 /* EOF */

--- a/src/object/lit_object.hpp
+++ b/src/object/lit_object.hpp
@@ -58,7 +58,7 @@ public:
    * @scripting
    * @description Returns the current light sprite action.
    */
-  std::string get_light_action() const;
+  const std::string& get_light_action() const;
   /**
    * @scripting
    * @description Sets the light sprite action.
@@ -72,6 +72,14 @@ private:
   std::string m_sprite_action;
   std::string m_light_sprite_action;
   SpritePtr m_light_sprite;
+
+#ifdef DOXYGEN_SCRIPTING
+  /**
+   * @scripting
+   * @description The current light sprite action.
+   */
+  std::string m_light_action;
+#endif
 
 private:
   LitObject(const LitObject&) = delete;

--- a/src/object/moving_sprite.cpp
+++ b/src/object/moving_sprite.cpp
@@ -123,6 +123,12 @@ MovingSprite::matches_sprite(const std::string& sprite_file) const
   return m_sprite_name == sprite_file || m_sprite_name == "/" + sprite_file;
 }
 
+void
+MovingSprite::set_sprite(const std::string& file)
+{
+  change_sprite(file);
+}
+
 std::string
 MovingSprite::get_action() const
 {
@@ -264,6 +270,8 @@ MovingSprite::register_class(ssq::VM& vm)
   cls.addFunc("get_action", &MovingSprite::get_action);
   cls.addFunc<void, MovingSprite, const std::string&>("set_action", &MovingSprite::set_action);
   cls.addFunc("set_action_loops", &MovingSprite::set_action_loops);
+
+  cls.addVar("sprite", &MovingSprite::get_sprite_name, &MovingSprite::set_sprite);
 }
 
 /* EOF */

--- a/src/object/moving_sprite.hpp
+++ b/src/object/moving_sprite.hpp
@@ -76,13 +76,16 @@ public:
   /** Get various sprite properties. **/
   Sprite* get_sprite() const { return m_sprite.get(); }
 
+  /** "void" wrapper for "change_sprite()" to be used for the "sprite" scripting property. **/
+  void set_sprite(const std::string& file);
+
 #ifdef DOXYGEN_SCRIPTING
   /**
    * @scripting
-   * @description Sets the sprite of the object.
+   * @description Sets the sprite of the object. Returns ""true"" on success.
    * @param string $file
    */
-  void set_sprite(const std::string& file);
+  bool set_sprite(const std::string& file);
   /**
    * @scripting
    * @description Returns the file of the object's sprite.

--- a/src/object/particlesystem.hpp
+++ b/src/object/particlesystem.hpp
@@ -68,14 +68,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""enabled"" property instead!
    * @description Enables/disables the system.
    * @param bool $enable
    */
   void set_enabled(bool enable);
   /**
    * @scripting
-   * @deprecated Use the ""enabled"" property instead!
    * @description Returns ""true"" if the system is enabled.
    */
   bool get_enabled() const;

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -3098,6 +3098,8 @@ Player::register_class(ssq::VM& vm)
   cls.addFunc("get_input_pressed", &Player::get_input_pressed);
   cls.addFunc("get_input_held", &Player::get_input_held);
   cls.addFunc("get_input_released", &Player::get_input_released);
+
+  cls.addVar("visible", &Player::m_visible);
 }
 
 /* EOF */

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -286,14 +286,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated
    * @description Set Tux visible or invisible.
    * @param bool $visible
    */
   void set_visible(bool visible);
   /**
    * @scripting
-   * @deprecated
    * @description Returns ""true"" if Tux is currently visible (has not been set invisible by the ""set_visible()"" method).
    */
   bool get_visible() const;

--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -537,6 +537,10 @@ private:
 
   Physic m_physic;
 
+  /**
+   * @scripting
+   * @description Determines whether Tux is visible.
+   */
   bool m_visible;
 
   Portable* m_grabbed_object;

--- a/src/object/scripted_object.cpp
+++ b/src/object/scripted_object.cpp
@@ -216,6 +216,7 @@ ScriptedObject::register_class(ssq::VM& vm)
   cls.addFunc("is_solid", &ScriptedObject::is_solid);
 
   cls.addVar("visible", &ScriptedObject::visible);
+  cls.addVar("solid", &ScriptedObject::is_solid, &ScriptedObject::set_solid);
 }
 
 /* EOF */

--- a/src/object/scripted_object.hpp
+++ b/src/object/scripted_object.hpp
@@ -98,14 +98,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""visible"" property instead!
    * @description Shows or hides the object, according to the value of ""visible"".
    * @param bool $visible
    */
   void set_visible(bool visible);
   /**
    * @scripting
-   * @deprecated Use the ""visible"" property instead!
    * @description Returns ""true"" if the object is visible.
    */
   bool is_visible() const;
@@ -124,6 +122,10 @@ public:
 
 private:
   Physic physic;
+  /**
+   * @scripting
+   * @description Determines whether the object is solid.
+   */
   bool solid;
   bool physic_enabled;
   /**

--- a/src/object/sound_object.cpp
+++ b/src/object/sound_object.cpp
@@ -145,6 +145,8 @@ SoundObject::register_class(ssq::VM& vm)
   cls.addFunc("stop_playing", &SoundObject::stop_looping_sounds);
   cls.addFunc("set_volume", &SoundObject::set_volume);
   cls.addFunc("get_volume", &SoundObject::get_volume);
+
+  cls.addVar("volume", &SoundObject::get_volume, &SoundObject::set_volume);
 }
 
 /* EOF */

--- a/src/object/sound_object.hpp
+++ b/src/object/sound_object.hpp
@@ -53,22 +53,26 @@ public:
 
 #ifdef DOXYGEN_SCRIPTING
   /**
-   * Starts playing sound, if currently stopped.
+   * @scripting
+   * @description Starts playing sound, if currently stopped.
    */
   void start_playing();
   /**
-   * Stops playing sound.
+   * @scripting
+   * @description Stops playing sound.
    */
   void stop_playing();
 #endif
 
   /**
-   * Sets the volume of sound played by SoundObject.
+   * @scripting
+   * @description Sets the volume of the played sound.
    * @param float $volume
    */
   void set_volume(float volume);
   /**
-   * Returns the volume of sound played by SoundObject.
+   * @scripting
+   * @description Returns the volume of the played sound.
    */
   float get_volume() const;
 
@@ -77,6 +81,10 @@ public:
 private:
   std::string m_sample;
   std::unique_ptr<SoundSource> m_sound_source;
+  /**
+   * @scripting
+   * @description The volume of the played sound.
+   */
   float m_volume;
   bool m_started;
 

--- a/src/object/spotlight.hpp
+++ b/src/object/spotlight.hpp
@@ -66,14 +66,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""enabled"" property instead!
    * @description Enables/disables the spotlight.
    * @param bool $enabled
    */
   void set_enabled(bool enabled);
   /**
    * @scripting
-   * @deprecated Use the ""enabled"" property instead!
    * @description Returns ""true"" if the spotlight is enabled.
    */
   bool is_enabled();
@@ -87,7 +85,6 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""angle"" property instead!
    * @description Sets the angle of the spotlight.
    * @param float $angle
    */
@@ -110,7 +107,6 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""speed"" property instead!
    * @description Sets the speed of the spotlight.
    * @param float $speed
    */

--- a/src/object/text_array_object.cpp
+++ b/src/object/text_array_object.cpp
@@ -276,6 +276,14 @@ TextArrayObject::should_fade() const
   if (item)                                       \
     return item->text_object.F;
 
+#define TEXT_OBJECT_FUNCTION_VOID_THROW(F)                              \
+  TEXT_OBJECT_FUNCTION_VOID(F)                                          \
+  throw std::runtime_error("No current TextObject in TextArrayObject!");
+
+#define TEXT_OBJECT_FUNCTION_RETURN_THROW(F)                            \
+  TEXT_OBJECT_FUNCTION_RETURN(F)                                        \
+  throw std::runtime_error("No current TextObject in TextArrayObject!");
+
 void
 TextArrayObject::set_text(const std::string& text)
 {
@@ -284,132 +292,148 @@ TextArrayObject::set_text(const std::string& text)
   add_text(text);
 }
 
+const std::string&
+TextArrayObject::get_text() const
+{
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_text())
+}
+
 void
 TextArrayObject::set_font(const std::string& fontname)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_font(fontname))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_font(fontname))
 }
 
 void
 TextArrayObject::fade_in(float fadetime)
 {
-  TEXT_OBJECT_FUNCTION_VOID(fade_in(fadetime))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(fade_in(fadetime))
 }
 
 void
 TextArrayObject::fade_out(float fadetime)
 {
-  TEXT_OBJECT_FUNCTION_VOID(fade_out(fadetime))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(fade_out(fadetime))
 }
 
 void
 TextArrayObject::grow_in(float fadetime)
 {
-  TEXT_OBJECT_FUNCTION_VOID(grow_in(fadetime))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(grow_in(fadetime))
 }
 
 void
 TextArrayObject::grow_out(float fadetime)
 {
-  TEXT_OBJECT_FUNCTION_VOID(grow_out(fadetime))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(grow_out(fadetime))
 }
 
 void
 TextArrayObject::set_visible(bool visible)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_visible(visible))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_visible(visible))
+}
+
+bool
+TextArrayObject::get_visible() const
+{
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_visible())
 }
 
 void
 TextArrayObject::set_centered(bool centered)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_centered(centered))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_centered(centered))
+}
+
+bool
+TextArrayObject::get_centered() const
+{
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_centered())
 }
 
 void
 TextArrayObject::set_pos(float x, float y)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_pos(Vector(x, y)))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_pos(Vector(x, y)))
 }
 
 float
 TextArrayObject::get_x() const
 {
-  TEXT_OBJECT_FUNCTION_RETURN(get_pos().x)
-
-  log_warning << "'TextArrayObject' position is not set. Assuming (0,0)." << std::endl;
-  return 0;
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_pos().x)
 }
 
 float
 TextArrayObject::get_y() const
 {
-  TEXT_OBJECT_FUNCTION_RETURN(get_pos().y)
-
-  log_warning << "'TextArrayObject' position is not set. Assuming (0,0)." << std::endl;
-  return 0;
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_pos().y)
 }
 
 void
 TextArrayObject::set_anchor_point(int anchor)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_anchor_point(static_cast<AnchorPoint>(anchor)))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_anchor_point(static_cast<AnchorPoint>(anchor)))
 }
 
 int
 TextArrayObject::get_anchor_point() const
 {
-  TEXT_OBJECT_FUNCTION_RETURN(get_anchor_point())
-
-  return -1;
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_anchor_point())
 }
 
 void
 TextArrayObject::set_anchor_offset(float x, float y)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_anchor_offset(x, y))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_anchor_offset(x, y))
 }
 
 float
 TextArrayObject::get_wrap_width() const
 {
-  TEXT_OBJECT_FUNCTION_RETURN(get_wrap_width())
-
-  return 0;
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_wrap_width())
 }
 
 void
 TextArrayObject::set_wrap_width(float width)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_wrap_width(width))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_wrap_width(width))
 }
 
 void
 TextArrayObject::set_front_fill_color(float red, float green, float blue, float alpha)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_front_fill_color(red, green, blue, alpha))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_front_fill_color(red, green, blue, alpha))
 }
 
 void
 TextArrayObject::set_back_fill_color(float red, float green, float blue, float alpha)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_back_fill_color(red, green, blue, alpha))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_back_fill_color(red, green, blue, alpha))
 }
 
 void
 TextArrayObject::set_text_color(float red, float green, float blue, float alpha)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_text_color(red, green, blue, alpha))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_text_color(red, green, blue, alpha))
 }
 
 void
 TextArrayObject::set_roundness(float roundness)
 {
-  TEXT_OBJECT_FUNCTION_VOID(set_roundness(roundness))
+  TEXT_OBJECT_FUNCTION_VOID_THROW(set_roundness(roundness))
+}
+
+float
+TextArrayObject::get_roundness() const
+{
+  TEXT_OBJECT_FUNCTION_RETURN_THROW(get_roundness())
 }
 
 #undef TEXT_OBJECT_FUNCTION_VOID
 #undef TEXT_OBJECT_FUNCTION_RETURN
+#undef TEXT_OBJECT_FUNCTION_VOID_THROW
+#undef TEXT_OBJECT_FUNCTION_RETURN_THROW
 
 
 void
@@ -437,15 +461,22 @@ TextArrayObject::register_class(ssq::VM& vm)
   cls.addFunc("next_text", &TextArrayObject::next_text);
   cls.addFunc("prev_text", &TextArrayObject::prev_text);
 
+  cls.addVar("keep_visible", &TextArrayObject::m_keep_visible);
+  cls.addVar("fade_transition", &TextArrayObject::m_fade_transition);
+  cls.addVar("finished", &TextArrayObject::m_finished);
+
   /* TextObject API related */
   cls.addFunc("set_text", &TextArrayObject::set_text);
+  cls.addFunc("get_text", &TextArrayObject::get_text);
   cls.addFunc("set_font", &TextArrayObject::set_font);
   cls.addFunc("fade_in", &TextArrayObject::fade_in);
   cls.addFunc("fade_out", &TextArrayObject::fade_out);
   cls.addFunc("grow_in", &TextArrayObject::grow_in);
   cls.addFunc("grow_out", &TextArrayObject::grow_out);
   cls.addFunc("set_visible", &TextArrayObject::set_visible);
+  cls.addFunc("get_visible", &TextArrayObject::get_visible);
   cls.addFunc("set_centered", &TextArrayObject::set_centered);
+  cls.addFunc("get_centered", &TextArrayObject::get_centered);
   cls.addFunc("set_pos", &TextArrayObject::set_pos);
   cls.addFunc("get_x", &TextArrayObject::get_x);
   cls.addFunc("get_y", &TextArrayObject::get_y);
@@ -460,10 +491,14 @@ TextArrayObject::register_class(ssq::VM& vm)
   cls.addFunc("set_back_fill_color", &TextArrayObject::set_back_fill_color);
   cls.addFunc("set_text_color", &TextArrayObject::set_text_color);
   cls.addFunc("set_roundness", &TextArrayObject::set_roundness);
+  cls.addFunc("get_roundness", &TextArrayObject::set_roundness);
 
-  cls.addVar("keep_visible", &TextArrayObject::m_keep_visible);
-  cls.addVar("fade_transition", &TextArrayObject::m_fade_transition);
-  cls.addVar("finished", &TextArrayObject::m_finished);
+  cls.addVar("text", &TextArrayObject::get_text, &TextArrayObject::set_text);
+  cls.addVar("visible", &TextArrayObject::get_visible, &TextArrayObject::set_visible);
+  cls.addVar("centered", &TextArrayObject::get_centered, &TextArrayObject::set_centered);
+  cls.addVar("anchor_point", &TextArrayObject::get_anchor_point, &TextArrayObject::set_anchor_point);
+  cls.addVar("wrap_width", &TextArrayObject::get_wrap_width, &TextArrayObject::set_wrap_width);
+  cls.addVar("roundness", &TextArrayObject::get_roundness, &TextArrayObject::set_roundness);
 }
 
 /* EOF */

--- a/src/object/text_array_object.hpp
+++ b/src/object/text_array_object.hpp
@@ -32,7 +32,8 @@ typedef size_t ta_index;
 
  * @scripting
  * @summary A ""TextArrayObject"" that was given a name can be controlled by scripts.
-            Supports all functions of ${SRG_REF_Text}, applying them to the current text item.${SRG_NEWPARAGRAPH}
+            Supports all functions and variables of ${SRG_REF_Text}, applying them to the current text item.
+            If no text item is available, calling functions or using variables of ${SRG_REF_Text} (other than ""set_text()"") will result in an error.${SRG_NEWPARAGRAPH}
             Intended for scripts with narration.
  * @instances A ""TextArrayObject"" is instantiated by placing a definition inside a level.
               It can then be accessed by its name from a script or via ""sector.name"" from the console.
@@ -88,14 +89,12 @@ public:
   void set_text_index(ta_index index);
   /**
    * @scripting
-   * @deprecated Use the ""keep_visible"" property instead!
    * @description If set, keeps the current text object visible.
    * @param bool $keep_visible
    */
   void set_keep_visible(bool keep_visible);
   /**
    * @scripting
-   * @deprecated Use the ""fade_transition"" property instead!
    * @description If set, allows for a fade-in and fade-out transition.
    * @param bool $fade_transition
    */
@@ -108,8 +107,8 @@ public:
   void set_fade_time(float fadetime);
   /**
    * @scripting
-   * @deprecated Use the ""finished"" property instead!
    * @description If set, sets the text array as finished going through all text objects.
+                  Alternatively, the "finished" property can be modified.
    * @param bool $done
    */
   void set_done(bool done);
@@ -135,13 +134,16 @@ public:
    * @see: text_object.hpp
    */
   void set_text(const std::string& text);
+  const std::string& get_text() const;
   void set_font(const std::string& fontname);
   void fade_in(float fadetime);
   void fade_out(float fadetime);
   void grow_in(float fadetime);
   void grow_out(float fadetime);
   void set_visible(bool visible);
+  bool get_visible() const;
   void set_centered(bool centered);
+  bool get_centered() const;
   void set_pos(float x, float y);
   float get_x() const;
   float get_y() const;
@@ -154,6 +156,7 @@ public:
   void set_back_fill_color(float red, float green, float blue, float alpha);
   void set_text_color(float red, float green, float blue, float alpha);
   void set_roundness(float roundness);
+  float get_roundness() const;
 
   /** Gets the text item at a certain index.
       @param: index  the index of the text item to get.

--- a/src/object/text_object.cpp
+++ b/src/object/text_object.cpp
@@ -98,6 +98,12 @@ TextObject::set_text(const std::string& text)
   wrap_text();
 }
 
+const std::string&
+TextObject::get_text() const
+{
+  return m_text;
+}
+
 void
 TextObject::grow_in(float fadetime)
 {
@@ -147,10 +153,22 @@ TextObject::set_visible(bool visible)
   }
 }
 
+bool
+TextObject::get_visible() const
+{
+  return m_visible;
+}
+
 void
 TextObject::set_centered(bool centered)
 {
   m_centered = centered;
+}
+
+bool
+TextObject::get_centered() const
+{
+  return m_centered;
 }
 
 void
@@ -223,6 +241,12 @@ void
 TextObject::set_roundness(float roundness)
 {
   m_roundness = roundness;
+}
+
+float
+TextObject::get_roundness() const
+{
+  return m_roundness;
 }
 
 void
@@ -310,13 +334,16 @@ TextObject::register_class(ssq::VM& vm)
 
   /* NOTE: Any functions exposed here should also be exposed in TextArrayObject. */
   cls.addFunc("set_text", &TextObject::set_text);
+  cls.addFunc("get_text", &TextObject::get_text);
   cls.addFunc("set_font", &TextObject::set_font);
   cls.addFunc("fade_in", &TextObject::fade_in);
   cls.addFunc("fade_out", &TextObject::fade_out);
   cls.addFunc("grow_in", &TextObject::grow_in);
   cls.addFunc("grow_out", &TextObject::grow_out);
   cls.addFunc("set_visible", &TextObject::set_visible);
+  cls.addFunc("get_visible", &TextObject::get_visible);
   cls.addFunc("set_centered", &TextObject::set_centered);
+  cls.addFunc("get_centered", &TextObject::get_centered);
   cls.addFunc<void, TextObject, float, float>("set_pos", &TextObject::set_pos);
   cls.addFunc("get_x", &TextObject::get_x);
   cls.addFunc("get_y", &TextObject::get_y);
@@ -331,9 +358,12 @@ TextObject::register_class(ssq::VM& vm)
   cls.addFunc("set_back_fill_color", &TextObject::set_back_fill_color);
   cls.addFunc("set_text_color", &TextObject::set_text_color);
   cls.addFunc("set_roundness", &TextObject::set_roundness);
+  cls.addFunc("get_roundness", &TextObject::get_roundness);
 
-  cls.addVar("visible", &TextObject::m_visible);
+  cls.addVar("text", &TextObject::get_text, &TextObject::set_text);
+  cls.addVar("visible", &TextObject::get_visible, &TextObject::set_visible);
   cls.addVar("centered", &TextObject::m_centered);
+  cls.addVar("anchor_point", &TextObject::get_anchor_point, &TextObject::set_anchor_point);
   cls.addVar("wrap_width", &TextObject::m_wrap_width);
   cls.addVar("roundness", &TextObject::m_roundness);
 }

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -251,6 +251,13 @@ private:
    */
   bool m_centered;
   AnchorPoint m_anchor;
+#ifdef DOXYGEN_SCRIPTING 
+  /**
+   * @scripting
+   * @description The current anchor point. 
+   */
+  int m_anchor_point;
+#endif
   Vector m_anchor_offset;
   Vector m_pos;
   /**

--- a/src/object/text_object.hpp
+++ b/src/object/text_object.hpp
@@ -67,6 +67,11 @@ public:
   void set_text(const std::string& text);
   /**
    * @scripting
+   * @description Returns the displayed text.
+   */
+  const std::string& get_text() const;
+  /**
+   * @scripting
    * @description Sets the font of the text to be displayed.
    * @param string $fontname Valid values are normal, big and small.
    */
@@ -97,18 +102,26 @@ public:
   void grow_out(float fadetime);
   /**
    * @scripting
-   * @deprecated Use the ""visible"" property instead! (Does not apply for usage from a ""TextArray"".)
    * @description Shows or hides the text abruptly (drastic counterpart to ""fade_in()"" and ""fade_out()"").
    * @param bool $visible
    */
   void set_visible(bool visible);
   /**
    * @scripting
-   * @deprecated Use the ""centered"" property instead! (Does not apply for usage from a ""TextArray"".)
+   * @description Returns ""true"" if the text is visible.
+   */
+  bool get_visible() const;
+  /**
+   * @scripting
    * @description If ""centered"" is ""true"", the text will be centered on the screen. Otherwise, it will be left-aligned.
    * @param bool $centered
    */
   void set_centered(bool centered);
+  /**
+   * @scripting
+   * @description Returns ""true"" if the text is centered.
+   */
+  bool get_centered() const;
   /**
    * @scripting
    * @description Sets the offset of the text, relative to the anchor point.
@@ -160,13 +173,11 @@ public:
   void set_anchor_offset(float x, float y);
   /**
    * @scripting
-   * @deprecated Use the ""wrap_width"" property instead! (Does not apply for usage from a ""TextArray"".)
    * @description Gets the text wrap width of the text.
    */
   float get_wrap_width() const;
   /**
    * @scripting
-   * @deprecated Use the ""wrap_width"" property instead! (Does not apply for usage from a ""TextArray"".)
    * @description Sets the text wrap width of the text.
    * @param float $width
    */
@@ -200,11 +211,15 @@ public:
   void set_text_color(float red, float green, float blue, float alpha);
   /**
    * @scripting
-   * @deprecated Use the ""roundness"" property instead! (Does not apply for usage from a ""TextArray"".)
    * @description Sets the frame's roundness.
    * @param float $roundness
    */
   void set_roundness(float roundness);
+  /**
+   * @scripting
+   * @description Returns the roundness of the text.
+   */
+  float get_roundness() const;
 
   void set_anchor_point(AnchorPoint anchor) { m_anchor = anchor; }
   void set_anchor_offset(const Vector& offset) { m_anchor_offset = offset; }
@@ -217,6 +232,10 @@ private:
 
 private:
   FontPtr m_font;
+  /**
+   * @scripting
+   * @description The displayed text.
+   */
   std::string m_text;
   std::string m_wrapped_text;
   float m_fade_progress;

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -632,6 +632,12 @@ TileMap::set_solid(bool solid)
   update_effective_solid ();
 }
 
+bool
+TileMap::get_solid() const
+{
+  return m_effective_solid;
+}
+
 uint32_t
 TileMap::get_tile_id(int x, int y) const
 {
@@ -993,6 +999,10 @@ TileMap::register_class(ssq::VM& vm)
   cls.addFunc("set_alpha", &TileMap::set_alpha);
   cls.addFunc("get_alpha", &TileMap::get_alpha);
   cls.addFunc("set_solid", &TileMap::set_solid);
+  cls.addFunc("get_solid", &TileMap::get_solid);
+
+  cls.addVar("alpha", &TileMap::get_alpha, &TileMap::set_alpha);
+  cls.addVar("solid", &TileMap::get_solid, &TileMap::set_solid);
 }
 
 /* EOF */

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -152,6 +152,11 @@ public:
    * @param bool $solid
    */
   void set_solid(bool solid = true);
+  /**
+   * @scripting
+   * @description Returns the effective solidity of the tilemap.
+   */
+  bool get_solid() const;
 
   bool is_outside_bounds(const Vector& pos) const;
   const Tile& get_tile(int x, int y) const;
@@ -288,6 +293,14 @@ private:
   typedef std::vector<uint32_t> Tiles;
   Tiles m_tiles;
 
+#ifdef DOXYGEN_SCRIPTING
+  /**
+   * @scripting
+   * @description Equivalent to ""get_solid()"" and ""set_solid()"".
+   */
+  bool m_solid;
+#endif
+
   /* read solid: In *general*, is this a solid layer? effective solid:
      is the layer *currently* solid? A generally solid layer may be
      not solid when its alpha is low. See `is_solid' above. */
@@ -308,6 +321,10 @@ private:
   std::shared_ptr<CollisionGroundMovementManager> m_ground_movement_manager;
 
   Flip m_flip;
+  /**
+   * @scripting
+   * @description Determines the tilemap's current opacity.
+   */
   float m_alpha; /**< requested tilemap opacity */
   float m_current_alpha; /**< current tilemap opacity */
   float m_remaining_fade_time; /**< seconds until requested tilemap opacity is reached */

--- a/src/object/torch.hpp
+++ b/src/object/torch.hpp
@@ -57,13 +57,11 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""burning"" property instead!
    * @description Returns ""true"" if the torch is burning.
    */
   bool get_burning() const;
   /**
    * @scripting
-   * @deprecated Use the ""burning"" property instead!
    * @description Switches the burning state of the torch.
    * @param bool $burning
    */

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -912,7 +912,7 @@ Sector::register_class(ssq::VM& vm)
   cls.addFunc<bool, Sector, float, float, float, float>("is_free_of_movingstatics", &Sector::is_free_of_movingstatics);
   cls.addFunc<bool, Sector, float, float, float, float>("is_free_of_specifically_movingstatics", &Sector::is_free_of_specifically_movingstatics);
 
-  cls.addVar("gravity", &Sector::m_gravity);
+  cls.addVar("gravity", &Sector::get_gravity, &Sector::set_gravity);
 }
 
 /* EOF */

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -206,14 +206,12 @@ public:
 
   /**
    * @scripting
-   * @deprecated Use the ""gravity"" property instead!
    * Sets the sector's gravity.
    * @param float $gravity
    */
   void set_gravity(float gravity);
   /**
    * @scripting
-   * @deprecated Use the ""gravity"" property instead!
    * Returns the sector's gravity.
    * @param float $gravity
    */


### PR DESCRIPTION
Fixes a bug in simplesquirrel, which caused exposed class member variables to be inaccessible from Squirrel.

Additionally:

* Simplesquirrel now supports custom getters and setters for class member variables. Because of this, more `get_` and `set_` functions of objects now have an alternative variable, which can also be used.
* All `get_` and `set_` functions which were made obsolete by member variables are now un-deprecated, because of a noticeable preference amongst scripters to keep both options available for convenience.