### PR TITLE
Editor: Support multiple autotilesets per tile

### DIFF
--- a/data/images/autotiles.satc
+++ b/data/images/autotiles.satc
@@ -14,7 +14,7 @@
 ;;  |
 ;;  V
 ;; Contains :
-;;   The autotileset name (unused as of writing these lines) : (name "snow")
+;;   The autotileset name (used as an indicator in the editor) : (name "snow")
 ;;     The name of the autotileset is "snow".
 ;;   The default tile ID (used if no tile matches any mask) : (default 11)
 ;;     If a very special tile is needed (and it doesn't exist), it will use this tile (it's a center tile) by default.
@@ -75,7 +75,7 @@
 ;;       (Contributor, 2020)
 ;;
 ;;
-;; NOTE : A single id MUST NOT OCCUR MORE THAN ONE AUTOTILE IN THE ENTIRE FILE.
+;; NOTE : A single id MUST NOT OCCUR IN MORE THAN ONE AUTOTILE IN AN AUTOTILESET.
 ;;        Otherwise, the behavior is UNDEFINED.
 
 (supertux-autotiles

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -411,6 +411,12 @@ Editor::get_tileselect_move_mode() const
 }
 
 void
+Editor::update_autotileset()
+{
+  m_overlay_widget->update_autotileset();
+}
+
+void
 Editor::scroll(const Vector& velocity)
 {
   if (!m_levelloaded) return;

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -124,6 +124,8 @@ public:
   void check_deprecated_tiles(bool focus = false);
   bool has_deprecated_tiles() const { return m_has_deprecated_tiles; }
 
+  void update_autotileset();
+
   /** Checks whether the level can be saved and does not contain
       obvious issues (currently: check if main sector and a spawn point
       named "main" is present) */

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1624,7 +1624,7 @@ EditorOverlayWidget::draw(DrawingContext& context)
       {
         if (autotileset)
         {
-          context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Autotile erasing mode is on (\"{}\") {}")), autotileset->get_name(), get_autotileset_key_range()), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_active_color);
+          context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Autotile erasing mode is on (\"{}\")")), autotileset->get_name()) + " " + get_autotileset_key_range(), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_active_color);
         }
         else
         {
@@ -1633,7 +1633,7 @@ EditorOverlayWidget::draw(DrawingContext& context)
       }
       else if (autotileset)
       {
-        context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Autotile mode is on (\"{}\") {}")), autotileset->get_name(), get_autotileset_key_range()), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_active_color);
+        context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Autotile mode is on (\"{}\")")), autotileset->get_name()) + " " + get_autotileset_key_range(), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_active_color);
       }
       else
       {
@@ -1642,11 +1642,11 @@ EditorOverlayWidget::draw(DrawingContext& context)
     }
     else if (m_editor.get_tiles()->pos(0, 0) == 0)
     {
-      context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Hold Ctrl to enable autotile erasing {}")), get_autotileset_key_range()), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_available_color);
+      context.color().draw_text(Resources::normal_font, _("Hold Ctrl to enable autotile erasing") + " " + get_autotileset_key_range(), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_available_color);
     }
     else
     {
-      context.color().draw_text(Resources::normal_font, fmt::format(fmt::runtime(_("Hold Ctrl to enable autotile {}")), get_autotileset_key_range()), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_available_color);
+      context.color().draw_text(Resources::normal_font, _("Hold Ctrl to enable autotile") + " " + get_autotileset_key_range(), Vector(144, 16), ALIGN_LEFT, LAYER_OBJECTS+1, EditorOverlayWidget::text_autotile_available_color);
     }
   }
 }

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1288,7 +1288,7 @@ EditorOverlayWidget::update_autotileset()
     return;
   }
   auto it_autotileset = std::find(m_available_autotilesets.begin(), m_available_autotilesets.end(), old_autotileset);
-  m_current_autotileset = it_autotileset != m_available_autotilesets.end() ? it_autotileset - m_available_autotilesets.begin() : 0;
+  m_current_autotileset = it_autotileset != m_available_autotilesets.end() ? static_cast<int>(it_autotileset - m_available_autotilesets.begin()) : 0;
 }
 
 AutotileSet*

