### PR TITLE
`Downloader`: Asynchronous downloading to memory, apply to release checker

### DIFF
--- a/mk/emscripten/template.html.in
+++ b/mk/emscripten/template.html.in
@@ -534,7 +534,7 @@
     }
 
     var onDownloadProgress, onDownloadFinished, onDownloadError, onDownloadAborted;
-    window.supertux_xhr_download = function(id, url, file) {
+    window.supertux_xhr_file_download = function(id, url, file) {
       console.log('id: ' + id);
       console.log('url: ' + url);
       console.log('file: ' + file);

--- a/mk/emscripten/template.html.in
+++ b/mk/emscripten/template.html.in
@@ -348,10 +348,10 @@
       },
       onRuntimeInitialized: function() {
         setResolution = Module.cwrap('set_resolution', 'void', ['number']);
-        onDownloadProgress = Module.cwrap('onDownloadProgress', 'void', ['number', 'number', 'number']);
-        onDownloadFinished = Module.cwrap('onDownloadFinished', 'void', ['number']);
-        onDownloadError = Module.cwrap('onDownloadError', 'void', ['number']);
-        onDownloadAborted = Module.cwrap('onDownloadAborted', 'void', ['number']);
+        onDownloadProgress = Module.cwrap('onDownloadProgress', 'void', ['number', 'number', 'number', 'number']);
+        onDownloadFinished = Module.cwrap('onDownloadFinished', 'void', ['number', 'number', 'string']);
+        onDownloadError = Module.cwrap('onDownloadError', 'void', ['number', 'number']);
+        onDownloadAborted = Module.cwrap('onDownloadAborted', 'void', ['number', 'number']);
       },
     };
 
@@ -534,7 +534,8 @@
     }
 
     var onDownloadProgress, onDownloadFinished, onDownloadError, onDownloadAborted;
-    window.supertux_xhr_file_download = function(id, url, file) {
+    window.supertux_xhr_file_download = function(ptr, id, url, file) {
+      console.log('downloader: ' + ptr);
       console.log('id: ' + id);
       console.log('url: ' + url);
       console.log('file: ' + file);
@@ -549,16 +550,38 @@
           var stream = FS.open(file, 'w+');
           FS.write(stream, data, 0, data.length, 0);
           FS.close(stream);
-          onDownloadFinished(id);
+          onDownloadFinished(ptr, id, "");
         }
       };
       xhr.responseType = "arraybuffer";
       xhr.open("GET", url);
       xhr.send();
 
-      xhr.addEventListener('progress', (e) => { onDownloadProgress(id, e.loaded, e.total); });
-      xhr.addEventListener('error', (e) => { onDownloadError(id); });
-      xhr.addEventListener('abort', (e) => { onDownloadAborted(id); })
+      xhr.addEventListener('progress', (e) => { onDownloadProgress(ptr, id, e.loaded, e.total); });
+      xhr.addEventListener('error', (e) => { onDownloadError(ptr, id); });
+      xhr.addEventListener('abort', (e) => { onDownloadAborted(ptr, id); })
+    }
+    window.supertux_xhr_string_download = function(ptr, id, url) {
+      console.log('downloader: ' + ptr);
+      console.log('id: ' + id);
+      console.log('url: ' + url);
+
+      if (!onDownloadProgress || !onDownloadFinished || !onDownloadError || !onDownloadAborted)
+        return;
+
+      var xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = function() {
+        if (xhr.readyState == 4) {
+          onDownloadFinished(ptr, id, xhr.responseText);
+        }
+      };
+      xhr.responseType = "text";
+      xhr.open("GET", url);
+      xhr.send();
+
+      xhr.addEventListener('progress', (e) => { onDownloadProgress(ptr, id, e.loaded, e.total); });
+      xhr.addEventListener('error', (e) => { onDownloadError(ptr, id); });
+      xhr.addEventListener('abort', (e) => { onDownloadAborted(ptr, id); })
     }
 
     window.addEventListener('resize', (e) => {

--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -992,30 +992,4 @@ AddonManager::check_for_langpack_updates()
   }
 }
 
-#ifdef EMSCRIPTEN
-void
-AddonManager::onDownloadProgress(int id, int loaded, int total)
-{
-  m_downloader.onDownloadProgress(id, loaded, total);
-}
-
-void
-AddonManager::onDownloadFinished(int id)
-{
-  m_downloader.onDownloadFinished(id);
-}
-
-void
-AddonManager::onDownloadError(int id)
-{
-  m_downloader.onDownloadError(id);
-}
-
-void
-AddonManager::onDownloadAborted(int id)
-{
-  m_downloader.onDownloadAborted(id);
-}
-#endif
-
 /* EOF */

