### PR TITLE
Show sprite file name for most related errors

### DIFF
--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -98,7 +98,7 @@ Sprite::set_action(const std::string& name, int loops)
 
   const SpriteData::Action* newaction = m_data.get_action(name);
   if (!newaction) {
-    log_warning << "Action '" << name << "' not found." << std::endl;
+    log_warning << m_data.get_sprite_path() << ": Action '" << name << "' not found." << std::endl;
     return;
   }
 

--- a/src/sprite/sprite_data.hpp
+++ b/src/sprite/sprite_data.hpp
@@ -34,7 +34,7 @@ public:
    * Sprite from data.
    * `mapping` has to be a pointer to data in the form of "((hitbox 5 10 0 0) ...)".
    */
-  SpriteData(const ReaderMapping& mapping);
+  SpriteData(const ReaderMapping& mapping, const std::string& image = nullptr);
   /** Single-image sprite */
   SpriteData(const std::string& image);
   /** Dummy texture sprite */
@@ -43,6 +43,11 @@ public:
   const std::string& get_name() const
   {
     return name;
+  }
+
+  const std::string& get_sprite_path() const
+  {
+    return m_sprite_path;
   }
 
 private:
@@ -98,6 +103,7 @@ private:
 private:
   Actions actions;
   std::string name;
+  std::string m_sprite_path;
 };
 
 #endif

--- a/src/sprite/sprite_manager.cpp
+++ b/src/sprite/sprite_manager.cpp
@@ -94,7 +94,7 @@ SpriteManager::load(const std::string& filename)
     }
     else
     {
-      sprite_data = std::make_unique<SpriteData>(root.get_mapping());
+      sprite_data = std::make_unique<SpriteData>(root.get_mapping(), filename);
     }
   }
   else


### PR DESCRIPTION
Adds the filename of the sprite for sprite-related errors, makes debugging those easier.