### PR TITLE
Change all "normal" actions to "default"

### DIFF
--- a/data/images/creatures/fish/forest/jumpfish.sprite
+++ b/data/images/creatures/fish/forest/jumpfish.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 18)
     (loops 1)
     (hitbox 12 24 40 46)

--- a/data/images/creatures/flame/flame.sprite
+++ b/data/images/creatures/flame/flame.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
  (action
   (hitbox 0 0 31.8 31.8)
-  (name "normal")
+  (name "default")
   (images "flame-0.png"
           "flame-1.png"))
  (action

--- a/data/images/creatures/flame/ghostflame.sprite
+++ b/data/images/creatures/flame/ghostflame.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
  (action
   (hitbox 0.2 0.2 31.6 31.6)
-  (name "normal")
+  (name "default")
   (images "ghostflame-0.png"
           "ghostflame-1.png"
           "ghostflame-2.png"

--- a/data/images/creatures/flame/iceflame.sprite
+++ b/data/images/creatures/flame/iceflame.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
  (action
   (hitbox 0 0 31.8 31.8)
-  (name "normal")
+  (name "default")
   (images "iceflame.png"))
  (action
   (hitbox 0 0 31.8 31.8)

--- a/data/images/creatures/flame_fish/flame_fish.sprite
+++ b/data/images/creatures/flame_fish/flame_fish.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 2 3 0 0)
   (images "left-0.png"
           "left-1.png"))

--- a/data/images/creatures/ghosttree/ghosttree.sprite
+++ b/data/images/creatures/ghosttree/ghosttree.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 230 300 40 60)
     (images
       "ghosttree.png"

--- a/data/images/creatures/skydive/skydive.sprite
+++ b/data/images/creatures/skydive/skydive.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
 	(fps 15)
     (hitbox 14 7 32 44)
     (images "skydive-0.png"

--- a/data/images/creatures/stalactite/stalactite_ice.sprite
+++ b/data/images/creatures/stalactite/stalactite_ice.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
 	(action
-	  (name "normal")
+	  (name "default")
 	  (hitbox 0 15 32 48)
 	  (images "stalactite_ice.png"))
 	(action

--- a/data/images/creatures/stalactite/stalactite_rock.sprite
+++ b/data/images/creatures/stalactite/stalactite_rock.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
 	(action
-	  (name "normal")
+	  (name "default")
 	  (hitbox 4 15 32 48)
 	  (images "stalactite_rock.png"))
 	(action

--- a/data/images/decal/forest/foxsleep.sprite
+++ b/data/images/decal/forest/foxsleep.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 10)
     (images "foxsleep1.png"
             "foxsleep2.png"

--- a/data/images/engine/menu/mousecursor.sprite
+++ b/data/images/engine/menu/mousecursor.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (images "mousecursor.png"))
 
  (action

--- a/data/images/objects/bonus_block/bonusblock.sprite
+++ b/data/images/objects/bonus_block/bonusblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
          (fps 15)
-         (name "normal")
+         (name "default")
          (images "full-0.png"
                  "full-1.png"
                  "full-2.png"

--- a/data/images/objects/bonus_block/brick.sprite
+++ b/data/images/objects/bonus_block/brick.sprite
@@ -7,7 +7,7 @@
         (displacement-texture (file "displacement.png")))))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/brick0.png"))
 
  (action

--- a/data/images/objects/bonus_block/brickIce.sprite
+++ b/data/images/objects/bonus_block/brickIce.sprite
@@ -7,7 +7,7 @@
     (displacement-texture (file "displacement.png")))))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/brick1.png"))
 
  (action

--- a/data/images/objects/bonus_block/brickWeb.sprite
+++ b/data/images/objects/bonus_block/brickWeb.sprite
@@ -7,7 +7,7 @@
     (displacement-texture (file "displacement.png")))))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/brick2.png"))
 
  (action

--- a/data/images/objects/bonus_block/heavy-brick.sprite
+++ b/data/images/objects/bonus_block/heavy-brick.sprite
@@ -7,7 +7,7 @@
     (displacement-texture (file "displacement.png")))))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/brick3.png"))
 
  (action

--- a/data/images/objects/bonus_block/hiddenbonus.sprite
+++ b/data/images/objects/bonus_block/hiddenbonus.sprite
@@ -6,6 +6,6 @@
            (diffuse-texture (file "empty.png"))
            (displacement-texture (file "displacement.png")))))
       (action 
-        (name "normal")
+        (name "default")
         (images "invisible.png"))
 )

