### PR TITLE
(cherry pick) Don't call GameSession::restart_level in the constructor

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -249,7 +249,7 @@ GameSession::restart_level(bool after_death, bool preserve_music)
     }
   }
   catch (std::exception& e) {
-    throw std::runtime_error(fmt::format("Couldn't start level: {}", e.what()));
+    throw std::runtime_error(std::string("Couldn't start level: ") + e.what());
     ScreenManager::current()->pop_screen();
   }
 

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -17,6 +17,8 @@
 #include "supertux/game_session.hpp"
 
 #include <cfloat>
+#include <fmt/format.h>
+#include <stdexcept>
 
 #include "audio/sound_manager.hpp"
 #include "control/input_manager.hpp"
@@ -151,7 +153,7 @@ GameSession::on_player_removed(int id)
   return false;
 }
 
-int
+void
 GameSession::restart_level(bool after_death, bool preserve_music)
 {
   const PlayerStatus& currentStatus = m_savegame.get_player_status();
@@ -234,7 +236,7 @@ GameSession::restart_level(bool after_death, bool preserve_music)
     m_currentsector = m_level->get_sector(spawnpoint->sector);
     if (!m_currentsector)
     {
-      throw std::runtime_error("Couldn't find sector '" + spawnpoint->sector + "' to spawn/respawn Tux.");
+      throw std::runtime_error(fmt::format("Couldn't find sector '{}' to spawn/respawn Tux.", spawnpoint->sector));
     }
     // Activate on either the spawnpoint (if set), or the spawn position.
     if (spawnpoint->spawnpoint.empty())
@@ -247,9 +249,8 @@ GameSession::restart_level(bool after_death, bool preserve_music)
     }
   }
   catch (std::exception& e) {
-    log_fatal << "Couldn't start level: " << e.what() << std::endl;
+    throw std::runtime_error(fmt::format("Couldn't start level: {}", e.what()));
     ScreenManager::current()->pop_screen();
-    return (-1);
   }
 
   if (m_levelintro_shown)
@@ -277,8 +278,6 @@ GameSession::restart_level(bool after_death, bool preserve_music)
     it->set_time(it->get_time() - m_play_time);
     it++;
   }
-
-  return (0);
 }
 
 void

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -250,7 +250,6 @@ GameSession::restart_level(bool after_death, bool preserve_music)
   }
   catch (std::exception& e) {
     throw std::runtime_error(std::string("Couldn't start level: ") + e.what());
-    ScreenManager::current()->pop_screen();
   }
 
   if (m_levelintro_shown)

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -94,9 +94,6 @@ GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Stat
   m_boni_at_start.resize(InputManager::current()->get_num_users(), BONUS_NONE);
 
   m_data_table.clear();
-
-  if (restart_level(false, preserve_music) != 0)
-    throw std::runtime_error ("Initializing the level failed.");
 }
 
 void

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -55,8 +55,7 @@ static const int SHRINKFADE_LAYER = LAYER_LIGHTMAP - 1;
 static const float TELEPORT_FADE_TIME = 1.0f;
 
 
-GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics,
-                         bool preserve_music) :
+GameSession::GameSession(const std::string& levelfile_, Savegame& savegame, Statistics* statistics) :
   reset_button(false),
   reset_checkpoint_button(false),
   m_prevent_death(false),

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -78,8 +78,7 @@ private:
   };
 
 public:
-  GameSession(const std::string& levelfile, Savegame& savegame, Statistics* statistics = nullptr,
-              bool preserve_music = false);
+  GameSession(const std::string& levelfile, Savegame& savegame, Statistics* statistics = nullptr);
 
   virtual void draw(Compositor& compositor) override;
   virtual void update(float dt_sec, const Controller& controller) override;

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -130,7 +130,7 @@ public:
   std::string get_working_directory() const;
   inline const std::string& get_level_file() const { return m_levelfile; }
   inline bool has_active_sequence() const { return m_end_sequence; }
