### PR TITLE
INSTALL.md: fix partial upgrade on Arch Linux install line

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 Install instructions for SuperTux - <https://supertux.org/>
 ====================================================================
-Last update: May 19, 2023
+Last update: August 28, 2024
 
 Quick links:
 - [Binaires](#binaries)
@@ -109,9 +109,9 @@ For ease of use, here are some installation lines for some Linux distributions:
   sudo apt-get update && sudo apt-get install -y cmake build-essential libogg-dev libvorbis-dev libopenal-dev libsdl2-dev libsdl2-image-dev libfreetype6-dev libraqm-dev libcurl4-openssl-dev libglew-dev libharfbuzz-dev libfribidi-dev libglm-dev zlib1g-dev
   ```
 
-- ArchLinux (using sudo, as of June 3rd 2023)
+- ArchLinux (using sudo, as of August 28th 2024)
   ```
-  sudo pacman -Sy cmake base-devel libogg libvorbis openal sdl2 sdl2_image freetype2 libraqm curl openssl glew harfbuzz fribidi glm zlib
+  sudo pacman -S cmake base-devel libogg libvorbis openal sdl2 sdl2_image freetype2 libraqm curl openssl glew harfbuzz fribidi glm zlib
   ```
 
 ### Linux/UNIX using CMake


### PR DESCRIPTION
Partial upgrades are dangerous on Arch Linux.
Partial upgrades may occur when a `-y` operation is given without a cor
responding `-u` operation.

Quote from the ArchWiki:
> Do **not** use:
> `pacman -Sy package`
> `pacman -Sy` followed by `pacman -S` package (Note the absence of
> `-Su` in the installation of the package.)
> `pacman -Syuw` (Note that `pacman -Syuw` does imply the same risks li
> ke pacman -Sy`, as it will update the pacman sync database without installing the newer packages.)

Source: https://t.ly/1CGKn
Example of breakage occuring from similar commands: https://t.ly/Bzc1f

[ci skip]