--- a/data/images/objects/bonus_block/icedbrick.sprite
+++ b/data/images/objects/bonus_block/icedbrick.sprite
@@ -4,7 +4,7 @@
   (images "empty.png"))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/brick1.png"))
 
  (action

--- a/data/images/objects/bonus_block/infoblock.sprite
+++ b/data/images/objects/bonus_block/infoblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
     (action
 	  (fps 15)
-      (name "normal")
+      (name "default")
       (images "infoblock-0.png"
               "infoblock-1.png"
               "infoblock-2.png"

--- a/data/images/objects/bonus_block/orangeblock.sprite
+++ b/data/images/objects/bonus_block/orangeblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
          (fps 15)
-         (name "normal")
+         (name "default")
          (images "orange-0.png"
                  "orange-1.png"
                  "orange-2.png"

--- a/data/images/objects/bonus_block/purpleblock.sprite
+++ b/data/images/objects/bonus_block/purpleblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
          (fps 15)
-         (name "normal")
+         (name "default")
          (images "purple-0.png"
                  "purple-1.png"
                  "purple-2.png"

--- a/data/images/objects/bonus_block/retro_brick.sprite
+++ b/data/images/objects/bonus_block/retro_brick.sprite
@@ -7,6 +7,6 @@
         (displacement-texture (file "displacement.png")))))
 
  (action
-  (name "normal")
+  (name "default")
   (images "../../tiles/blocks/retro_brick.png"))
  )

--- a/data/images/objects/bonus_block/retroblock.sprite
+++ b/data/images/objects/bonus_block/retroblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
          (fps 15)
-         (name "normal")
+         (name "default")
          (images "box-full.png"
                  ))
       (action

--- a/data/images/objects/bonus_block/scriptblock.sprite
+++ b/data/images/objects/bonus_block/scriptblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
          (fps 15)
-		 (name "normal")
+		 (name "default")
          (images "scriptblock-0.png"
                  "scriptblock-1.png"
                  "scriptblock-2.png"

--- a/data/images/objects/castledoor/keyholes.sprite
+++ b/data/images/objects/castledoor/keyholes.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
   (images "keyholes.png"))
 )

--- a/data/images/objects/castledoor/torchflame.sprite
+++ b/data/images/objects/castledoor/torchflame.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
 (fps 4)
   (images 

--- a/data/images/objects/coin/coin.sprite
+++ b/data/images/objects/coin/coin.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (fps 15.0)
           (images "coin-0.png"
                   "coin-1.png"

--- a/data/images/objects/coin/retro_coin.sprite
+++ b/data/images/objects/coin/retro_coin.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (fps 15.0)
           (images "retro_coin-0.png"
                   "retro_coin-1.png"

--- a/data/images/objects/crystals/crystal_1.sprite
+++ b/data/images/objects/crystals/crystal_1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "c2.png"
                   "c1.png"))
       (action

--- a/data/images/objects/crystals/crystal_2.sprite
+++ b/data/images/objects/crystals/crystal_2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "d2.png"
                   "d1.png"))
       (action

--- a/data/images/objects/crystals/crystal_3.sprite
+++ b/data/images/objects/crystals/crystal_3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "b2.png"
                   "b1.png"))
       (action

--- a/data/images/objects/crystals/crystal_4.sprite
+++ b/data/images/objects/crystals/crystal_4.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "a2.png"
                   "a1.png"))
       (action

--- a/data/images/objects/fallblock/branchleft.sprite
+++ b/data/images/objects/fallblock/branchleft.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 123 32)
     (images "branchleft.png")
   )

--- a/data/images/objects/fallblock/branchright.sprite
+++ b/data/images/objects/fallblock/branchright.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 5 32 123 32)
     (images "branchright.png")
   )

--- a/data/images/objects/fallblock/cave-2x3.sprite
+++ b/data/images/objects/fallblock/cave-2x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 64 96)
     (images "cave-2x3.png")
   )

--- a/data/images/objects/fallblock/cave-3x2.sprite
+++ b/data/images/objects/fallblock/cave-3x2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 96 64)
     (images "cave-3x2.png")
   )