--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -28,6 +28,7 @@
 #include "supertux/timer.hpp"
 #include "util/typed_uid.hpp"
 
+class AutotileSet;
 class Color;
 class DrawingContext;
 class Editor;
@@ -64,6 +65,7 @@ public:
   virtual void on_window_resize() override;
 
   void update_pos();
+  void update_autotileset();
   void delete_markers();
   void update_node_iterators();
   void on_level_change();
@@ -101,6 +103,9 @@ private:
   void select_object();
   void add_path_node();
 
+  AutotileSet* get_current_autotileset() const;
+  std::string get_autotileset_key_range() const;
+
   void draw_tile_tip(DrawingContext&);
   void draw_tile_grid(DrawingContext&, int tile_size, bool draw_shadow) const;
   void draw_tilemap_border(DrawingContext&);
@@ -130,6 +135,7 @@ private:
   Editor& m_editor;
   Vector m_hovered_tile;
   Vector m_hovered_tile_prev;
+  Vector m_last_hovered_tile;
   Vector m_sector_pos;
   Vector m_mouse_pos;
   Vector m_previous_mouse_pos;
@@ -146,6 +152,9 @@ private:
   TypedUID<GameObject> m_selected_object;
   TypedUID<PathGameObject> m_edited_path;
   TypedUID<NodeMarker> m_last_node_marker;
+
+  std::vector<AutotileSet*> m_available_autotilesets;
+  int m_current_autotileset;
 
   std::unique_ptr<Tip> m_object_tip;
   Vector m_obj_mouse_desync;

--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -83,7 +83,7 @@ private:
   void input_autotile(const Vector& pos, uint32_t tile);
   void autotile_corner(const Vector& pos, uint32_t tile, TileMap::AutotileCornerOperation op);
   void input_autotile_corner(const Vector& corner, uint32_t tile, const Vector& override_pos = Vector(-1.f, -1.f));
-  void put_tile(const Vector& target_tile);
+  void put_tiles(const Vector& target_tile, TileSelection* tiles);
   void put_next_tiles();
   void draw_rectangle();
   void preview_rectangle();

--- a/src/editor/toolbox_widget.cpp
+++ b/src/editor/toolbox_widget.cpp
@@ -108,6 +108,7 @@ EditorToolboxWidget::on_mouse_button_down(const SDL_MouseButtonEvent& button)
 {
   if (m_tilebox->on_mouse_button_down(button))
   {
+    m_editor.update_autotileset();
     update_mouse_icon();
     return true;
   }
@@ -150,6 +151,7 @@ EditorToolboxWidget::on_mouse_button_down(const SDL_MouseButtonEvent& button)
           case 0:
             m_tilebox->get_tiles()->set_tile(0);
             m_tilebox->set_object("");
+            m_editor.update_autotileset();
             update_mouse_icon();
             break;
 

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -654,6 +654,12 @@ TileMap::get_tile_id(int x, int y) const
   return m_tiles[y*m_width + x];
 }
 
