### PR TITLE
Add trigger direction property to script trigger

### DIFF
--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -38,6 +38,7 @@ public:
 
 private:
   EventType triggerevent;
+  Direction m_trigger_direction;
   std::string script;
   bool must_activate;
   bool oneshot;


### PR DESCRIPTION
Adds a direction property to script trigger:
"auto" means that the trigger can be triggered from all sides.

"left" means only from the left side, "right" only from the right side etc.