--- a/data/images/objects/fallblock/cave-3x4.sprite
+++ b/data/images/objects/fallblock/cave-3x4.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 96 128)
     (images "cave-3x4.png")
   )

--- a/data/images/objects/fallblock/cave-4x3.sprite
+++ b/data/images/objects/fallblock/cave-4x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 128 96)
     (images "cave-4x3.png")
   )

--- a/data/images/objects/fallblock/cave-4x4.sprite
+++ b/data/images/objects/fallblock/cave-4x4.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 128 128)
     (images "cave-4x4.png")
   )

--- a/data/images/objects/fallblock/cave-4x6.sprite
+++ b/data/images/objects/fallblock/cave-4x6.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 128 192)
     (images "cave-4x6.png")
   )

--- a/data/images/objects/fallblock/cave-5x3.sprite
+++ b/data/images/objects/fallblock/cave-5x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 160 96)
     (images "cave-5x3.png")
   )

--- a/data/images/objects/fallblock/cave-5x7.sprite
+++ b/data/images/objects/fallblock/cave-5x7.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 160 224)
     (images "cave-5x7.png")
   )

--- a/data/images/objects/fallblock/cave-6x4.sprite
+++ b/data/images/objects/fallblock/cave-6x4.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 192 128)
     (images "cave-6x4.png")
   )

--- a/data/images/objects/fallblock/rockblock-0.5x0.5.sprite
+++ b/data/images/objects/fallblock/rockblock-0.5x0.5.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 16 16)
     (images "rockblock-0.5x0.5.png")
   )

--- a/data/images/objects/fallblock/rockblock-1x1.sprite
+++ b/data/images/objects/fallblock/rockblock-1x1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 32 32)
     (images "rockblock-1x1.png")
   )

--- a/data/images/objects/fallblock/rockblock-1x2.sprite
+++ b/data/images/objects/fallblock/rockblock-1x2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 32 64)
     (images "rockblock-1x2.png")
   )

--- a/data/images/objects/fallblock/rockblock-1x3.sprite
+++ b/data/images/objects/fallblock/rockblock-1x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 32 96)
     (images "rockblock-1x3.png")
   )

--- a/data/images/objects/fallblock/rockblock-2x1.sprite
+++ b/data/images/objects/fallblock/rockblock-2x1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 64 32)
     (images "rockblock-2x1.png")
   )

--- a/data/images/objects/fallblock/rockblock-2x2.sprite
+++ b/data/images/objects/fallblock/rockblock-2x2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 64 64)
     (images "rockblock-2x2.png")
   )

--- a/data/images/objects/fallblock/rockblock-2x3.sprite
+++ b/data/images/objects/fallblock/rockblock-2x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 64 96)
     (images "rockblock-2x3.png")
   )

--- a/data/images/objects/fallblock/rockblock-3x1.sprite
+++ b/data/images/objects/fallblock/rockblock-3x1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 96 32)
     (images "rockblock-3x1.png")
   )

--- a/data/images/objects/fallblock/rockblock-3x2.sprite
+++ b/data/images/objects/fallblock/rockblock-3x2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 96 64)
     (images "rockblock-3x2.png")
   )

--- a/data/images/objects/fallblock/rockblock-3x3.sprite
+++ b/data/images/objects/fallblock/rockblock-3x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 96 96)
     (images "rockblock-3x3.png")
   )

--- a/data/images/objects/fallblock/rockplatform-0.5x0.5.sprite
+++ b/data/images/objects/fallblock/rockplatform-0.5x0.5.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 8 8 16 16)
     (images "rockplatform-0.5x0.5.png")
   )

--- a/data/images/objects/fallblock/rockplatform-1x1.sprite
+++ b/data/images/objects/fallblock/rockplatform-1x1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 32 32)
     (images "rockplatform-1x1.png")
   )

--- a/data/images/objects/fallblock/rockplatform-1x3.sprite
+++ b/data/images/objects/fallblock/rockplatform-1x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 32 96)
     (images "rockplatform-1x3.png")
   )

--- a/data/images/objects/fallblock/rockplatform-2x2.sprite
+++ b/data/images/objects/fallblock/rockplatform-2x2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 64 64)
     (images "rockplatform-2x2.png")
   )

