### PR TITLE
Fix nullptr crash in player status hud due to wrong player item pocket access

### DIFF
--- a/src/supertux/player_status_hud.cpp
+++ b/src/supertux/player_status_hud.cpp
@@ -111,7 +111,7 @@ PlayerStatusHUD::draw(DrawingContext& context)
         pos += 20;
 
         Sprite* sprite = m_bonus_sprites[m_player_status.m_item_pockets[i]].get();
-        if (sprite != nullptr)
+        if (sprite)
           sprite->draw(context.color(), pos, LAYER_HUD);
       }
     }

--- a/src/supertux/player_status_hud.cpp
+++ b/src/supertux/player_status_hud.cpp
@@ -109,8 +109,10 @@ PlayerStatusHUD::draw(DrawingContext& context)
       if (m_bonus_sprites.find(m_player_status.m_item_pockets[i]) != m_bonus_sprites.end())
       {
         pos += 20;
-        Sprite* sprite = m_bonus_sprites[m_player_status.m_item_pockets.front()].get();
-        sprite->draw(context.color(), pos, LAYER_HUD);
+
+        Sprite* sprite = m_bonus_sprites[m_player_status.m_item_pockets[i]].get();
+        if (sprite != nullptr)
+          sprite->draw(context.color(), pos, LAYER_HUD);
       }
     }
   }


### PR DESCRIPTION
Fixes a crash if multiple players are in the game and the first player does not have any bonus while other players have a bonus. Due to a wrong access of m_bonus_sprites, a nullptr is returned for the sprite pointer which causes a segfault when the hud tries to draw the sprite.