+uint32_t
+TileMap::get_tile_id(const Vector& pos) const
+{
+  return get_tile_id(static_cast<int>(pos.x), static_cast<int>(pos.y));
+}
+
 bool
 TileMap::is_outside_bounds(const Vector& pos) const
 {
@@ -957,7 +963,7 @@ TileMap::register_class(ssq::VM& vm)
 
   PathObject::register_members(cls);
 
-  cls.addFunc("get_tile_id", &TileMap::get_tile_id);
+  cls.addFunc<uint32_t, TileMap, int, int>("get_tile_id", &TileMap::get_tile_id);
   cls.addFunc<uint32_t, TileMap, float, float>("get_tile_id_at", &TileMap::get_tile_id_at);
   cls.addFunc("change", &TileMap::change);
   cls.addFunc<void, TileMap, float, float, uint32_t>("change_at", &TileMap::change_at);

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -820,7 +820,7 @@ TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos, AutotileSet
   if (!autotileset || (current_tile != 0 && !autotileset->is_member(current_tile)))
     return;
 
-  if (autotileset->is_corner())
+  if (current_tile != 0 && autotileset->is_corner())
   {
     int x = static_cast<int>(corner_pos.x), y = static_cast<int>(corner_pos.y);
     autotile_corner(x, y, current_tile, autotileset, AutotileCornerOperation::REMOVE_TOP_LEFT);

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -817,7 +817,7 @@ TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos, AutotileSet
 
   uint32_t current_tile = m_tiles[static_cast<int>(pos.y)*m_width
                                   + static_cast<int>(pos.x)];
-  if (!autotileset || !autotileset->is_member(current_tile))
+  if (!autotileset || (current_tile != 0 && !autotileset->is_member(current_tile)))
     return;
 
   if (autotileset->is_corner())

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -726,80 +726,43 @@ TileMap::change_all(uint32_t oldtile, uint32_t newtile)
 }
 
 void
-TileMap::autotile(int x, int y, uint32_t tile)
+TileMap::autotile(int x, int y, uint32_t tile, AutotileSet* autotileset)
 {
   if (x < 0 || x >= m_width || y < 0 || y >= m_height)
     return;
 
-  uint32_t current_tile = m_tiles[y*m_width + x];
-  AutotileSet* curr_set;
-  if (current_tile == 0)
-  {
-    // Special case 1 : If the tile is empty, check if we can use a non-solid
-    // tile from the currently selected tile's autotile set (if any).
-    curr_set = m_tileset->get_autotileset_from_tile(tile);
-  }
-  else if (m_tileset->get_autotileset_from_tile(tile) != nullptr &&
-      m_tileset->get_autotileset_from_tile(tile)->is_member(current_tile))
-  {
-    // Special case 2 : If the tile is in multiple autotilesets, check if it
-    // is in the same tileset as the selected tile. (Example : tile 47)
-    curr_set = m_tileset->get_autotileset_from_tile(tile);
-  }
-  else
-  {
-    curr_set = m_tileset->get_autotileset_from_tile(current_tile);
-  }
-
-  // If tile is not autotileable, abort
-  // If tile is from a corner autotileset, abort as well
-  if (curr_set == nullptr)
-  {
+  if (!autotileset || !autotileset->is_member(tile))
     return;
-  }
 
-  uint32_t realtile = curr_set->get_autotile(current_tile,
-    curr_set->is_solid(get_tile_id(x-1, y-1)),
-    curr_set->is_solid(get_tile_id(x  , y-1)),
-    curr_set->is_solid(get_tile_id(x+1, y-1)),
-    curr_set->is_solid(get_tile_id(x-1, y  )),
-    curr_set->is_solid(get_tile_id(x  , y  )),
-    curr_set->is_solid(get_tile_id(x+1, y  )),
-    curr_set->is_solid(get_tile_id(x-1, y+1)),
-    curr_set->is_solid(get_tile_id(x  , y+1)),
-    curr_set->is_solid(get_tile_id(x+1, y+1)),
+  m_tiles[y*m_width + x] = autotileset->get_autotile(m_tiles[y*m_width + x],
+    autotileset->is_solid(get_tile_id(x-1, y-1)),
+    autotileset->is_solid(get_tile_id(x  , y-1)),
+    autotileset->is_solid(get_tile_id(x+1, y-1)),
+    autotileset->is_solid(get_tile_id(x-1, y  )),
+    autotileset->is_solid(get_tile_id(x  , y  )),
+    autotileset->is_solid(get_tile_id(x+1, y  )),
+    autotileset->is_solid(get_tile_id(x-1, y+1)),
+    autotileset->is_solid(get_tile_id(x  , y+1)),
+    autotileset->is_solid(get_tile_id(x+1, y+1)),
     x, y);
-
-  m_tiles[y*m_width + x] = realtile;
 }
 
 void
-TileMap::autotile_corner(int x, int y, uint32_t tile, AutotileCornerOperation op)
+TileMap::autotile_corner(int x, int y, uint32_t tile, AutotileSet* autotileset, AutotileCornerOperation op)
 {
   if (x < 0 || x >= m_width || y < 0 || y >= m_height)
     return;
 
-  if (!m_tileset->get_autotileset_from_tile(tile)->is_corner())
+  if (!autotileset || !autotileset->is_corner() || !autotileset->is_member(tile))
     return;
-
-  AutotileSet* curr_set = m_tileset->get_autotileset_from_tile(tile);
-
-  // If tile is not autotileable, abort
-  if (curr_set == nullptr)
-  {
-    return;
-  }
 
   // If tile is not empty or already of the appropriate tileset, abort
   uint32_t current_tile = m_tiles[y*m_width + x];
-  if (current_tile != 0 && (m_tileset->get_autotileset_from_tile(tile) != nullptr
-      && !m_tileset->get_autotileset_from_tile(tile)->is_member(current_tile)))
-  {
+  if (current_tile != 0 && !autotileset->is_member(current_tile))
     return;
-  }
 
   // If the current tile is 0, it will automatically return 0
-  uint8_t mask = curr_set->get_mask_from_tile(current_tile);
+  uint8_t mask = autotileset->get_mask_from_tile(current_tile);
   if (op == AutotileCornerOperation::REMOVE_TOP_LEFT) mask = static_cast<uint8_t>(mask & 0x07);
   if (op == AutotileCornerOperation::REMOVE_TOP_RIGHT) mask = static_cast<uint8_t>(mask & 0x0B);
   if (op == AutotileCornerOperation::REMOVE_BOTTOM_LEFT) mask = static_cast<uint8_t>(mask & 0x0D);
@@ -809,7 +772,7 @@ TileMap::autotile_corner(int x, int y, uint32_t tile, AutotileCornerOperation op
   if (op == AutotileCornerOperation::ADD_BOTTOM_LEFT) mask = static_cast<uint8_t>(mask | 0x02);
   if (op == AutotileCornerOperation::ADD_BOTTOM_RIGHT) mask = static_cast<uint8_t>(mask | 0x01);
 
-  uint32_t realtile = (!mask) ? 0 : curr_set->get_autotile(current_tile,
+  uint32_t realtile = (!mask) ? 0 : autotileset->get_autotile(current_tile,
     (mask & 0x08) != 0,
     false,
     (mask & 0x04) != 0,
@@ -827,12 +790,16 @@ TileMap::autotile_corner(int x, int y, uint32_t tile, AutotileCornerOperation op
 bool
 TileMap::is_corner(uint32_t tile) const
 {
-  auto* ats = m_tileset->get_autotileset_from_tile(tile);
-  return ats && ats->is_corner();
+  for (const AutotileSet* autotileset : get_autotilesets(tile))
+  {
+    if (autotileset->is_corner())
+      return true;
+  }
+  return false;
 }
 
 void
-TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos)
+TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos, AutotileSet* autotileset)
 {
   if (pos.x < 0.f || pos.x >= static_cast<float>(m_width) ||
       pos.y < 0.f || pos.y >= static_cast<float>(m_height))
@@ -844,15 +811,16 @@ TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos)
 
   uint32_t current_tile = m_tiles[static_cast<int>(pos.y)*m_width
                                   + static_cast<int>(pos.x)];
+  if (!autotileset || !autotileset->is_member(current_tile))
+    return;
 
-  AutotileSet* curr_set = m_tileset->get_autotileset_from_tile(current_tile);
-
-  if (curr_set && curr_set->is_corner()) {
+  if (autotileset->is_corner())
+  {
     int x = static_cast<int>(corner_pos.x), y = static_cast<int>(corner_pos.y);
-    autotile_corner(x, y, current_tile, AutotileCornerOperation::REMOVE_TOP_LEFT);
-    autotile_corner(x-1, y, current_tile, AutotileCornerOperation::REMOVE_TOP_RIGHT);
-    autotile_corner(x, y-1, current_tile, AutotileCornerOperation::REMOVE_BOTTOM_LEFT);
-    autotile_corner(x-1, y-1, current_tile, AutotileCornerOperation::REMOVE_BOTTOM_RIGHT);
+    autotile_corner(x, y, current_tile, autotileset, AutotileCornerOperation::REMOVE_TOP_LEFT);
+    autotile_corner(x-1, y, current_tile, autotileset, AutotileCornerOperation::REMOVE_TOP_RIGHT);
+    autotile_corner(x, y-1, current_tile, autotileset, AutotileCornerOperation::REMOVE_BOTTOM_LEFT);
+    autotile_corner(x-1, y-1, current_tile, autotileset, AutotileCornerOperation::REMOVE_BOTTOM_RIGHT);
   }
   else
   {
@@ -861,58 +829,58 @@ TileMap::autotile_erase(const Vector& pos, const Vector& corner_pos)
 
     if (x - 1 >= 0 && y - 1 >= 0 && !is_corner(m_tiles[(y-1)*m_width + x-1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y-1)*m_width + x-1]);
-      autotile(x-1, y-1, m_tiles[(y-1)*m_width + x-1]);
+        autotile(x, y, m_tiles[(y-1)*m_width + x-1], autotileset);
+      autotile(x-1, y-1, m_tiles[(y-1)*m_width + x-1], autotileset);
     }
 
     if (y - 1 >= 0 && !is_corner(m_tiles[(y-1)*m_width + x])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y-1)*m_width + x]);
-      autotile(x, y-1, m_tiles[(y-1)*m_width + x]);
+        autotile(x, y, m_tiles[(y-1)*m_width + x], autotileset);
+      autotile(x, y-1, m_tiles[(y-1)*m_width + x], autotileset);
     }
 
     if (y - 1 >= 0 && x + 1 < m_width && !is_corner(m_tiles[(y-1)*m_width + x+1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y-1)*m_width + x+1]);
-      autotile(x+1, y-1, m_tiles[(y-1)*m_width + x+1]);
+        autotile(x, y, m_tiles[(y-1)*m_width + x+1], autotileset);
+      autotile(x+1, y-1, m_tiles[(y-1)*m_width + x+1], autotileset);
     }
 
     if (x - 1 >= 0 && !is_corner(m_tiles[y*m_width + x-1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[y*m_width + x-1]);
-      autotile(x-1, y, m_tiles[y*m_width + x-1]);
+        autotile(x, y, m_tiles[y*m_width + x-1], autotileset);
+      autotile(x-1, y, m_tiles[y*m_width + x-1], autotileset);
     }
 
     if (x + 1 < m_width && !is_corner(m_tiles[y*m_width + x+1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[y*m_width + x+1]);
-      autotile(x+1, y, m_tiles[y*m_width + x+1]);
+        autotile(x, y, m_tiles[y*m_width + x+1], autotileset);
+      autotile(x+1, y, m_tiles[y*m_width + x+1], autotileset);
     }
 
     if (x - 1 >= 0 && y + 1 < m_height && !is_corner(m_tiles[(y+1)*m_width + x-1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y+1)*m_width + x-1]);
-      autotile(x-1, y+1, m_tiles[(y+1)*m_width + x-1]);
+        autotile(x, y, m_tiles[(y+1)*m_width + x-1], autotileset);
+      autotile(x-1, y+1, m_tiles[(y+1)*m_width + x-1], autotileset);
     }
 
     if (y + 1 < m_height && !is_corner(m_tiles[(y+1)*m_width + x])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y+1)*m_width + x]);
-      autotile(x, y+1, m_tiles[(y+1)*m_width + x]);
+        autotile(x, y, m_tiles[(y+1)*m_width + x], autotileset);
+      autotile(x, y+1, m_tiles[(y+1)*m_width + x], autotileset);
     }
 
     if (y + 1 < m_height && x + 1 < m_width && !is_corner(m_tiles[(y+1)*m_width + x+1])) {
       if (m_tiles[y*m_width + x] == 0)
-        autotile(x, y, m_tiles[(y+1)*m_width + x+1]);
-      autotile(x+1, y+1, m_tiles[(y+1)*m_width + x+1]);
+        autotile(x, y, m_tiles[(y+1)*m_width + x+1], autotileset);
+      autotile(x+1, y+1, m_tiles[(y+1)*m_width + x+1], autotileset);
     }
   }
 }
 