--- a/src/addon/addon_manager.hpp
+++ b/src/addon/addon_manager.hpp
@@ -97,13 +97,6 @@ public:
   void update();
   void check_for_langpack_updates();
 
-#ifdef EMSCRIPTEN
-  void onDownloadProgress(int id, int loaded, int total);
-  void onDownloadFinished(int id);
-  void onDownloadError(int id);
-  void onDownloadAborted(int id);
-#endif
-
 private:
   TransferStatusListPtr request_install_addon_dependencies(const Addon& addon);
 

--- a/src/addon/downloader.cpp
+++ b/src/addon/downloader.cpp
@@ -700,7 +700,7 @@ Downloader::onDownloadFinished(int id, const char* data)
     const size_t data_len = strlen(data);
     if (data_len != 0)
     {
-      auto* str_transfer = dynamic_cast<StringTransfer*>(it->second->get());
+      auto* str_transfer = dynamic_cast<StringTransfer*>(it->second.get());
       if (str_transfer)
         str_transfer->on_data(data, data_len, 1);
     }

--- a/src/addon/downloader.cpp
+++ b/src/addon/downloader.cpp
@@ -232,27 +232,23 @@ TransferStatusList::is_active() const
   return !m_transfer_statuses.empty();
 }
 
-class Transfer final
+class Transfer
 {
-private:
+protected:
   Downloader& m_downloader;
   TransferId m_id;
 
-  std::string m_url;
+  const std::string m_url;
 #ifndef EMSCRIPTEN
   CURL* m_handle;
   std::array<char, CURL_ERROR_SIZE> m_error_buffer;
 #endif
 
   TransferStatusPtr m_status;
-#ifndef EMSCRIPTEN
-  std::unique_ptr<PHYSFS_file, int(*)(PHYSFS_File*)> m_fout;
-#endif
 
 public:
   Transfer(Downloader& downloader, TransferId id,
-           const std::string& url,
-           const std::string& outfile) :
+           const std::string& url) :
     m_downloader(downloader),
     m_id(id),
     m_url(url),
@@ -261,19 +257,8 @@ public:
     m_error_buffer({{'\0'}}),
 #endif
     m_status(new TransferStatus(m_downloader, id, url))