--- a/data/images/objects/fallblock/rockplatform-3x3.sprite
+++ b/data/images/objects/fallblock/rockplatform-3x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 96 96)
     (images "rockplatform-3x3.png")
   )

--- a/data/images/objects/fallblock/rockplatform-4x1.sprite
+++ b/data/images/objects/fallblock/rockplatform-4x1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 128 32)
     (images "rockplatform-4x1.png")
   )

--- a/data/images/objects/fallblock/rockplatform-4x3.sprite
+++ b/data/images/objects/fallblock/rockplatform-4x3.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 32 128 96)
     (images "rockplatform-4x3.png")
   )

--- a/data/images/objects/firefly/firefly.sprite
+++ b/data/images/objects/firefly/firefly.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
 (fps 1)
   (images "sleep-1.png"

--- a/data/images/objects/icecube/icecube.sprite
+++ b/data/images/objects/icecube/icecube.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
 (fps 5)
   (images 

--- a/data/images/objects/lantern/lantern.sprite
+++ b/data/images/objects/lantern/lantern.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action
-        (name "normal")
+        (name "default")
         (hitbox 8 10 34 39)
 		(fps 16)
         (images

--- a/data/images/objects/letter/letter-small.sprite
+++ b/data/images/objects/letter/letter-small.sprite
@@ -1,5 +1,5 @@
 (supertux-sprite
       (action
-        (name "normal")
+        (name "default")
         (images "letter-small.png"))
 )

--- a/data/images/objects/magicblock/magicblock.sprite
+++ b/data/images/objects/magicblock/magicblock.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
       (action
       (hitbox 8 8 32 32)
-        (name "normal")
+        (name "default")
         (images "magicblock.png"))
       (action
         (name "solid")

--- a/data/images/objects/resetpoints/bell.sprite
+++ b/data/images/objects/resetpoints/bell.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (images "bell-m.png")
   (hitbox 8 5 32 32)
  )

--- a/data/images/objects/resetpoints/default-resetpoint.sprite
+++ b/data/images/objects/resetpoints/default-resetpoint.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (images "bell-m.png")
   (hitbox 8 5 32 32)
  )

--- a/data/images/objects/resetpoints/firefly.sprite
+++ b/data/images/objects/resetpoints/firefly.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
   (images "firefly1.png")
  )

--- a/data/images/objects/resetpoints/torch.sprite
+++ b/data/images/objects/resetpoints/torch.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (hitbox 0 0 0 0)
 (fps 1)
   (images "torch-off1.png"

--- a/data/images/objects/resetpoints/vbell.sprite
+++ b/data/images/objects/resetpoints/vbell.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (x-offset 0)
   (y-offset 0)
   (images "vbell-m.png")

--- a/data/images/objects/rock/rock-b.sprite
+++ b/data/images/objects/rock/rock-b.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 64 64)
     (images "rock-b.png")
   )

--- a/data/images/objects/rock/rock-c.sprite
+++ b/data/images/objects/rock/rock-c.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 16 16)
     (images "rock-c.png")
   )

--- a/data/images/objects/rock/rock-d.sprite
+++ b/data/images/objects/rock/rock-d.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 96 96)
     (images "rock-d.png")
   )

--- a/data/images/objects/rock/rock.sprite
+++ b/data/images/objects/rock/rock.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 0 0 32 32)
     (images "rock.png")
   )

--- a/data/images/objects/rusty-trampoline/rusty-trampoline.sprite
+++ b/data/images/objects/rusty-trampoline/rusty-trampoline.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 2 32 32 32)
     (images "rustytrampoline1.png")
   )

