### PR TITLE
Prevent Tux from wanting to take baths in lava

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -524,6 +524,11 @@ Player::update(float dt_sec)
     Rectf swim_here_box = get_bbox();
     swim_here_box.set_bottom(m_col.m_bbox.get_bottom() - 16.f);
     bool can_swim_here = !Sector::get().is_free_of_tiles(swim_here_box, true, Tile::WATER);
+    
+    if(can_swim_here && !m_invincible_timer.started())
+    {
+      can_swim_here = Sector::get().is_free_of_tiles(swim_here_box, true, Tile::HURTS);
+    }
 
     if (m_swimming)
     {

--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -525,8 +525,10 @@ Player::update(float dt_sec)
     swim_here_box.set_bottom(m_col.m_bbox.get_bottom() - 16.f);
     bool can_swim_here = !Sector::get().is_free_of_tiles(swim_here_box, true, Tile::WATER);
     
-    if(can_swim_here && !m_invincible_timer.started())
+    if (can_swim_here && !m_invincible_timer.started())
     {
+      // HACK: Very disgusting! In a perfect world we'd call this function only once.
+      // But we don't live in a perfect world where this function is actually good.
       can_swim_here = Sector::get().is_free_of_tiles(swim_here_box, true, Tile::HURTS);
     }
 


### PR DESCRIPTION
I propose the following code change to prevent Tux from swimming in lava baths unless he has the invincibility star. That means that once Tux enters lava, he'll fall right through. During invincibility, Tux will swim as usual.