-AutotileSet*
-TileMap::get_autotileset(uint32_t tile) const
+std::vector<AutotileSet*>
+TileMap::get_autotilesets(uint32_t tile) const
 {
-  return m_tileset->get_autotileset_from_tile(tile);
+  return m_tileset->get_autotilesets_from_tile(tile);
 }
 
 void

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -170,6 +170,7 @@ public:
    * @param int $y
    */
   uint32_t get_tile_id(int x, int y) const;
+  uint32_t get_tile_id(const Vector& pos) const;
   /**
    * @scripting
    * @description Returns the ID of the tile at the given position (in world coordinates).

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -31,6 +31,7 @@
 #include "video/flip.hpp"
 #include "video/drawing_target.hpp"
 
+class AutotileSet;
 class CollisionObject;
 class CollisionGroundMovementManager;
 class DrawingContext;
@@ -205,7 +206,7 @@ public:
   void change_all(uint32_t oldtile, uint32_t newtile);
 
   /** Puts the correct autotile block at the given position */
-  void autotile(int x, int y, uint32_t tile);
+  void autotile(int x, int y, uint32_t tile, AutotileSet* autotileset);
 
   enum class AutotileCornerOperation {
     ADD_TOP_LEFT,
@@ -219,13 +220,13 @@ public:
   };
 
   /** Puts the correct autotile blocks at the tiles around the given corner */