--- a/data/images/objects/skull_tile/skull_tile.sprite
+++ b/data/images/objects/skull_tile/skull_tile.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images "skull.png")
   )
   (action

--- a/data/images/objects/snowman/snow_man_big.sprite
+++ b/data/images/objects/snowman/snow_man_big.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "s_manbig_1.png"
                   "s_manbig_2.png"
                   "s_manbig_3.png"

--- a/data/images/objects/snowman/snow_man_big_passable.sprite
+++ b/data/images/objects/snowman/snow_man_big_passable.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (hitbox 2 4 1 1)
           (images "s_manbig_1.png"
                   "s_manbig_2.png"

--- a/data/images/objects/snowman/snow_man_small.sprite
+++ b/data/images/objects/snowman/snow_man_small.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
       (action 
-          (name "normal")
+          (name "default")
           (images "s_man_1.png"
                   "s_man_2.png"
                   "s_man_3.png"

--- a/data/images/objects/trampoline/bumper.sprite
+++ b/data/images/objects/trampoline/bumper.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal-right")
+    (name "default-right")
     (hitbox 0 2 18 27)
     (images "right-0.png")
   )
@@ -17,9 +17,9 @@
     )
   )
   (action
-    (name "normal-left")
+    (name "default-left")
     (hitbox 14 2 18 27)
-    (mirror-action "normal-right")
+    (mirror-action "default-right")
   )
   (action
     (name "swinging-left")

--- a/data/images/objects/trampoline/trampoline.sprite
+++ b/data/images/objects/trampoline/trampoline.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 2 32 32 32)
     (images "trampoline1-0.png")
   )

--- a/data/images/objects/trampoline/trampoline_fix.sprite
+++ b/data/images/objects/trampoline/trampoline_fix.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (hitbox 2 32 32 32)
     (images "trampoline2-0.png")
   )

--- a/data/images/objects/unstable_tile/brick.sprite
+++ b/data/images/objects/unstable_tile/brick.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images 
       "brick-0.png"
     )

--- a/data/images/objects/unstable_tile/iceplatform.sprite
+++ b/data/images/objects/unstable_tile/iceplatform.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images 
       "iceplatform.png"
     )

--- a/data/images/objects/unstable_tile/snow.sprite
+++ b/data/images/objects/unstable_tile/snow.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images 
       "snow-0.png"
     )

--- a/data/images/objects/weak_block/meltbox.sprite
+++ b/data/images/objects/weak_block/meltbox.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images 
       "meltbox-0.png"
     )

--- a/data/images/objects/weak_block/strawbox.sprite
+++ b/data/images/objects/weak_block/strawbox.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images 
       "strawbox-0.png"
     )

--- a/data/images/particles/air_bubble.sprite
+++ b/data/images/particles/air_bubble.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
  (action
-  (name "normal")
+  (name "default")
   (fps 15)
   (loops 1)
   (images "air_bubble-0.png"

--- a/data/images/particles/ice_piece1.sprite
+++ b/data/images/particles/ice_piece1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 1)
     (images "ice_piece1.png"))
  )

--- a/data/images/particles/ice_piece2.sprite
+++ b/data/images/particles/ice_piece2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 1)
     (images "ice_piece2.png"))
  )

--- a/data/images/particles/water_piece1.sprite
+++ b/data/images/particles/water_piece1.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 8)
     (images "water_piece1-1.png"
             "water_piece1-2.png"

--- a/data/images/particles/water_piece2.sprite
+++ b/data/images/particles/water_piece2.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (fps 6)
     (images "water_piece2-1.png"
             "water_piece2-2.png"))

--- a/data/images/powerups/egg/egg.sprite
+++ b/data/images/powerups/egg/egg.sprite
@@ -1,6 +1,6 @@
 (supertux-sprite
   (action
-    (name "normal")
+    (name "default")
     (images "egg.png")
   )
   (action

--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -1152,7 +1152,7 @@ BadGuy::after_editor_set()
   MovingSprite::after_editor_set();
 
   const std::string direction_str = m_start_dir == Direction::AUTO ? "left" : dir_to_string(m_start_dir);
-  const std::string actions[] = {"editor", "normal", "idle", "flying", "walking", "standing", "swim"};
+  const std::string actions[] = {"editor", "default", "idle", "flying", "walking", "standing", "swim"};
   bool action_set = false;
 
   for (const auto& action_str : actions)

--- a/src/badguy/fish_jumping.cpp
+++ b/src/badguy/fish_jumping.cpp
@@ -111,7 +111,7 @@ FishJumping::active_update(float dt_sec)
   // Set sprite.
   if (!m_frozen && !is_ignited())
     set_action((m_physic.get_velocity_y() == 0.f && m_in_water) ? "wait" :
-      m_physic.get_velocity_y() < 0.f ? "normal" : "down");
+      m_physic.get_velocity_y() < 0.f ? "default" : "down");
 
   // We can't afford flying out of the tilemap, 'cause the engine would remove us.
   if ((get_pos().y - 31.8f) < 0) // Too high, let us fall.
@@ -162,7 +162,7 @@ void
 FishJumping::kill_fall()
 {
   if (!is_ignited())
-  set_action("normal");
+  set_action("default");
   BadGuy::kill_fall();
 }
 

--- a/src/badguy/ghosttree.cpp
+++ b/src/badguy/ghosttree.cpp
@@ -199,7 +199,7 @@ GhostTree::active_update(float dt_sec)
           die();
         }
         if (m_lives > 0) {
-          set_action("normal");
+          set_action("default");
           mystate = STATE_IDLE;
           spawn_lantern();
         }

