### PR TITLE
`Screen`: Virtual methods for SDL and window resize events

### DIFF
--- a/src/editor/button_widget.cpp
+++ b/src/editor/button_widget.cpp
@@ -62,7 +62,7 @@ ButtonWidget::setup()
 }
 
 void
-ButtonWidget::resize()
+ButtonWidget::on_window_resize()
 {
 }
 

--- a/src/editor/button_widget.hpp
+++ b/src/editor/button_widget.hpp
@@ -39,7 +39,7 @@ public:
   virtual void update(float dt_sec) override;
 
   virtual void setup() override;
-  virtual void resize() override;
+  virtual void on_window_resize() override;
 
   virtual bool on_mouse_button_up(const SDL_MouseButtonEvent& button) override;
   virtual bool on_mouse_button_down(const SDL_MouseButtonEvent& button) override;

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -840,11 +840,11 @@ Editor::setup()
 }
 
 void
-Editor::resize()
+Editor::on_window_resize()
 {
   for(const auto& widget: m_widgets)
   {
-    widget->resize();
+    widget->on_window_resize();
   }
 }
 

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -82,8 +82,8 @@ public:
 
   virtual IntegrationStatus get_status() const override;
 
-  void event(const SDL_Event& ev);
-  void resize();
+  void event(const SDL_Event& ev) override;
+  void on_window_resize() override;
 
   void disable_keyboard() { m_enabled = false; }
 

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -350,7 +350,7 @@ EditorLayersWidget::has_mouse_focus() const
 }
 
 void
-EditorLayersWidget::resize()
+EditorLayersWidget::on_window_resize()
 {
   m_Ypos = SCREEN_HEIGHT - 32;
   m_Width = SCREEN_WIDTH - 128;
@@ -359,7 +359,7 @@ EditorLayersWidget::resize()
 void
 EditorLayersWidget::setup()
 {
-  resize();
+  on_window_resize();
 }
 
 void

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -59,7 +59,7 @@ public:
   virtual bool on_mouse_wheel(const SDL_MouseWheelEvent& wheel) override;
 
   virtual void setup() override;
-  virtual void resize() override;
+  virtual void on_window_resize() override;
 
   void refresh();
 

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1240,7 +1240,7 @@ EditorOverlayWidget::on_key_down(const SDL_KeyboardEvent& key)
 }
 
 void
-EditorOverlayWidget::resize()
+EditorOverlayWidget::on_window_resize()
 {
   update_pos();
 }

--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -61,7 +61,7 @@ public:
   virtual bool on_mouse_motion(const SDL_MouseMotionEvent& motion) override;
   virtual bool on_key_up(const SDL_KeyboardEvent& key) override;
   virtual bool on_key_down(const SDL_KeyboardEvent& key) override;
-  virtual void resize() override;
+  virtual void on_window_resize() override;
 
   void update_pos();
   void delete_markers();

--- a/src/editor/particle_editor.hpp
+++ b/src/editor/particle_editor.hpp
@@ -59,7 +59,7 @@ public:
 
   virtual IntegrationStatus get_status() const override;
 
-  void event(const SDL_Event& ev);
+  void event(const SDL_Event& ev) override;
   void update_keyboard(const Controller& controller);
   void check_unsaved_changes(const std::function<void ()>& action);
   void quit_editor();

--- a/src/editor/tilebox.cpp
+++ b/src/editor/tilebox.cpp
@@ -310,7 +310,7 @@ EditorTilebox::update_hovered_tile()
 }
 
 void
