### PR TITLE
Add clear selection button for filesystem menu

### DIFF
--- a/src/gui/menu_filesystem.cpp
+++ b/src/gui/menu_filesystem.cpp
@@ -116,6 +116,7 @@ FileSystemMenu::refresh_items()
 
   add_hl();
   add_entry(-2, _("Open Directory"));
+  add_entry(-3, _("Clear Selection"));
   add_hl();
   add_back(_("Cancel"));
 
@@ -172,6 +173,15 @@ FileSystemMenu::menu_action(MenuItem& item)
   else if (item.get_id() == -2)
   {
     FileSystem::open_path(FileSystem::join(PHYSFS_getRealDir(m_directory.c_str()), m_directory));
+  }
+  else if (item.get_id() == -3)
+  {
+    if (m_filename)
+      *m_filename = "";
+
+    if (m_callback)
+      m_callback("");
+    MenuManager::instance().pop_menu();
   }
 }
 


### PR DESCRIPTION
This allows the user to clear the selection of a filesystem option, as if it was brand new. Useful for removing the selection of a worldmap file on a teleporter, for example, which fixes #3030.