-#ifndef EMSCRIPTEN
-    ,
-    m_fout(PHYSFS_openWrite(outfile.c_str()), PHYSFS_close)
-#endif
   {
 #ifndef EMSCRIPTEN
-    if (!m_fout)
-    {
-      std::ostringstream out;
-      out << "PHYSFS_openRead() failed: " << physfsutil::get_last_error();
-      throw std::runtime_error(out.str());
-    }
-
     m_handle = curl_easy_init();
     if (!m_handle)
     {
@@ -297,12 +282,6 @@ public:
       curl_easy_setopt(m_handle, CURLOPT_PROGRESSDATA, this);
       curl_easy_setopt(m_handle, CURLOPT_PROGRESSFUNCTION, &Transfer::on_progress_wrap);
     }
-#else
-    // Sanitize input to prevent code injection from malicious callers.
-    // Escape backslashes and single quotes in the URL and file path to ensure safe usage.
-    auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
-    auto path_clean = StringUtil::replace_all(StringUtil::replace_all(FileSystem::join(std::string(PHYSFS_getWriteDir()), outfile), "\\", "\\\\"), "'", "\\'");
-    emscripten_run_script(("supertux_xhr_download(" + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
 #endif
   }
 
@@ -342,13 +321,7 @@ public:
     return m_url;
   }
 
-#ifndef EMSCRIPTEN
-  size_t on_data(void* ptr, size_t size, size_t nmemb)
-  {
-    PHYSFS_writeBytes(m_fout.get(), ptr, size * nmemb);
-    return size * nmemb;
-  }
-#endif
+  virtual size_t on_data(char* ptr, size_t size, size_t nmemb) = 0;
 
   int on_progress(double dltotal, double dlnow,
                    double ultotal, double ulnow)
@@ -380,6 +353,81 @@ private:
 private:
   Transfer(const Transfer&) = delete;
   Transfer& operator=(const Transfer&) = delete;
+};
+
+class FileTransfer final : public Transfer
+{
+private:
+#ifndef EMSCRIPTEN
+  std::unique_ptr<PHYSFS_file, int(*)(PHYSFS_File*)> m_fout;
+#endif
+
+public:
+  FileTransfer(Downloader& downloader, TransferId id,
+               const std::string& url, const std::string& outfile) :
+    Transfer(downloader, id, url)
+#ifndef EMSCRIPTEN
+    ,
+    m_fout(PHYSFS_openWrite(outfile.c_str()), PHYSFS_close)
+#endif
+  {
+#ifndef EMSCRIPTEN
+    if (!m_fout)
+    {
+      std::ostringstream out;
+      out << "PHYSFS_openRead() failed: " << physfsutil::get_last_error();
+      throw std::runtime_error(out.str());
+    }
+#else
+    // Sanitize input to prevent code injection from malicious callers.
+    // Escape backslashes and single quotes in the URL and file path to ensure safe usage.
+    auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
+    auto path_clean = StringUtil::replace_all(StringUtil::replace_all(FileSystem::join(std::string(PHYSFS_getWriteDir()), outfile), "\\", "\\\\"), "'", "\\'");
+    emscripten_run_script(("supertux_xhr_file_download(" + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
+#endif
+  }
+
+  size_t on_data(char* ptr, size_t size, size_t nmemb) override
+  {
+#ifndef EMSCRIPTEN
+    PHYSFS_writeBytes(m_fout.get(), ptr, size * nmemb);
+#endif
+    return size * nmemb;
+  }
+
+private:
+  FileTransfer(const FileTransfer&) = delete;
+  FileTransfer& operator=(const FileTransfer&) = delete;
+};
+
+class StringTransfer final : public Transfer
+{
+private:
+  std::string& m_out;
+
+public:
+  StringTransfer(Downloader& downloader, TransferId id,
+                 const std::string& url, std::string& outstr) :
+    Transfer(downloader, id, url),
+    m_out(outstr)
+  {
+#ifdef EMSCRIPTEN
+    // Sanitize input to prevent code injection from malicious callers.
+    // Escape backslashes and single quotes in the URL to ensure safe usage.
+    auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
+    emscripten_run_script(("supertux_xhr_string_download(" + std::to_string(m_id) + ", '" + url_clean + "');").c_str());
+#endif
+  }
+
+  size_t on_data(char* ptr, size_t size, size_t nmemb) override
+  {
+    m_out += std::string(ptr, size * nmemb);
+    return size * nmemb;
+  }
+
+private:
+  StringTransfer(const StringTransfer&) = delete;
+  StringTransfer& operator=(const StringTransfer&) = delete;
 };
 
 Downloader::Downloader() :
@@ -595,16 +643,28 @@ Downloader::update()
 }
 
 TransferStatusPtr
-Downloader::request_download(const std::string& url, const std::string& outfile)
+Downloader::add_transfer(std::unique_ptr<Transfer> transfer)
 {
-  log_info << "Requesting download for: " << url << std::endl;
-  auto transfer = std::make_unique<Transfer>(*this, m_next_transfer_id++, url, outfile);
 #ifndef EMSCRIPTEN
   curl_multi_add_handle(m_multi_handle, transfer->get_curl_handle());
 #endif
   auto transferId = transfer->get_id();
   m_transfers[transferId] = std::move(transfer);
   return m_transfers[transferId]->get_status();
+}
+
+TransferStatusPtr
+Downloader::request_download(const std::string& url, const std::string& filename)
+{
+  log_info << "Requesting download for: " << url << std::endl;
+  return add_transfer(std::make_unique<FileTransfer>(*this, m_next_transfer_id++, url, filename));
+}
+
+TransferStatusPtr
+Downloader::request_string_download(const std::string& url, std::string& out_string)
+{
+  log_info << "Requesting download for: " << url << std::endl;
+  return add_transfer(std::make_unique<StringTransfer>(*this, m_next_transfer_id++, url, out_string));
 }
 
 #ifdef EMSCRIPTEN

--- a/src/addon/downloader.cpp
+++ b/src/addon/downloader.cpp
@@ -383,7 +383,7 @@ public:
     // Escape backslashes and single quotes in the URL and file path to ensure safe usage.
     auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
     auto path_clean = StringUtil::replace_all(StringUtil::replace_all(FileSystem::join(std::string(PHYSFS_getWriteDir()), outfile), "\\", "\\\\"), "'", "\\'");
-    emscripten_run_script(("supertux_xhr_file_download(" + std::to_string(static_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
+    emscripten_run_script(("supertux_xhr_file_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
 #endif
   }
 
@@ -415,7 +415,7 @@ public:
     // Sanitize input to prevent code injection from malicious callers.
     // Escape backslashes and single quotes in the URL to ensure safe usage.
     auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
-    emscripten_run_script(("supertux_xhr_string_download(" + std::to_string(static_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "');").c_str());
+    emscripten_run_script(("supertux_xhr_string_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "');").c_str());
 #endif
   }
 
@@ -697,11 +697,12 @@ Downloader::onDownloadFinished(int id, const char* data)
     // If a string with the downloaded data is provided,
     // that would mean a StringTransfer was taking place.
     // Pass the data to that transfer.
-    if (strlen(data) != 0)
+    const size_t data_len = strlen(data);
+    if (data_len != 0)
     {
-      auto* str_transfer = dynamic_cast<StringTransfer*>(it->get());
+      auto* str_transfer = dynamic_cast<StringTransfer*>(it->second->get());
       if (str_transfer)
-        str_transfer->on_data(data, strlen(data), 1);
+        str_transfer->on_data(data, data_len, 1);
     }
 
     TransferStatusPtr status = it->second->get_status();

--- a/src/addon/downloader.cpp
+++ b/src/addon/downloader.cpp
@@ -383,7 +383,7 @@ public:
     // Escape backslashes and single quotes in the URL and file path to ensure safe usage.
     auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
     auto path_clean = StringUtil::replace_all(StringUtil::replace_all(FileSystem::join(std::string(PHYSFS_getWriteDir()), outfile), "\\", "\\\\"), "'", "\\'");
-    emscripten_run_script(("supertux_xhr_file_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
+    emscripten_run_script(("supertux_xhr_file_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", " + std::to_string(m_id) + ", '" + url_clean + "', '" + path_clean + "');").c_str());
 #endif
   }
 
@@ -415,7 +415,7 @@ public:
     // Sanitize input to prevent code injection from malicious callers.
     // Escape backslashes and single quotes in the URL to ensure safe usage.
     auto url_clean = StringUtil::replace_all(StringUtil::replace_all(url, "\\", "\\\\"), "'", "\\'");
-    emscripten_run_script(("supertux_xhr_string_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", '" + std::to_string(m_id) + ", '" + url_clean + "');").c_str());
+    emscripten_run_script(("supertux_xhr_string_download(" + std::to_string(reinterpret_cast<intptr_t>(&m_downloader)) + ", " + std::to_string(m_id) + ", '" + url_clean + "');").c_str());
 #endif
   }
 

--- a/src/addon/downloader.hpp
+++ b/src/addon/downloader.hpp
@@ -148,7 +148,7 @@ public:
 
 #ifdef EMSCRIPTEN
   void onDownloadProgress(int id, int loaded, int total);
-  void onDownloadFinished(int id);
+  void onDownloadFinished(int id, const char* data);
   void onDownloadError(int id);
   void onDownloadAborted(int id);
 #endif

--- a/src/addon/downloader.hpp
+++ b/src/addon/downloader.hpp
@@ -143,6 +143,7 @@ public:
   void update();
 
   TransferStatusPtr request_download(const std::string& url, const std::string& filename);
+  TransferStatusPtr request_string_download(const std::string& url, std::string& out_string);
   void abort(TransferId id);
 
 #ifdef EMSCRIPTEN
@@ -151,6 +152,9 @@ public:
   void onDownloadError(int id);
   void onDownloadAborted(int id);
 #endif
+
+private:
+  TransferStatusPtr add_transfer(std::unique_ptr<Transfer> transfer);
 
 private:
   Downloader(const Downloader&) = delete;

--- a/src/port/emscripten.hpp
+++ b/src/port/emscripten.hpp
@@ -21,7 +21,7 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
-#include "addon/addon_manager.hpp"
+#include "addon/downloader.hpp"
 #include "gui/menu_manager.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
@@ -32,10 +32,10 @@ extern "C" {
 void set_resolution(int w, int h);
 void save_config();
 void init_emscripten();
-void onDownloadProgress(int id, int loaded, int total);
-void onDownloadFinished(int id);
-void onDownloadError(int id);
-void onDownloadAborted(int id);
+void onDownloadProgress(intptr_t address, int id, int loaded, int total);
+void onDownloadFinished(intptr_t address, int id, const char* data);
+void onDownloadError(intptr_t address, int id);
+void onDownloadAborted(intptr_t address, int id);
 const char* getExceptionMessage(intptr_t address);
 
 EMSCRIPTEN_KEEPALIVE // This is probably not useful, I just want ppl to know it exists
@@ -54,27 +54,27 @@ save_config()
 }
 
 void
-onDownloadProgress(int id, int loaded, int total)
+onDownloadProgress(intptr_t address, int id, int loaded, int total)
 {
-  AddonManager::current()->onDownloadProgress(id, loaded, total);
+  reinterpret_cast<Downloader*>(address)->onDownloadProgress(id, loaded, total);
 }
 
 void
-onDownloadFinished(int id)
+onDownloadFinished(intptr_t address, int id, const char* data)
 {
-  AddonManager::current()->onDownloadFinished(id);
+  reinterpret_cast<Downloader*>(address)->onDownloadFinished(id, data);
 }
 
 void
-onDownloadError(int id)
+onDownloadError(intptr_t address, int id)
 {
-  AddonManager::current()->onDownloadError(id);
+  reinterpret_cast<Downloader*>(address)->onDownloadError(id);
 }
 
 void
-onDownloadAborted(int id)
+onDownloadAborted(intptr_t address, int id)
 {
-  AddonManager::current()->onDownloadAborted(id);
+  reinterpret_cast<Downloader*>(address)->onDownloadAborted(id);
 }
 
 const char*

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -142,7 +142,8 @@ Main::Main() :
   m_game_manager(),
   m_screen_manager(),
   m_savegame(),
-  m_downloader() // Used for getting the version of the latest SuperTux release.
+  m_downloader(), // Used for getting the version of the latest SuperTux release.
+  m_version_info()
 {
 }
 
@@ -773,16 +774,18 @@ Main::release_check()
 {
   // Detect a potential new release of SuperTux. If a release, other than
   // the current one is indicated on the given web file, show a notification on the main menu screen.
-  const std::string target_file = "ver_info.nfo";
-  TransferStatusPtr status = m_downloader.request_download("https://raw.githubusercontent.com/SuperTux/addons/master/ver_info.nfo", target_file);
-  status->then([target_file, status](bool success)
+  TransferStatusPtr status = m_downloader.request_string_download(
+    "https://raw.githubusercontent.com/SuperTux/addons/master/ver_info.nfo",
+    m_version_info
+  );
+  status->then([this, status](bool success)
   {
     if (!success)
     {
       log_warning << "Error performing new release check: Failed to download \"supertux-versioninfo\" file: " << status->error_msg << std::endl;
       return;
     }
-    auto doc = ReaderDocument::from_file(target_file);
+    auto doc = ReaderDocument::from_string(m_version_info, "ver_info.nfo");
     auto root = doc.get_root();
     if (root.get_name() != "supertux-versioninfo")
     {

--- a/src/supertux/main.hpp
+++ b/src/supertux/main.hpp
@@ -123,6 +123,7 @@ private:
   std::unique_ptr<Savegame> m_savegame;
 
   Downloader m_downloader; // Used for getting the version of the latest SuperTux release.
+  std::string m_version_info;
 
 private:
   Main(const Main&) = delete;

--- a/src/util/reader_document.cpp
+++ b/src/util/reader_document.cpp
@@ -24,6 +24,14 @@
 #include "util/log.hpp"
 
 ReaderDocument
+ReaderDocument::from_string(const std::string& string, const std::string& filename)
+{
+  std::stringstream stream;
+  stream << string;
+  return from_stream(stream, filename);
+}
+
+ReaderDocument
 ReaderDocument::from_stream(std::istream& stream, const std::string& filename)
 {
   sexp::Value sx = sexp::Parser::from_stream(stream, sexp::Parser::USE_ARRAYS);

--- a/src/util/reader_document.hpp
+++ b/src/util/reader_document.hpp
@@ -27,6 +27,7 @@
 class ReaderDocument final
 {
 public:
+  static ReaderDocument from_string(const std::string& string, const std::string& filename = "<string>");
   static ReaderDocument from_stream(std::istream& stream, const std::string& filename = "<stream>");
   static ReaderDocument from_file(const std::string& filename);
 


### PR DESCRIPTION
`Transfer` is now a base class for two new derived classes: `FileTransfer` and `StringTransfer`. `FileTransfer` has the same functionality which `Transfer` had before - it writes received data to a file. `StringTransfer`, however, appends received data to a referenced string. These additions are also supported by WASM (**NOTE:** Needs to be tested).

A `StringTransfer`, which is requested by calling `Downloader::request_string_download()`, is now used for downloading the "supertux-versioninfo" file, used by the in-game release checker.

Additionally:

* WASM now supports downloaders, other than the `AddonManager` one, by providing a pointer to the current `Downloader` (**NOTE:** Needs to be tested).
* `ReaderDocument` now contains the `from_string()` static function, which is a convenience wrapper around `from_stream()`, where a stream, which only has the given string in its buffer, is provided.

Closes #2627.