### PR TITLE
`GameObject` change undo/redo refactor to track different options

### DIFF
--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -148,17 +148,7 @@ EditorLayersWidget::draw(DrawingContext& context)
 void
 EditorLayersWidget::update(float dt_sec)
 {
-  auto it = m_layer_icons.begin();
-  while (it != m_layer_icons.end())
-  {
-    auto layer_icon = (*it).get();
-    if (!layer_icon->is_valid())
-    {
-      it = m_layer_icons.erase(it);
-      continue;
-    }
-    ++it;
-  }
+  remove_invalid_layers();
 
   TileMap* selected_tilemap = get_selected_tilemap();
   if (selected_tilemap)
@@ -460,6 +450,8 @@ EditorLayersWidget::add_layer(GameObject* layer, bool initial)
 void
 EditorLayersWidget::update_tip()
 {
+  remove_invalid_layers();
+
   if (m_hovered_layer == m_layer_icons.size())
      m_object_tip->set_info(_("Add Layer"));
   else if (m_hovered_layer > m_layer_icons.size())
@@ -475,6 +467,22 @@ EditorLayersWidget::update_current_tip()
     return;
 
   update_tip();
+}
+
+void
+EditorLayersWidget::remove_invalid_layers()
+{
+  auto it = m_layer_icons.begin();
+  while (it != m_layer_icons.end())
+  {
+    auto layer_icon = (*it).get();
+    if (!layer_icon->is_valid())
+    {
+      it = m_layer_icons.erase(it);
+      continue;
+    }
+    ++it;
+  }
 }
 
 TileMap*

--- a/src/editor/layers_widget.hpp
+++ b/src/editor/layers_widget.hpp
@@ -78,7 +78,9 @@ public:
 private:
   Vector get_layer_coords(const int pos) const;
   int get_layer_pos(const Vector& coords) const;
+
   void update_tip();
+  void remove_invalid_layers();
 
 private:
   Editor& m_editor;

--- a/src/editor/object_option.hpp
+++ b/src/editor/object_option.hpp
@@ -69,6 +69,7 @@ public:
 
   virtual void save_state();
   bool has_state_changed() const;
+  virtual void parse_state(const ReaderMapping& reader);
   virtual void save_old_state(std::ostream& out) const;
   virtual void save_new_state(Writer& writer) const;
 
@@ -381,6 +382,25 @@ public:
   virtual void save(Writer& writer) const override;
   virtual std::string to_string() const override;
   virtual void add_to_menu(Menu& menu) const override;
+
+  virtual void save_state() override;
+  virtual void parse_state(const ReaderMapping& reader) override;
+  virtual void save_old_state(std::ostream& out) const override;
+  virtual void save_new_state(Writer& writer) const override;
+
+private:
+  void save_tile_changes(Writer& writer, bool new_tiles) const;
+
+private:
+  struct TilesState final
+  {
+    TilesState();
+
+    int width;
+    int height;
+    std::vector<uint32_t> tiles;
+  };
+  TilesState m_last_tiles_state;
 
 private:
   TilesObjectOption(const TilesObjectOption&) = delete;

--- a/src/editor/object_settings.cpp
+++ b/src/editor/object_settings.cpp
@@ -410,6 +410,23 @@ ObjectSettings::remove(const std::string& key)
 }
 
 void
+ObjectSettings::parse(const ReaderMapping& reader)
+{
+  for (const auto& option : m_options)
+  {
+    try
+    {
+      option->parse(reader);
+    }
+    catch (const std::exception& err)
+    {
+      log_warning << "Error processing data for option '" << option->get_key()
+                  << "': " << err.what() << std::endl;
+    }
+  }
+}
+
+void
 ObjectSettings::save_state()
 {
   for (const auto& option : m_options)
@@ -427,17 +444,17 @@ ObjectSettings::has_state_changed() const
 }
 
 void