-  void autotile_corner(int x, int y, uint32_t tile, AutotileCornerOperation op);
+  void autotile_corner(int x, int y, uint32_t tile, AutotileSet* autotileset, AutotileCornerOperation op);
 
   /** Erases in autotile mode */
-  void autotile_erase(const Vector& pos, const Vector& corner_pos);
+  void autotile_erase(const Vector& pos, const Vector& corner_pos, AutotileSet* autotileset);
 
-  /** Returns the Autotileset associated with the given tile */
-  AutotileSet* get_autotileset(uint32_t tile) const;
+  /** Returns the Autotilesets associated with the given tile */
+  std::vector<AutotileSet*> get_autotilesets(uint32_t tile) const;
 
   void set_flip(Flip flip) { m_flip = flip; }
   Flip get_flip() const { return m_flip; }

--- a/src/supertux/autotile.hpp
+++ b/src/supertux/autotile.hpp
@@ -100,6 +100,8 @@ public:
   /** Returns the id of the first block in the autotileset. Used for erronous configs. */
   uint32_t get_default_tile() const { return m_default; }
 
+  const std::string& get_name() const { return m_name; }
+
   /** true if the given tile is present in the autotileset */
   bool is_member(uint32_t tile_id) const;
 

--- a/src/supertux/tile_set.cpp
+++ b/src/supertux/tile_set.cpp
@@ -87,22 +87,35 @@ TileSet::get(const uint32_t id) const
   }
 }
 