-EditorTilebox::resize()
+EditorTilebox::on_window_resize()
 {
   m_scrollbar->set_covered_region(m_rect.get_height());
   m_scrollbar->set_total_region(get_tiles_height());
@@ -320,7 +320,7 @@ EditorTilebox::resize()
 void
 EditorTilebox::setup()
 {
-  resize();
+  on_window_resize();
   m_tiles->set_tile(0);
 }
 
@@ -328,7 +328,7 @@ void
 EditorTilebox::set_rect(const Rectf& rect)
 {
   m_rect = rect;
-  resize();
+  on_window_resize();
 
   m_hovered_item = HoveredItem::NONE;
   m_hovered_tile = -1;

--- a/src/editor/tilebox.hpp
+++ b/src/editor/tilebox.hpp
@@ -67,7 +67,7 @@ public:
   virtual bool on_mouse_wheel(const SDL_MouseWheelEvent& wheel) override;
 
   virtual void setup() override;
-  virtual void resize() override;
+  virtual void on_window_resize() override;
 
   void set_rect(const Rectf& rect);
   Rectf get_rect() const { return m_rect; }

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -252,7 +252,7 @@ EditorToolboxWidget::on_mouse_wheel(const SDL_MouseWheelEvent& wheel)
 }
 
 void
-EditorToolboxWidget::resize()
+EditorToolboxWidget::on_window_resize()
 {
   m_pos_x = static_cast<float>(SCREEN_WIDTH - 128);
   m_tilebox->set_rect(Rectf(Vector(m_pos_x, 96.f),
@@ -264,7 +264,7 @@ EditorToolboxWidget::resize()
   m_move_mode->m_pos        = Vector(m_pos_x + 64.0f, 64.0f);
   m_undo_mode->m_pos        = Vector(m_pos_x + 96.0f, 64.0f);
 
-  m_tilebox->resize();
+  m_tilebox->on_window_resize();
 }
 
 void
@@ -272,7 +272,7 @@ EditorToolboxWidget::setup()
 {
   m_tilebox->setup();
 
-  resize();
+  on_window_resize();
   m_tilebox->get_tiles()->set_tile(0);
 }
 

--- a/src/editor/toolbox_widget.hpp
+++ b/src/editor/toolbox_widget.hpp
@@ -51,7 +51,7 @@ public:
   virtual bool on_mouse_wheel(const SDL_MouseWheelEvent& wheel) override;
 
   virtual void setup() override;
-  virtual void resize() override;
+  virtual void on_window_resize() override;
 
   void select_tilegroup(int id);
   void select_objectgroup(int id);

--- a/src/editor/widget.cpp
+++ b/src/editor/widget.cpp
@@ -39,12 +39,6 @@ Widget::event(const SDL_Event& ev)
     case SDL_KEYUP:
       return on_key_up(ev.key);
 
-    case SDL_WINDOWEVENT:
-      if (ev.window.event == SDL_WINDOWEVENT_RESIZED) {
-        resize();
-      }
-      return false;
-
     default:
       return false;
   }

--- a/src/editor/widget.hpp
+++ b/src/editor/widget.hpp
@@ -33,7 +33,7 @@ public:
   virtual void update(float dt_sec) {}
 
   virtual void setup() {}
-  virtual void resize() {}
+  virtual void on_window_resize() {}
 
   virtual bool on_mouse_button_up(const SDL_MouseButtonEvent& button) { return false; }
   virtual bool on_mouse_button_down(const SDL_MouseButtonEvent& button) { return false; }

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -24,11 +24,11 @@
 #include "gui/item_stringselect.hpp"
 #include "gui/item_toggle.hpp"
 #include "gui/menu_item.hpp"
-#include "gui/menu_manager.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/menu/menu_storage.hpp"
+#include "supertux/screen_manager.hpp"
 #include "supertux/title_screen.hpp"
 #include "util/gettext.hpp"
 #include "util/log.hpp"
@@ -579,13 +579,13 @@ OptionsMenu::menu_action(MenuItem& item)
         {
           g_config->aspect_size = Size(0, 0); // Magic values
           VideoSystem::current()->apply_config();
-          MenuManager::instance().on_window_resize();
+          ScreenManager::current()->on_window_resize();
         }
         else if (sscanf(m_aspect_ratios.list[m_aspect_ratios.next].c_str(), "%d:%d",
                         &g_config->aspect_size.width, &g_config->aspect_size.height) == 2)
         {
           VideoSystem::current()->apply_config();
-          MenuManager::instance().on_window_resize();
+          ScreenManager::current()->on_window_resize();
         }
         else
         {
@@ -605,7 +605,7 @@ OptionsMenu::menu_action(MenuItem& item)
         g_config->magnification /= 100.0f;
       }
       VideoSystem::current()->apply_config();
-      MenuManager::instance().on_window_resize();
+      ScreenManager::current()->on_window_resize();
       break;
 
     case MNID_WINDOW_RESIZABLE:
@@ -626,7 +626,7 @@ OptionsMenu::menu_action(MenuItem& item)
         {
           g_config->window_size = Size(width, height);
           VideoSystem::current()->apply_config();
-          MenuManager::instance().on_window_resize();
+          ScreenManager::current()->on_window_resize();
         }
       }
       break;
@@ -711,7 +711,7 @@ OptionsMenu::menu_action(MenuItem& item)
 
     case MNID_FULLSCREEN:
       VideoSystem::current()->apply_config();
-      MenuManager::instance().on_window_resize();
+      ScreenManager::current()->on_window_resize();
       g_config->save();
       break;
 

--- a/src/supertux/screen.hpp
+++ b/src/supertux/screen.hpp
@@ -21,6 +21,7 @@
 
 class Compositor;
 class Controller;
+union SDL_Event;
 
 /**
  * Abstract base class for code the MainLoop runs exclusively and full-screen.
@@ -55,6 +56,16 @@ public:
    * updates and logic here
    */
   virtual void update(float dt_sec, const Controller& controller) = 0;
+
+  /**
+   * gets called whenever an SDL event occurs
+   */
+  virtual void event(const SDL_Event& ev) {}
+
+  /**
+   * gets called whenever the game window is resized or resolution settings are changed
+   */
+  virtual void on_window_resize() {}
 
   /** 
    * Gives details about what the user is doing right now.

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -20,8 +20,7 @@
 
 #include "addon/addon_manager.hpp"
 #include "audio/sound_manager.hpp"
-#include "editor/editor.hpp"
-#include "editor/particle_editor.hpp"
+#include "control/input_manager.hpp"
 #include "gui/dialog.hpp"
 #include "gui/menu_manager.hpp"
 #include "gui/mousecursor.hpp"
@@ -203,6 +202,15 @@ float
 ScreenManager::get_speed() const
 {
   return m_speed;
+}
+
+void
+ScreenManager::on_window_resize()
+{
+  m_menu_manager->on_window_resize();
+
+  for (const auto& screen : m_screen_stack)
+    screen->on_window_resize();
 }
 
 void
@@ -395,13 +403,7 @@ ScreenManager::process_events()
 
     m_menu_manager->event(event);
 
-    if (Editor::is_active()) {
-      Editor::current()->event(event);
-    }
-
-    if (ParticleEditor::is_active()) {
-      ParticleEditor::current()->event(event);
-    }
+    m_screen_stack.back()->event(event);
 
     switch (event.type)
     {
@@ -414,10 +416,7 @@ ScreenManager::process_events()
         {
           case SDL_WINDOWEVENT_RESIZED:
             m_video_system.on_resize(event.window.data1, event.window.data2);
-            m_menu_manager->on_window_resize();
-            if (Editor::is_active()) {
-              Editor::current()->resize();
-            }
+            on_window_resize();
             break;
 
           case SDL_WINDOWEVENT_HIDDEN:

--- a/src/supertux/screen_manager.hpp
+++ b/src/supertux/screen_manager.hpp
@@ -52,6 +52,8 @@ public:
   float get_speed() const;
   bool has_pending_fadeout() const;
 
+  void on_window_resize();
+
   // push new screen on screen_stack
   void push_screen(std::unique_ptr<Screen> screen, std::unique_ptr<ScreenFade> fade = {});
   void pop_screen(std::unique_ptr<ScreenFade> fade = {});


### PR DESCRIPTION
The `Screen` abstract class now provides virtual methods for SDL and window resize events. The `Editor` and `PartcleEditor` classes now `override` the `event(const SDL_Event& ev)` method and `Editor` `override`s `on_window_resize()`.

Resize events in `ScreenManager` are now handled by all `Screen`s in the stack. SDL events are only handled by the current (top) screen.

Additionally, `OptionsMenu` now calls `ScreenManager::on_window_resize()` on video setting changes, instead of just calling `MenuManager::on_window_resize()`. This fixes a bug where the game crashes on changing the "Video Resolution" and "Magnification" settings from the in-editor "Options" menu.