--- a/src/badguy/skydive.cpp
+++ b/src/badguy/skydive.cpp
@@ -29,7 +29,7 @@ SkyDive::SkyDive(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/skydive/skydive.sprite")
 {
   SoundManager::current()->preload("sounds/explosion.wav");
-  set_action("normal");
+  set_action("default");
 }
 
 void

--- a/src/badguy/yeti_stalactite.cpp
+++ b/src/badguy/yeti_stalactite.cpp
@@ -59,7 +59,7 @@ YetiStalactite::update(float dt_sec)
     set_state(STATE_ACTIVE);
     state = STALACTITE_HANGING;
     // Attempt to minimize any potential collisions during this process.
-    set_action("normal");
+    set_action("default");
     set_pos(m_start_position);
     set_colgroup_active(COLGROUP_TOUCHABLE);
   }

--- a/src/gui/mousecursor.cpp
+++ b/src/gui/mousecursor.cpp
@@ -62,7 +62,7 @@ MouseCursor::apply_state(MouseCursorState state)
     switch(state)
     {
       case MouseCursorState::NORMAL:
-        m_sprite->set_action("normal");
+        m_sprite->set_action("default");
         break;
 
       case MouseCursorState::CLICK:

--- a/src/object/bigsnowball.cpp
+++ b/src/object/bigsnowball.cpp
@@ -50,7 +50,7 @@ BigSnowball::BigSnowball(const ReaderMapping& reader) :
     m_dir = string_to_dir(dir_str);
   }
   m_physic.set_velocity_x(m_dir == Direction::RIGHT ? m_speed : -m_speed);
-  set_action("normal", m_dir);
+  set_action("default", m_dir);
 }
 
 BigSnowball::BigSnowball(const Vector& pos, const Direction& dir, bool bounce) :
@@ -70,7 +70,7 @@ BigSnowball::BigSnowball(const Vector& pos, const Direction& dir, bool bounce) :
   if (bounce) {
     m_physic.set_velocity_y(SPEED_Y);
   }
-  set_action("normal", m_dir);
+  set_action("default", m_dir);
 }
 
 ObjectSettings

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -71,7 +71,7 @@ BonusBlock::BonusBlock(const Vector& pos, int tile_data) :
   m_lightsprite(),
   m_coin_sprite(get_default_coin_sprite())
 {
-  set_action("normal");
+  set_action("default");
   m_contents = get_content_by_data(tile_data);
   preload_contents(tile_data);
 }

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -41,10 +41,12 @@ Bumper::Bumper(const ReaderMapping& reader) :
   bool old_facing_left = false;
 
   reader.get("sticky", m_sticky, false);
+
   if (reader.get("direction", dir_str))
     m_dir = string_to_dir(dir_str);
   else if (reader.get("left", old_facing_left) && old_facing_left)
     m_dir = Direction::LEFT;
+
   set_action("default", m_dir);
   m_physic.enable_gravity(false);
 }

--- a/src/object/bumper.cpp
+++ b/src/object/bumper.cpp
@@ -45,7 +45,7 @@ Bumper::Bumper(const ReaderMapping& reader) :
     m_dir = string_to_dir(dir_str);
   else if (reader.get("left", old_facing_left) && old_facing_left)
     m_dir = Direction::LEFT;
-  set_action("normal", m_dir);
+  set_action("default", m_dir);
   m_physic.enable_gravity(false);
 }
 
@@ -63,7 +63,7 @@ void
 Bumper::update(float dt_sec)
 {
   if (m_sprite->animation_done())
-    set_action("normal", m_dir);
+    set_action("default", m_dir);
 
   // Pushing rocks, as well as dynamic with tilemap, platform, and fallblock.
 
@@ -132,7 +132,7 @@ Bumper::after_editor_set()
 {
   MovingSprite::after_editor_set();
 
-  set_action("normal", m_dir);
+  set_action("default", m_dir);
 }
 
 void

--- a/src/object/firefly.cpp
+++ b/src/object/firefly.cpp
@@ -92,7 +92,7 @@ Firefly::update_state()
   }
   else // Is deactivated.
   {
-    set_action("normal");
+    set_action("default");
   }
 }
 