-  int restart_level(bool after_death = false, bool preserve_music = false);
+  void restart_level(bool after_death = false, bool preserve_music = false);
 
   void toggle_pause();
   void abort_level();

--- a/src/supertux/levelset_screen.cpp
+++ b/src/supertux/levelset_screen.cpp
@@ -26,7 +26,6 @@
 #include "supertux/screen_manager.hpp"
 #include "util/file_system.hpp"
 #include "util/log.hpp"
-#include <SDL_atomic.h>
 
 LevelsetScreen::LevelsetScreen(const std::string& basedir, const std::string& level_filename,
                                Savegame& savegame,

--- a/src/supertux/levelset_screen.cpp
+++ b/src/supertux/levelset_screen.cpp
@@ -27,6 +27,8 @@
 #include "util/file_system.hpp"
 #include "util/log.hpp"
 
+// TODO: wtf?????????
+
 LevelsetScreen::LevelsetScreen(const std::string& basedir, const std::string& level_filename,
                                Savegame& savegame,
                                const std::optional<std::pair<std::string, Vector>>& start_pos) :
@@ -88,8 +90,8 @@ LevelsetScreen::setup()
                                                   m_savegame);
       if (m_start_pos) {
         screen->set_start_pos(m_start_pos->first, m_start_pos->second);
-        screen->restart_level();
       }
+      screen->restart_level();
       ScreenManager::current()->push_screen(std::move(screen));
     }
   }

--- a/src/supertux/levelset_screen.cpp
+++ b/src/supertux/levelset_screen.cpp
@@ -27,8 +27,6 @@
 #include "util/file_system.hpp"
 #include "util/log.hpp"
 
-// TODO: wtf?????????
-
 LevelsetScreen::LevelsetScreen(const std::string& basedir, const std::string& level_filename,
                                Savegame& savegame,
                                const std::optional<std::pair<std::string, Vector>>& start_pos) :

--- a/src/supertux/levelset_screen.cpp
+++ b/src/supertux/levelset_screen.cpp
@@ -26,6 +26,7 @@
 #include "supertux/screen_manager.hpp"
 #include "util/file_system.hpp"
 #include "util/log.hpp"
+#include <SDL_atomic.h>
 
 LevelsetScreen::LevelsetScreen(const std::string& basedir, const std::string& level_filename,
                                Savegame& savegame,
@@ -89,8 +90,17 @@ LevelsetScreen::setup()
       if (m_start_pos) {
         screen->set_start_pos(m_start_pos->first, m_start_pos->second);
       }
-      screen->restart_level();
-      ScreenManager::current()->push_screen(std::move(screen));
+      
+      try
+      {
+        screen->restart_level();
+        ScreenManager::current()->push_screen(std::move(screen));
+      }
+      catch (const std::runtime_error& e)
+      {
+        log_warning << "Couldn't load level: " << e.what() << std::endl;
+        ScreenManager::current()->pop_screen();
+      }
     }
   }
 }

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -624,7 +624,6 @@ Main::launch_game(const CommandLineArguments& args)
           std::string spawnpointname = args.spawnpoint.value_or(default_spawnpoint);
 
           session->set_start_point(sectorname, spawnpointname);
-          session->restart_level();
         }
 
         if (g_config->tux_spawn_pos)
@@ -633,6 +632,7 @@ Main::launch_game(const CommandLineArguments& args)
           session->get_current_sector().get_players()[0]->set_pos(*g_config->tux_spawn_pos);
         }
 
+        session->restart_level();
         m_screen_manager->push_screen(std::move(session));
       }
     }

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -120,8 +120,11 @@ TitleScreen::refresh_level()
         log_warning << "Error loading custom title screen level '" << title_level << "': " << err.what() << std::endl;
 
         if (!m_titlesession || m_titlesession->get_level_file() != DEFAULT_TITLE_LEVEL)
+        {
           new_session = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
+        }
       }
