### PR TITLE
Explosion light sprite fades in and out smoothly

### DIFF
--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -41,7 +41,7 @@ Explosion::Explosion(const Vector& pos, float p_push_strength,
   m_lightsprite(SpriteManager::current()->create(p_short_fuse ?
                                                  "images/objects/lightmap_light/lightmap_light-medium.sprite" :
                                                  "images/objects/lightmap_light/lightmap_light-large.sprite")),
-  m_color(0.5f, 0.3f, 0.2f, 0.f),
+  m_color(1.f, 0.5f, 0.2f, 0.f),
   m_fading_timer(),
   short_fuse(p_short_fuse)
 {
@@ -60,7 +60,7 @@ Explosion::Explosion(const ReaderMapping& reader) :
   num_particles(100),
   m_state(E_STATE_WAITING),
   m_lightsprite(nullptr),
-  m_color(0.5f, 0.3f, 0.2f, 0.f),
+  m_color(1.f, 0.5f, 0.2f, 0.f),
   m_fading_timer(),
   short_fuse(false)
 {

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -37,14 +37,16 @@ Explosion::Explosion(const Vector& pos, float p_push_strength,
   hurt(!p_short_fuse),
   push_strength(p_push_strength),
   num_particles(p_num_particles),
-  state(STATE_WAITING),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  m_state(E_STATE_WAITING),
+  m_lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  m_color(0.6f, 0.6f, 0.6f, 0.f),
+  m_fading_timer(),
   short_fuse(p_short_fuse)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
   set_pos(get_pos() - (m_col.m_bbox.get_middle() - get_pos()));
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.6f, 0.6f, 0.6f));
+  m_lightsprite->set_blend(Blend::ADD);
+  m_lightsprite->set_color(m_color);
 }
 
 Explosion::Explosion(const ReaderMapping& reader) :
@@ -52,21 +54,23 @@ Explosion::Explosion(const ReaderMapping& reader) :
   hurt(true),
   push_strength(-1),
   num_particles(100),
-  state(STATE_WAITING),
-  lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  m_state(E_STATE_WAITING),
+  m_lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
+  m_color(0.6f, 0.6f, 0.6f, 0.f),
+  m_fading_timer(),
   short_fuse(false)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
-  lightsprite->set_blend(Blend::ADD);
-  lightsprite->set_color(Color(0.6f, 0.6f, 0.6f));
+  m_lightsprite->set_blend(Blend::ADD);
+  m_lightsprite->set_color(m_color);
 }
 
 void
 Explosion::explode()
 {
-  if (state != STATE_WAITING)
+  if (m_state != E_STATE_WAITING)
     return;
-  state = STATE_EXPLODING;
+  m_state = E_STATE_EXPLODING;
 
   Sector::get().get_camera().shake(.1f, 0.f, 10.f);
 
@@ -151,14 +155,32 @@ Explosion::explode()
 void
 Explosion::update(float )
 {
-  switch (state) {
-    case STATE_WAITING:
+  switch (m_state)
+  {
+    case E_STATE_WAITING:
       explode();
+      m_fading_timer.start(0.15f);
       break;
-    case STATE_EXPLODING:
-      if (m_sprite->animation_done()) {
+
+    case E_STATE_EXPLODING:
+      m_color.alpha = std::min(m_fading_timer.get_progress(), 1.f);
+
+      if (m_fading_timer.check())
+      {
+        m_fading_timer.start(1.5f);
+        m_state = E_STATE_FADING;
+      }
+
+      break;
+
+    case E_STATE_FADING:
+      m_color.alpha = std::max(1.f - m_fading_timer.get_progress(), 0.f);
+
+      if (m_fading_timer.check())
+      {
         remove_me();
       }
+
       break;
   }
 }
@@ -167,13 +189,14 @@ void
 Explosion::draw(DrawingContext& context)
 {
   m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS+40);
-  lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
+  m_lightsprite->set_color(m_color);
+  m_lightsprite->draw(context.light(), m_col.m_bbox.get_middle(), 0);
 }
 
 HitResponse
 Explosion::collision(GameObject& other, const CollisionHit& )
 {
-  if ((state != STATE_EXPLODING) || !hurt || m_sprite->get_current_frame() > 8)
+  if ((m_state != E_STATE_EXPLODING) || !hurt || m_sprite->get_current_frame() > 8)
     return ABORT_MOVE;
 
   auto player = dynamic_cast<Player*>(&other);

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -167,7 +167,7 @@ Explosion::update(float )
 
       if (m_fading_timer.check())
       {
-        m_fading_timer.start(1.5f);
+        m_fading_timer.start(hurt ? 1.5f : .85f);
         m_state = E_STATE_FADING;
       }
 

--- a/src/object/explosion.cpp
+++ b/src/object/explosion.cpp
@@ -38,13 +38,17 @@ Explosion::Explosion(const Vector& pos, float p_push_strength,
   push_strength(p_push_strength),
   num_particles(p_num_particles),
   m_state(E_STATE_WAITING),
-  m_lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
-  m_color(0.6f, 0.6f, 0.6f, 0.f),
+  m_lightsprite(SpriteManager::current()->create(p_short_fuse ?
+                                                 "images/objects/lightmap_light/lightmap_light-medium.sprite" :
+                                                 "images/objects/lightmap_light/lightmap_light-large.sprite")),
+  m_color(0.5f, 0.3f, 0.2f, 0.f),
   m_fading_timer(),
   short_fuse(p_short_fuse)
 {
-  SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
   set_pos(get_pos() - (m_col.m_bbox.get_middle() - get_pos()));
+
+  SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
+
   m_lightsprite->set_blend(Blend::ADD);
   m_lightsprite->set_color(m_color);
 }
@@ -55,12 +59,16 @@ Explosion::Explosion(const ReaderMapping& reader) :
   push_strength(-1),
   num_particles(100),
   m_state(E_STATE_WAITING),
-  m_lightsprite(SpriteManager::current()->create("images/objects/lightmap_light/lightmap_light-large.sprite")),
-  m_color(0.6f, 0.6f, 0.6f, 0.f),
+  m_lightsprite(nullptr),
+  m_color(0.5f, 0.3f, 0.2f, 0.f),
   m_fading_timer(),
   short_fuse(false)
 {
   SoundManager::current()->preload(short_fuse ? "sounds/firecracker.ogg" : "sounds/explosion.wav");
+
+  m_lightsprite = (SpriteManager::current()->create(short_fuse ?
+                                                    "images/objects/lightmap_light/lightmap_light-medium.sprite" :
+                                                    "images/objects/lightmap_light/lightmap_light-large.sprite"));
   m_lightsprite->set_blend(Blend::ADD);
   m_lightsprite->set_color(m_color);
 }
@@ -167,7 +175,7 @@ Explosion::update(float )
 
       if (m_fading_timer.check())
       {
-        m_fading_timer.start(hurt ? 1.5f : .85f);
+        m_fading_timer.start(short_fuse ? .85f : 1.5f);
         m_state = E_STATE_FADING;
       }
 

--- a/src/object/explosion.hpp
+++ b/src/object/explosion.hpp
@@ -19,6 +19,8 @@
 
 #include "object/moving_sprite.hpp"
 
+#include "supertux/timer.hpp"
+
 #define EXPLOSION_STRENGTH_DEFAULT (1464.8f * 32.0f * 32.0f)
 #define EXPLOSION_STRENGTH_NEAR (1000.f * 32.0f * 32.0f)
 
@@ -50,16 +52,19 @@ private:
 
 private:
   enum State {
-    STATE_WAITING,
-    STATE_EXPLODING
+    E_STATE_WAITING,
+    E_STATE_EXPLODING,
+    E_STATE_FADING
   };
 
 private:
   bool hurt;
   float push_strength;
   int num_particles;
-  State state;
-  SpritePtr lightsprite;
+  State m_state;
+  SpritePtr m_lightsprite;
+  Color m_color;
+  Timer m_fading_timer;
   bool short_fuse;
 
 private:


### PR DESCRIPTION
The explosion light sprite now fades in and out in a smooth fashion.

fixes #960