### PR TITLE
[Draft] Refactor Player.cpp

### DIFF
--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -17,6 +17,7 @@
 #ifndef HEADER_SUPERTUX_OBJECT_PLAYER_HPP
 #define HEADER_SUPERTUX_OBJECT_PLAYER_HPP
 
+#include "moving_sprite.hpp"
 #include "sprite/sprite_ptr.hpp"
 #include "supertux/direction.hpp"
 #include "supertux/moving_object.hpp"
@@ -42,12 +43,12 @@ extern const float TUX_INVINCIBLE_TIME_WARNING;
 
 /**
  * @scripting
- * @summary This module contains methods controlling the player. (No, SuperTux doesn't use mind control. ""Player"" refers to the type of the player object.)
+ * @summary This module contains methods controlling the player.
  * @instances The first player can be accessed using ""Tux"", or ""sector.Tux"" from the console.
               All following players (2nd, 3rd, etc...) can be accessed by ""Tux{index}"".
               For example, to access the 2nd player, use ""Tux1"" (or ""sector.Tux1"" from the console).
  */
-class Player final : public MovingObject
+class Player final : public MovingSprite
 {
 public:
   static void register_class(ssq::VM& vm);
@@ -579,8 +580,6 @@ private:
   Portable* m_grabbed_object;
   std::unique_ptr<ObjectRemoveListener> m_grabbed_object_remove_listener;
   bool m_released_object;
-
-  SpritePtr m_sprite; /**< The main sprite representing Tux */
 
   float m_swimming_angle;
   float m_swimming_accel_modifier;


### PR DESCRIPTION
About damn time.

Highlights:
- Moved Player to MovingSprite, now you can use Squirrel `Tux.set_sprite` calls and have fun with that. Custom sprites are possible now. This was so easy to do it hurts.

Main things on my bucketlist are refactoring the majority of state into either a) their own smaller classes, b) into more functions, and c) maybe bitwise state and/or std::bitset. The input code is kind of disgusting and could be set up some. State machinery stuff related to switching the players sprite likely has room for improvement. Update function is just putrid. Input/shooting/powerup code MIGHT be able to get refactored out of player, i'll see what I can do :)