+      new_session->restart_level();
       if (new_session)
       {
         m_titlesession = std::move(new_session);
@@ -132,9 +135,9 @@ TitleScreen::refresh_level()
   else if (!m_titlesession || m_titlesession->get_level_file() != DEFAULT_TITLE_LEVEL)
   {
     m_titlesession = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
+    m_titlesession->restart_level();
     level_init = true;
   }
-  m_titlesession->restart_level();
 
   /** Initialize the main sector. */
   Sector& sector = m_titlesession->get_current_sector();

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -122,7 +122,6 @@ TitleScreen::refresh_level()
         if (!m_titlesession || m_titlesession->get_level_file() != DEFAULT_TITLE_LEVEL)
           new_session = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
       }
-
       if (new_session)
       {
         m_titlesession = std::move(new_session);
@@ -135,6 +134,7 @@ TitleScreen::refresh_level()
     m_titlesession = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
     level_init = true;
   }
+  m_titlesession->restart_level();
 
   /** Initialize the main sector. */
   Sector& sector = m_titlesession->get_current_sector();

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -113,7 +113,7 @@ TitleScreen::refresh_level()
       std::unique_ptr<GameSession> new_session;
       try
       {
-        new_session = std::make_unique<GameSession>(title_level, m_savegame, nullptr, true);
+        new_session = std::make_unique<GameSession>(title_level, m_savegame, nullptr);
       }
       catch (const std::exception& err)
       {
@@ -121,10 +121,10 @@ TitleScreen::refresh_level()
 
         if (!m_titlesession || m_titlesession->get_level_file() != DEFAULT_TITLE_LEVEL)
         {
-          new_session = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
+          new_session = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr);
         }
       }
-      new_session->restart_level();
+      new_session->restart_level(false, true);
       if (new_session)
       {
         m_titlesession = std::move(new_session);
@@ -134,8 +134,8 @@ TitleScreen::refresh_level()
   }
   else if (!m_titlesession || m_titlesession->get_level_file() != DEFAULT_TITLE_LEVEL)
   {
-    m_titlesession = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr, true);
-    m_titlesession->restart_level();
+    m_titlesession = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr);
+    m_titlesession->restart_level(false, true);
     level_init = true;
   }
 

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -355,12 +355,12 @@ WorldMapSector::update(float dt_sec)
                                     level_->get_pos().y +  8 - m_camera->get_offset().y);
           std::string levelfile = m_parent.m_levels_path + level_->get_level_filename();
           
-          auto gamesession = std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics());
-          gamesession->restart_level();
+          auto game_session = std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics());
+          game_session->restart_level();
 
           // update state and savegame
           m_parent.save_state();
-          ScreenManager::current()->push_screen(std::move(gamesession),
+          ScreenManager::current()->push_screen(std::move(game_session),
                                                 std::make_unique<ShrinkFade>(shrinkpos, 1.0f, LAYER_LIGHTMAP - 1));
 
           m_parent.m_in_level = true;

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -354,10 +354,13 @@ WorldMapSector::update(float dt_sec)
           Vector shrinkpos = Vector(level_->get_pos().x + 16 - m_camera->get_offset().x,
                                     level_->get_pos().y +  8 - m_camera->get_offset().y);
           std::string levelfile = m_parent.m_levels_path + level_->get_level_filename();
+          
+          auto gamesession = std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics());
+          gamesession->restart_level();
 
           // update state and savegame
           m_parent.save_state();
-          ScreenManager::current()->push_screen(std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics()),
+          ScreenManager::current()->push_screen(std::move(gamesession),
                                                 std::make_unique<ShrinkFade>(shrinkpos, 1.0f, LAYER_LIGHTMAP - 1));
 
           m_parent.m_in_level = true;


### PR DESCRIPTION
This stops testing (on the "Test from here")/the title screen (yes, the title screen) from reparsing the level by simply changing the usage pattern of the GameSession constructor.

Cherry picked from commit https://github.com/swagtoy/supertux/commit/0d25b71d0b92d1f2feedcc6735b581fed34dbeaa upon the request of Vankata.