### PR TITLE
S-Expression: Minimize lag when parsing level names

### DIFF
--- a/src/supertux/level_parser.cpp
+++ b/src/supertux/level_parser.cpp
@@ -34,7 +34,7 @@ LevelParser::get_level_name(const std::string& filename)
   try
   {
     register_translation_directory(filename);
-    auto doc = ReaderDocument::from_file(filename);
+    auto doc = ReaderDocument::from_file(filename, 1);
     auto root = doc.get_root();
 
     if (root.get_name() != "supertux-level") {

--- a/src/util/reader_document.cpp
+++ b/src/util/reader_document.cpp
@@ -24,14 +24,21 @@
 #include "util/log.hpp"
 
 ReaderDocument
-ReaderDocument::from_stream(std::istream& stream, const std::string& filename)
+ReaderDocument::from_string(const std::string& string, const std::string& filename, int depth)
 {
-  sexp::Value sx = sexp::Parser::from_stream(stream, sexp::Parser::USE_ARRAYS);
+  std::istringstream stream(string);
+  return from_stream(stream, filename, depth);
+}
+
+ReaderDocument
+ReaderDocument::from_stream(std::istream& stream, const std::string& filename, int depth)
+{
+  sexp::Value sx = sexp::Parser::from_stream(stream, sexp::Parser::USE_ARRAYS, depth);
   return ReaderDocument(filename, std::move(sx));
 }
 
 ReaderDocument
-ReaderDocument::from_file(const std::string& filename)
+ReaderDocument::from_file(const std::string& filename, int depth)
 {
   log_debug << "ReaderDocument::parse: " << filename << std::endl;
 
@@ -41,7 +48,7 @@ ReaderDocument::from_file(const std::string& filename)
     msg << "Parser problem: Couldn't open file '" << filename << "'.";
     throw std::runtime_error(msg.str());
   } else {
-    return from_stream(in, filename);
+    return from_stream(in, filename, depth);
   }
 }
 

--- a/src/util/reader_document.hpp
+++ b/src/util/reader_document.hpp
@@ -27,8 +27,9 @@
 class ReaderDocument final
 {
 public:
-  static ReaderDocument from_stream(std::istream& stream, const std::string& filename = "<stream>");
-  static ReaderDocument from_file(const std::string& filename);
+  static ReaderDocument from_string(const std::string& string, const std::string& filename = "<string>", int depth = -1);
+  static ReaderDocument from_stream(std::istream& stream, const std::string& filename = "<stream>", int depth = -1);
+  static ReaderDocument from_file(const std::string& filename, int depth = -1);
 
 public:
   ReaderDocument(const std::string& filename, sexp::Value sx);

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -129,11 +129,7 @@ ReaderMapping::get(const char* key, std::string& value, const std::optional<cons
     if (item[1].is_string()) {
       value = item[1].as_string();
       return true;
-    } else if (item[1].is_array() &&
-               item[1].as_array().size() == 2 &&
-               item[1].as_array()[0].is_symbol() &&
-               item[1].as_array()[0].as_string() == "_" &&
-               item[1].as_array()[1].is_string()) {
+    } else if (item[1].is_translatable_string()) {
       if (s_translations_enabled) {
         value = _(item[1].as_array()[1].as_string());
       } else {


### PR DESCRIPTION
`sexp::Parser` now supports specifying a custom `depth` property for omitting (not parsing) structures deeper than `depth` in the tree, starting from 0. This optimizes parsing level names from level files a ton, since level files tend to be very big and used to take a while to parse collectively.