--- a/src/object/lantern.cpp
+++ b/src/object/lantern.cpp
@@ -82,7 +82,7 @@ Lantern::updateColor(){
     set_action("off");
     m_sprite->set_color(Color(1.0f, 1.0f, 1.0f));
   } else {
-    set_action("normal");
+    set_action("default");
     m_sprite->set_color(lightcolor);
   }
 }

--- a/src/object/magicblock.cpp
+++ b/src/object/magicblock.cpp
@@ -180,7 +180,7 @@ MagicBlock::update(float dt_sec)
     set_group(COLGROUP_STATIC);
   } else {
     m_color.alpha = ALPHA_NONSOLID;
-    set_action("normal");
+    set_action("default");
     set_group(COLGROUP_DISABLED);
   }
 }

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -144,7 +144,7 @@ const float SWIM_BOOST_SPEED = 600.f;
 const float SWIM_TO_BOOST_ACCEL = 15.f;
 const float TURN_MAGNITUDE = 0.15f;
 const float TURN_MAGNITUDE_BOOST = 0.2f;
-const std::array<std::string, 2> BUBBLE_ACTIONS = { "normal", "small" };
+const std::array<std::string, 2> BUBBLE_ACTIONS = { "default", "small" };
 
 /* Buttjump variables */
 

--- a/src/object/rusty_trampoline.cpp
+++ b/src/object/rusty_trampoline.cpp
@@ -49,7 +49,7 @@ RustyTrampoline::update(float dt_sec)
     if (counter < 1) {
       remove_me();
     } else {
-      set_action("normal");
+      set_action("default");
     }
 
   }

--- a/src/object/trampoline.cpp
+++ b/src/object/trampoline.cpp
@@ -84,7 +84,7 @@ void
 Trampoline::update(float dt_sec)
 {
   if (m_sprite->animation_done()) {
-    set_action("normal");
+    set_action("default");
   }
 
   Rock::update(dt_sec);

--- a/src/object/unstable_tile.cpp
+++ b/src/object/unstable_tile.cpp
@@ -57,7 +57,7 @@ UnstableTile::UnstableTile(const ReaderMapping& mapping, int type) :
     parse_type(mapping);
   }
 
-  set_action("normal");
+  set_action("default");
 
   physic.set_gravity_modifier(.98f);
   physic.enable_gravity(false);
@@ -199,7 +199,7 @@ UnstableTile::revive()
   m_col.set_movement(Vector(0.0f, 0.0f));
   m_revive_timer.stop();
   m_respawn.reset(new FadeHelper(&m_alpha, FADE_IN_TIME, 1.f));
-  set_action("normal");
+  set_action("default");
 }
 
 void
@@ -233,7 +233,7 @@ UnstableTile::update(float dt_sec)
       }
       else
       {
-        set_action("normal");
+        set_action("default");
         m_fall_timer.stop();
         m_col.set_pos(m_original_pos);
       }

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -63,7 +63,7 @@ WeakBlock::WeakBlock(const ReaderMapping& mapping) :
   else
     SoundManager::current()->preload("sounds/sizzle.ogg");
 
-  set_action("normal");
+  set_action("default");
 }
 
 void

--- a/src/sprite/sprite.cpp
+++ b/src/sprite/sprite.cpp
@@ -34,7 +34,7 @@ Sprite::Sprite(SpriteData& newdata) :
   m_color(1.0f, 1.0f, 1.0f, 1.0f),
   m_blend(),
   m_is_paused(false),
-  m_action(m_data.get_action("normal"))
+  m_action(m_data.get_action("default"))
 {
   if (!m_action)
     m_action = m_data.actions.begin()->second.get();


### PR DESCRIPTION
This will absolutely remove all sprite file inconsistencies between "normal" and "default". Seriously, what were they thinking!

Now that all files are consistent there should be no more weird cases with objects showing wrong actions or giving cryptic warnings.

Testers: Please test badguys like granito, goldbomb, etc. thoroughly