### PR TITLE
Allow picking up items while crawling

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1736,7 +1736,7 @@ Player::position_grabbed_object(bool teleport)
 bool
 Player::try_grab()
 {
-  if (m_controller->hold(Control::ACTION) && !m_grabbed_object && !m_duck && !m_released_object)
+  if (m_controller->hold(Control::ACTION) && !m_grabbed_object && !(m_duck ^ m_crawl) && !m_released_object)
   {
 
     Vector pos(0.0f, 0.0f);


### PR DESCRIPTION
Allows picking up items (such as springs* and stone blocks), while Tux is crawling (triggered by moving while ducking).

This is to avoid Tux getting trapped by any item that can be grabbed.

Closes #2979.