-ObjectSettings::parse(const ReaderMapping& reader)
+ObjectSettings::parse_state(const ReaderMapping& reader)
 {
   for (const auto& option : m_options)
   {
     try
     {
-      option->parse(reader);
+      option->parse_state(reader);
     }
     catch (const std::exception& err)
     {
-      log_warning << "Error processing data for option '" << option->get_key()
+      log_warning << "Error processing state data for option '" << option->get_key()
                   << "': " << err.what() << std::endl;
     }
   }

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -28,10 +28,14 @@ class Color;
 enum class Direction;
 class GameObject;
 class PathObject;
+class ReaderMapping;
 enum class WalkMode;
+class Writer;
+
 namespace worldmap {
 enum class Direction;
 } // namespace worldmap
+
 namespace sexp {
 class Value;
 } // namespace sexp
@@ -40,7 +44,9 @@ class ObjectSettings final
 {
 public:
   ObjectSettings(const std::string& name);
-  ObjectSettings(ObjectSettings&&) = default;
+  ObjectSettings(ObjectSettings&& other);
+
+  ObjectSettings& operator=(ObjectSettings&&) = default;
 
   const std::string& get_name() const { return m_name; }
 
@@ -166,6 +172,19 @@ public:
 
   /** Remove an option from the list, this is a hack */
   void remove(const std::string& key);
+
+  /** Save the current states of all options. */
+  void save_state();
+
+  /** Check all options for any with a changed state. */
+  bool has_state_changed() const;
+
+  /** Parse option properties. */
+  void parse(const ReaderMapping& reader);
+
+  /** Write the old/new states of all modified options. */
+  void save_old_state(std::ostream& out) const;
+  void save_new_state(Writer& writer) const;
 
 private:
   void add_option(std::unique_ptr<BaseObjectOption> option);

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -173,7 +173,7 @@ public:
   /** Remove an option from the list, this is a hack */
   void remove(const std::string& key);
 
-  /** Parse option properties from a previous state. */
+  /** Parse option properties. */
   void parse(const ReaderMapping& reader);
 
   /** Save the current states of all options. */

--- a/src/editor/object_settings.hpp
+++ b/src/editor/object_settings.hpp
@@ -173,14 +173,17 @@ public:
   /** Remove an option from the list, this is a hack */
   void remove(const std::string& key);
 
+  /** Parse option properties from a previous state. */
+  void parse(const ReaderMapping& reader);
+
   /** Save the current states of all options. */
   void save_state();
 
   /** Check all options for any with a changed state. */
   bool has_state_changed() const;
 
-  /** Parse option properties. */
-  void parse(const ReaderMapping& reader);
+  /** Parse option properties from an alternative state. */
+  void parse_state(const ReaderMapping& reader);
 
   /** Write the old/new states of all modified options. */
   void save_old_state(std::ostream& out) const;

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -164,7 +164,8 @@ TileMap::parse_tiles(const ReaderMapping& reader)
 {
   reader.get("width", m_width);
   reader.get("height", m_height);
-  if (m_width < 0 || m_height < 0) {
+  if (m_width < 0 || m_height < 0)
+  {
     //throw std::runtime_error("Invalid/No width/height specified in tilemap.");
     m_width = 0;
     m_height = 0;
@@ -172,13 +173,15 @@ TileMap::parse_tiles(const ReaderMapping& reader)
     resize(static_cast<int>(Sector::get().get_width() / 32.0f),
            static_cast<int>(Sector::get().get_height() / 32.0f));
     m_editor_active = false;
-  } else {
-    if (!reader.get("tiles", m_tiles))
+  }
+  else
+  {
+    reader.get("tiles", m_tiles);
+    if (m_tiles.empty())
       throw std::runtime_error("No tiles in tilemap.");
 
-    if (int(m_tiles.size()) != m_width * m_height) {
+    if (static_cast<int>(m_tiles.size()) != m_width * m_height)
       throw std::runtime_error("wrong number of tiles in tilemap.");
-    }
   }
 
   bool empty = true;
@@ -711,6 +714,12 @@ TileMap::change(int x, int y, uint32_t newtile)
 }
 
 void
+TileMap::change(int idx, uint32_t newtile)
+{
+  m_tiles[idx] = newtile;
+}
+
+void
 TileMap::change_at(const Vector& pos, uint32_t newtile)
 {
   Vector xy = (pos - m_offset) / 32.0f;
@@ -1002,7 +1011,7 @@ TileMap::register_class(ssq::VM& vm)
 
   cls.addFunc("get_tile_id", &TileMap::get_tile_id);
   cls.addFunc<uint32_t, TileMap, float, float>("get_tile_id_at", &TileMap::get_tile_id_at);
-  cls.addFunc("change", &TileMap::change);
+  cls.addFunc<void, TileMap, int, int, uint32_t>("change", &TileMap::change);
   cls.addFunc<void, TileMap, float, float, uint32_t>("change_at", &TileMap::change_at);
   cls.addFunc("change_all", &TileMap::change_all);
   cls.addFunc("fade", &TileMap::fade);

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -156,6 +156,12 @@ TileMap::TileMap(const TileSet *tileset_, const ReaderMapping& reader) :
   m_effective_solid = m_real_solid;
   update_effective_solid(false);
 
+  parse_tiles(reader);
+}
+
+void
+TileMap::parse_tiles(const ReaderMapping& reader)
+{
   reader.get("width", m_width);
   reader.get("height", m_height);
   if (m_width < 0 || m_height < 0) {
@@ -190,6 +196,11 @@ TileMap::TileMap(const TileSet *tileset_, const ReaderMapping& reader) :
   {
     log_info << "Tilemap '" << get_name() << "', z-pos '" << m_z_pos << "' is empty." << std::endl;
   }
+
+  m_new_size_x = m_width;
+  m_new_size_y = m_height;
+  m_new_offset_x = 0;
+  m_new_offset_y = 0;
 }
 
 void

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -189,6 +189,7 @@ public:
    * @param int $newtile
    */
   void change(int x, int y, uint32_t newtile);
+  void change(int idx, uint32_t newtile);
   /**
    * @scripting
    * @description Changes the tile at the given position (in-world coordinates) to ""newtile"".

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -57,6 +57,8 @@ public:
   TileMap(const TileSet *tileset, const ReaderMapping& reader);
   ~TileMap() override;
 
+  void parse_tiles(const ReaderMapping& reader);
+
   virtual void finish_construction() override;
 
   static std::string class_name() { return "tilemap"; }

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -196,14 +196,14 @@ GameObject::save_state()
 
   if (!m_parent->undo_tracking_enabled())
   {
-    m_last_state.clear();
+    m_last_state.reset();
     return;
   }
-  if (!track_state())
+  if (!track_state() || m_last_state)
     return;
 
-  if (m_last_state.empty())
-    m_last_state = save();
+  m_last_state = get_settings();
+  m_last_state->save_state();
 }
 
 void
@@ -214,21 +214,15 @@ GameObject::check_state()
 
   if (!m_parent->undo_tracking_enabled())
   {
-    m_last_state.clear();
+    m_last_state.reset();
     return;
   }
-  if (!track_state())
+  if (!track_state() || !m_last_state)
     return;
 
-  // If settings have changed, save the change.
-  if (!m_last_state.empty())
-  {
-    if (m_last_state != save())
-    {
-      m_parent->save_object_change(*this, m_last_state);
-    }
-    m_last_state.clear();
-  }
+  // Save any option changes.
+  m_parent->save_object_change(*this, *m_last_state);
+  m_last_state.reset();
 }
 
 void

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <optional>
 #include <typeindex>
 
 #include "editor/object_settings.hpp"
@@ -309,9 +310,9 @@ private:
   /** this flag indicates if the object should be removed at the end of the frame */
   bool m_scheduled_for_removal;
 
-  /** The object's data at the time of the last state save.
+  /** The object's settings at the time of the last state save.
       Used to check for changes that may have occured. */
-  std::string m_last_state;
+  std::optional<ObjectSettings> m_last_state;
 
   std::vector<std::unique_ptr<GameObjectComponent> > m_components;
 

--- a/src/supertux/game_object_change.cpp
+++ b/src/supertux/game_object_change.cpp
@@ -1,0 +1,92 @@
+//  SuperTux
+//  Copyright (C) 2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "supertux/game_object_change.hpp"
+
+#include "util/log.hpp"
+#include "util/reader_iterator.hpp"
+#include "util/reader_mapping.hpp"
+#include "util/writer.hpp"
+
+GameObjectChange::GameObjectChange(const std::string& name_, const UID& uid_,
+                                   const std::string& data_, const std::string& new_data_,
+                                   Action action_) :
+  name(name_),
+  uid(uid_),
+  data(data_),
+  new_data(new_data_),
+  action(action_)
+{
+}
+
+GameObjectChange::GameObjectChange(const ReaderMapping& reader) :
+  name(),
+  uid(),
+  data(),
+  new_data(),
+  action()
+{
+  reader.get("name", name);
+  reader.get("uid", uid);
+  reader.get("data", data);
+  reader.get("action", reinterpret_cast<int&>(action));
+}
+
+void
+GameObjectChange::save(Writer& writer) const
+{
+  writer.write("name", name);
+  writer.write("uid", uid);
+  writer.write("data", data);
+  writer.write("action", reinterpret_cast<const int&>(action));
+}
+
+
+GameObjectChanges::GameObjectChanges(const UID& uid_, std::vector<GameObjectChange> objects_) :
+  uid(uid_),
+  objects(std::move(objects_))
+{
+}
+
+GameObjectChanges::GameObjectChanges(const ReaderMapping& reader) :
+  uid(),
+  objects()
+{
+  auto iter = reader.get_iter();
+  while (iter.next())
+  {
+    if (iter.get_key() != "object-change")
+    {
+      log_warning << "Unknown key '" << iter.get_key() << "' in GameObjectChanges data. Ignoring." << std::endl;
+      continue;
+    }
+
+    objects.push_back(GameObjectChange(iter.as_mapping()));
+  }
+}
+
+void
+GameObjectChanges::save(Writer& writer) const
+{
+  for (const auto& change : objects)
+  {
+    writer.start_list("object-change");
+    change.save(writer);
+    writer.end_list("object-change");
+  }
+}
+
+/* EOF */

--- a/src/supertux/game_object_change.cpp
+++ b/src/supertux/game_object_change.cpp
@@ -55,15 +55,15 @@ GameObjectChange::save(Writer& writer) const
 }
 
 
-GameObjectChanges::GameObjectChanges(const UID& uid_, std::vector<GameObjectChange> objects_) :
+GameObjectChangeSet::GameObjectChangeSet(const UID& uid_, std::vector<GameObjectChange> objects_) :
   uid(uid_),
-  objects(std::move(objects_))
+  changes(std::move(objects_))
 {
 }
 
-GameObjectChanges::GameObjectChanges(const ReaderMapping& reader) :
+GameObjectChangeSet::GameObjectChangeSet(const ReaderMapping& reader) :
   uid(),
-  objects()
+  changes()
 {
   auto iter = reader.get_iter();
   while (iter.next())
@@ -74,14 +74,14 @@ GameObjectChanges::GameObjectChanges(const ReaderMapping& reader) :
       continue;
     }
 
-    objects.push_back(GameObjectChange(iter.as_mapping()));
+    changes.push_back(GameObjectChange(iter.as_mapping()));
   }
 }
 
 void
-GameObjectChanges::save(Writer& writer) const
+GameObjectChangeSet::save(Writer& writer) const
 {
-  for (const auto& change : objects)
+  for (const auto& change : changes)
   {
     writer.start_list("object-change");
     change.save(writer);

--- a/src/supertux/game_object_change.cpp
+++ b/src/supertux/game_object_change.cpp
@@ -55,9 +55,9 @@ GameObjectChange::save(Writer& writer) const
 }
 
 
-GameObjectChangeSet::GameObjectChangeSet(const UID& uid_, std::vector<GameObjectChange> objects_) :
+GameObjectChangeSet::GameObjectChangeSet(const UID& uid_, std::vector<GameObjectChange> changes_) :
   uid(uid_),
-  changes(std::move(objects_))
+  changes(std::move(changes_))
 {
 }
 

--- a/src/supertux/game_object_change.hpp
+++ b/src/supertux/game_object_change.hpp
@@ -1,0 +1,70 @@
+//  SuperTux
+//  Copyright (C) 2024 Vankata453
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HEADER_SUPERTUX_SUPERTUX_GAME_OBJECT_CHANGE_HPP
+#define HEADER_SUPERTUX_SUPERTUX_GAME_OBJECT_CHANGE_HPP
+
+#include <string>
+
+#include "util/uid.hpp"
+
+class ReaderMapping;
+class Writer;
+
+/** Stores a change in a GameObject's state. */
+class GameObjectChange final
+{
+public:
+  enum class Action
+  {
+    CREATE,
+    DELETE,
+    MODIFY
+  };
+
+public:
+  GameObjectChange(const std::string& name, const UID& uid,
+                   const std::string& data, const std::string& new_data,
+                   Action action);
+  GameObjectChange(const ReaderMapping& reader);
+
+  void save(Writer& writer) const;
+
+public:
+  std::string name;
+  UID uid;
+  std::string data; // Stores old data of changed object options
+  std::string new_data; // Stores new data of changed object options
+  Action action; // The action which triggered a state change
+};
+
+/** Stores multiple GameObjectChanges. */
+class GameObjectChanges final
+{
+public:
+  GameObjectChanges(const UID& uid, std::vector<GameObjectChange> objects);
+  GameObjectChanges(const ReaderMapping& reader);
+
+  void save(Writer& writer) const;
+
+public:
+  UID uid;
+  std::vector<GameObjectChange> objects;
+};
+
+#endif
+
+/* EOF */

--- a/src/supertux/game_object_change.hpp
+++ b/src/supertux/game_object_change.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_SUPERTUX_GAME_OBJECT_CHANGE_HPP
 
 #include <string>
+#include <vector>
 
 #include "util/uid.hpp"
 
@@ -28,11 +29,11 @@ class Writer;
 class GameObjectChange final
 {
 public:
-  enum class Action
+  enum Action
   {
-    CREATE,
-    DELETE,
-    MODIFY
+    ACTION_CREATE,
+    ACTION_DELETE,
+    ACTION_MODIFY
   };
 
 public:
@@ -51,18 +52,18 @@ public:
   Action action; // The action which triggered a state change
 };
 
-/** Stores multiple GameObjectChanges. */
-class GameObjectChanges final
+/** Stores multiple GameObjectChange-s. */
+class GameObjectChangeSet final
 {
 public:
-  GameObjectChanges(const UID& uid, std::vector<GameObjectChange> objects);
-  GameObjectChanges(const ReaderMapping& reader);
+  GameObjectChangeSet(const UID& uid, std::vector<GameObjectChange> objects);
+  GameObjectChangeSet(const ReaderMapping& reader);
 
   void save(Writer& writer) const;
 
 public:
   UID uid;
-  std::vector<GameObjectChange> objects;
+  std::vector<GameObjectChange> changes;
 };
 
 #endif

--- a/src/supertux/game_object_change.hpp
+++ b/src/supertux/game_object_change.hpp
@@ -56,7 +56,7 @@ public:
 class GameObjectChangeSet final
 {
 public:
-  GameObjectChangeSet(const UID& uid, std::vector<GameObjectChange> objects);
+  GameObjectChangeSet(const UID& uid, std::vector<GameObjectChange> changes);
   GameObjectChangeSet(const ReaderMapping& reader);
 
   void save(Writer& writer) const;

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -517,7 +517,7 @@ GameObjectManager::parse_object_settings(ObjectSettings& settings, const std::st
   if (root.get_name() != "supertux-game-object")
     throw std::runtime_error("Data is not 'supertux-game-object'.");
 
-  settings.parse(root.get_mapping());
+  settings.parse_state(root.get_mapping());
 }
 
 std::string

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -394,7 +394,7 @@ GameObjectManager::apply_object_change(const GameObjectChange& change, bool trac
     case GameObjectChange::Action::DELETE:
     {
       if (!object)
-        throw std::runtime_error("Object does not exist.");
+        throw std::runtime_error("Object '" + change.name + "' does not exist.");
 
       object->m_track_undo = track_undo;
       object->remove_me();
@@ -404,7 +404,7 @@ GameObjectManager::apply_object_change(const GameObjectChange& change, bool trac
     case GameObjectChange::Action::MODIFY:
     {
       if (!object)
-        throw std::runtime_error("Object does not exist.");
+        throw std::runtime_error("Object '" + change.name + "' does not exist.");
 
       auto settings = object->get_settings();
       if (track_undo)
@@ -544,7 +544,8 @@ GameObjectManager::process_object_change(GameObjectChange& change)
   {
     case GameObjectChange::Action::CREATE: /** Object was added, remove it. */
     {
-      assert(object);
+      if (!object)
+        throw std::runtime_error("Object '" + change.name + "' no longer exists.");
 
       object->m_track_undo = false;
       object->remove_me();
@@ -566,7 +567,8 @@ GameObjectManager::process_object_change(GameObjectChange& change)
 
     case GameObjectChange::Action::MODIFY: /** Object was modified, revert settings. */
     {
-      assert(object);
+      if (!object)
+        throw std::runtime_error("Object '" + change.name + "' no longer exists.");
 
       auto settings = object->get_settings();
       settings.save_state();

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "supertux/game_object.hpp"
+#include "supertux/game_object_change.hpp"
 #include "util/uid_generator.hpp"
 
 class DrawingContext;
@@ -273,14 +274,19 @@ public:
   void undo();
   void redo();
 
-  /** Save object change in the undo stack with given data.
+  /** Apply saved object changes. */
+  void apply_object_change(const GameObjectChange& change, bool track_undo);
+  void apply_object_changes(const GameObjectChanges& changes, bool track_undo);
+
+  /** Save object settings changes in the undo stack.
       Used to save an object's previous state before a change had occurred. */
-  void save_object_change(GameObject& object, const std::string& data);
+  void save_object_change(const GameObject& object, const ObjectSettings& settings);
 
   /** Clear undo/redo stacks. */
   void clear_undo_stack();
 
-  /** Indicate if there are any object changes in the undo stack. */
+  /** Indicate if there are any unsaved object changes in the undo stack.
+      @see m_last_saved_change */
   bool has_object_changes() const;
 
   /** Called on editor level save. */
@@ -311,27 +317,20 @@ protected:
   }
 
 private:
-  struct ObjectChange
-  {
-    std::string name;
-    UID uid;
-    std::string data;
-    bool creation; // If the change represents an object creation.
-  };
-  struct ObjectChanges
-  {
-    UID uid;
-    std::vector<ObjectChange> objects;
-  };
-
   /** Create object from object change. */
-  void create_object_from_change(const ObjectChange& change);
+  void create_object_from_change(const GameObjectChange& change, bool track_undo);
 
-  /** Process object change on undo/redo. */
-  void process_object_change(ObjectChange& change);
+  /** Parse object settings ("supertux-game-object") from a string. */
+  static void parse_object_settings(ObjectSettings& settings, const std::string& data);
 
-  /** Save object change in the undo stack. */
-  void save_object_change(GameObject& object, bool creation = false);
+  /** Save old or new state of object settings. */
+  static std::string save_object_settings_state(const ObjectSettings& settings, bool new_state);
+
+  /** Undo/redo object change. */
+  void process_object_change(GameObjectChange& change);
+
+  /** Save object state in the undo stack. */
+  void save_object_state(GameObject& object, GameObjectChange::Action action);
 
   void this_before_object_add(GameObject& object);
   void this_before_object_remove(GameObject& object);
@@ -347,9 +346,9 @@ private:
   UIDGenerator m_change_uid_generator;
   bool m_undo_tracking;
   int m_undo_stack_size;
-  std::vector<ObjectChanges> m_undo_stack;
-  std::vector<ObjectChanges> m_redo_stack;
-  std::vector<ObjectChange> m_pending_change_stack; // Before a flush, any changes go here
+  std::vector<GameObjectChanges> m_undo_stack;
+  std::vector<GameObjectChanges> m_redo_stack;
+  std::vector<GameObjectChange> m_pending_change_stack; // Before a flush, any changes go here
   UID m_last_saved_change;
 
   std::vector<std::unique_ptr<GameObject>> m_gameobjects;

--- a/src/supertux/game_object_manager.hpp
+++ b/src/supertux/game_object_manager.hpp
@@ -276,7 +276,7 @@ public:
 
   /** Apply saved object changes. */
   void apply_object_change(const GameObjectChange& change, bool track_undo);
-  void apply_object_changes(const GameObjectChanges& changes, bool track_undo);
+  void apply_object_changes(const GameObjectChangeSet& changes, bool track_undo);
 
   /** Save object settings changes in the undo stack.
       Used to save an object's previous state before a change had occurred. */
@@ -346,8 +346,8 @@ private:
   UIDGenerator m_change_uid_generator;
   bool m_undo_tracking;
   int m_undo_stack_size;
-  std::vector<GameObjectChanges> m_undo_stack;
-  std::vector<GameObjectChanges> m_redo_stack;
+  std::vector<GameObjectChangeSet> m_undo_stack;
+  std::vector<GameObjectChangeSet> m_redo_stack;
   std::vector<GameObjectChange> m_pending_change_stack; // Before a flush, any changes go here
   UID m_last_saved_change;
 

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -45,6 +45,9 @@ ReaderMapping::get_iter() const
 const sexp::Value*
 ReaderMapping::get_item(const char* key) const
 {
+  if (!key || !key[0]) // Check whether key is valid and non-empty
+    return nullptr;
+
   for (size_t i = 1; i < m_arr.size(); ++i)
   {
     auto const& pair = m_arr[i];
@@ -91,6 +94,12 @@ ReaderMapping::get(const char* key, int& value, const std::optional<int>& defaul
 
 bool
 ReaderMapping::get(const char* key, uint32_t& value, const std::optional<uint32_t>& default_value) const
+{
+  GET_VALUE_MACRO("uint32_t", is_integer, as_int)
+}
+
+bool
+ReaderMapping::get(const char* key, UID& value, const std::optional<UID>& default_value) const
 {
   GET_VALUE_MACRO("uint32_t", is_integer, as_int)
 }

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -146,6 +146,7 @@ ReaderMapping::get(const char* key, std::string& value, const std::optional<cons
     return false;                                                       \
   } else {                                                              \
     assert_is_array(m_doc, *sx);                                        \
+    value.clear();                                                      \
     auto const& item = sx->as_array();                                  \
     for (size_t i = 1; i < item.size(); ++i)                            \
     {                                                                   \
@@ -159,7 +160,6 @@ bool
 ReaderMapping::get(const char* key, std::vector<bool>& value,
                    const std::optional<std::vector<bool>>& default_value) const
 {
-  value.clear();
   GET_VALUES_MACRO("bool", is_boolean, as_bool)
 }
 
@@ -167,7 +167,6 @@ bool
 ReaderMapping::get(const char* key, std::vector<int>& value,
                    const std::optional<std::vector<int>>& default_value) const
 {
-  value.clear();
   GET_VALUES_MACRO("int", is_integer, as_int)
 }
 
@@ -176,7 +175,6 @@ bool
 ReaderMapping::get(const char* key, std::vector<float>& value,
                    const std::optional<std::vector<float>>& default_value) const
 {
-  value.clear();
   GET_VALUES_MACRO("float", is_real, as_float)
 }
 
@@ -184,7 +182,6 @@ bool
 ReaderMapping::get(const char* key, std::vector<std::string>& value,
                    const std::optional<std::vector<std::string>>& default_value) const
 {
-  value.clear();
   GET_VALUES_MACRO("string", is_string, as_string)
 }
 
@@ -192,7 +189,6 @@ bool
 ReaderMapping::get(const char* key, std::vector<unsigned int>& value,
                    const std::optional<std::vector<unsigned int>>& default_value) const
 {
-  value.clear();
   GET_VALUES_MACRO("unsigned int", is_integer, as_int)
 }
 

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -21,6 +21,7 @@
 #include <optional>
 
 #include "util/reader_iterator.hpp"
+#include "util/uid.hpp"
 
 namespace sexp {
 class Value;
@@ -43,6 +44,7 @@ public:
   bool get(const char* key, bool& value, const std::optional<bool>& default_value = std::nullopt) const;
   bool get(const char* key, int& value, const std::optional<int>& default_value = std::nullopt) const;
   bool get(const char* key, uint32_t& value, const std::optional<uint32_t>& default_value = std::nullopt) const;
+  bool get(const char* key, UID& value, const std::optional<UID>& default_value = std::nullopt) const;
   bool get(const char* key, float& value, const std::optional<float>& default_value = std::nullopt) const;
   bool get(const char* key, std::string& value, const std::optional<const char*>& default_value = std::nullopt) const;
 

--- a/src/util/uid.hpp
+++ b/src/util/uid.hpp
@@ -55,6 +55,11 @@ public:
   UID(const UID& other) = default;
   UID& operator=(const UID& other) = default;
 
+  inline UID& operator=(uint32_t value) {
+    m_value = value;
+    return *this;
+  }
+
   inline operator bool() const {
     return m_value != 0;
   }

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -104,6 +104,13 @@ Writer::write(const std::string& name, float value)
   *out << '(' << name << ' ' << value << ")\n";
 }
 
+void
+Writer::write(const std::string& name, const UID& uid)
+{
+  indent();
+  *out << '(' << name << ' ' << uid << ")\n";
+}
+
 /** This function is needed to properly resolve the overloaded write()
     function, without it the call write("foo", "bar") would call
     write(name, bool), not write(name, string, bool) */

--- a/src/util/writer.hpp
+++ b/src/util/writer.hpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "util/uid.hpp"
+
 namespace sexp {
 class Value;
 } // namespace sexp
@@ -38,6 +40,7 @@ public:
   void write(const std::string& name, bool value);
   void write(const std::string& name, int value);
   void write(const std::string& name, float value);
+  void write(const std::string& name, const UID& uid);
   void write(const std::string& name, const char* value);
   void write(const std::string& name, const std::string& value, bool translatable = false);
   void write(const std::string& name, const std::vector<int>& value);

--- a/src/video/color.cpp
+++ b/src/video/color.cpp
@@ -45,7 +45,7 @@ Color::Color(float red_, float green_, float blue_, float alpha_) :
   assert(0 <= blue  && blue <= 1.0f);
 }
 
-Color::Color(const std::vector<float>& vals) :
+Color::Color(const std::vector<float>& vals, bool use_alpha) :
   red(),
   green(),
   blue(),
@@ -61,7 +61,7 @@ Color::Color(const std::vector<float>& vals) :
   red   = vals[0];
   green = vals[1];
   blue  = vals[2];
-  if (vals.size() > 3)
+  if (use_alpha && vals.size() > 3)
     alpha = vals[3];
   else
     alpha = 1.0;

--- a/src/video/color.hpp
+++ b/src/video/color.hpp
@@ -95,7 +95,7 @@ public:
 
   Color(float red_, float green_, float blue_, float alpha_ = 1.0);
 
-  Color(const std::vector<float>& vals);
+  Color(const std::vector<float>& vals, bool use_alpha = true);
 
   bool operator==(const Color& other) const;
   bool operator!=(const Color& other) const;


### PR DESCRIPTION
`GameObject`, instead of comparing all options against each other, now saves the state of and compares individual ones, so the change data is more memory-efficient.

This way of tracking object changes also allows for proper undo/redo tracking with multiple remote users (regarding the [remote level editing concept](https://github.com/SuperTux/supertux/tree/editor-remote-level-networking), which branch these changes originate from).

`TileMap` tile changes are now saved in a way more memory-efficient way. Instead of saving the whole tiles array for each change, only the changed tiles are saved in a list of pairs (tile index, old/new tile ID).