-AutotileSet*
-TileSet::get_autotileset_from_tile(uint32_t tile_id) const
+std::vector<AutotileSet*>
+TileSet::get_autotilesets_from_tile(uint32_t tile_id) const
 {
   if (tile_id == 0)
   {
-    return nullptr;
+    return {};
   }
 
+  std::vector<AutotileSet*> autotilesets;
   for (auto& ats : m_autotilesets)
   {
     if (ats->is_member(tile_id))
-    {
-      return ats.get();
-    }
+      autotilesets.push_back(ats.get());
   }
-  return nullptr;
+  return autotilesets;
+}
+
+bool
+TileSet::has_mutual_autotileset(uint32_t lhs, uint32_t rhs) const
+{
+  if (lhs == rhs)
+    return true;
+
+  for (const auto& autotileset : m_autotilesets)
+  {
+    if (autotileset->is_member(lhs) && autotileset->is_member(rhs))
+      return true;
+  }
+  return false;
 }
 
 void

--- a/src/supertux/tile_set.hpp
+++ b/src/supertux/tile_set.hpp
@@ -63,7 +63,8 @@ public:
 
   const Tile& get(const uint32_t id) const;
   
-  AutotileSet* get_autotileset_from_tile(uint32_t tile_id) const;
+  std::vector<AutotileSet*> get_autotilesets_from_tile(uint32_t tile_id) const;
+  bool has_mutual_autotileset(uint32_t lhs, uint32_t rhs) const;
 
   uint32_t get_max_tileid() const {
     return static_cast<uint32_t>(m_tiles.size());


### PR DESCRIPTION
Tiles can now be present in multiple autotilesets in the same tileset. They would be autotileable with all (max. 10) autotilesets they are included in.

The editor allows for pressing keys 0-9 to choose from all 10 autotilesets the user can tile with. This is visually indicated in the autotile help strings.