### PR TITLE
Compress `TileMap` tiles in level file

### DIFF
--- a/src/editor/object_option.cpp
+++ b/src/editor/object_option.cpp
@@ -711,11 +711,9 @@ TilesObjectOption::parse(const ReaderMapping& reader)
 }
 
 void
-TilesObjectOption::save(Writer& write) const
+TilesObjectOption::save(Writer& writer) const
 {
-  write.write("width", m_value_pointer->get_width());
-  write.write("height", m_value_pointer->get_height());
-  write.write("tiles", m_value_pointer->get_tiles(), m_value_pointer->get_width());
+  m_value_pointer->write_tiles(writer);
 }
 
 std::string

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -176,7 +176,7 @@ TileMap::parse_tiles(const ReaderMapping& reader)
   }
   else
   {
-    reader.get_merge("tiles", m_tiles, 0);
+    reader.get_compressed("tiles", m_tiles);
     if (m_tiles.empty())
       throw std::runtime_error("No tiles in tilemap.");
 
@@ -211,7 +211,7 @@ TileMap::write_tiles(Writer& writer) const
 {
   writer.write("width", m_width);
   writer.write("height", m_height);
-  writer.write_merge("tiles", m_tiles, 0, m_width);
+  writer.write_compressed("tiles", m_tiles, m_width);
 }
 
 void

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -176,7 +176,7 @@ TileMap::parse_tiles(const ReaderMapping& reader)
   }
   else
   {
-    reader.get("tiles", m_tiles);
+    reader.get_merge("tiles", m_tiles, 0);
     if (m_tiles.empty())
       throw std::runtime_error("No tiles in tilemap.");
 
@@ -204,6 +204,14 @@ TileMap::parse_tiles(const ReaderMapping& reader)
   m_new_size_y = m_height;
   m_new_offset_x = 0;
   m_new_offset_y = 0;
+}
+
+void
+TileMap::write_tiles(Writer& writer) const
+{
+  writer.write("width", m_width);
+  writer.write("height", m_height);
+  writer.write_merge("tiles", m_tiles, 0, m_width);
 }
 
 void

--- a/src/object/tilemap.cpp
+++ b/src/object/tilemap.cpp
@@ -211,7 +211,7 @@ TileMap::write_tiles(Writer& writer) const
 {
   writer.write("width", m_width);
   writer.write("height", m_height);
-  writer.write_compressed("tiles", m_tiles, m_width);
+  writer.write_compressed("tiles", m_tiles);
 }
 
 void

--- a/src/object/tilemap.hpp
+++ b/src/object/tilemap.hpp
@@ -59,8 +59,6 @@ public:
   TileMap(const TileSet *tileset, const ReaderMapping& reader);
   ~TileMap() override;
 
-  void parse_tiles(const ReaderMapping& reader);
-
   virtual void finish_construction() override;
 
   static std::string class_name() { return "tilemap"; }
@@ -83,6 +81,9 @@ public:
   virtual void editor_update() override;
 
   virtual void on_flip(float height) override;
+
+  void parse_tiles(const ReaderMapping& reader);
+  void write_tiles(Writer& writer) const;
 
   void set(int width, int height, const std::vector<unsigned int>& vec,
            int z_pos, bool solid);

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -201,6 +201,29 @@ ReaderMapping::get(const char* key, std::vector<unsigned int>& value,
   GET_VALUES_MACRO("unsigned int", is_integer, as_int)
 }
 
+bool
+ReaderMapping::get_merge(const char* key, std::vector<unsigned int>& value, unsigned int merge_value) const
+{
+  const auto sx = get_item(key);
+  if (!sx)
+    return false;
+
+  assert_is_array(m_doc, *sx);
+  value.clear();
+  const auto& item = sx->as_array();
+  for (size_t i = 1; i < item.size(); ++i)
+  {
+    assert_is_integer(m_doc, item[i]);
+
+    const int val = item[i].as_int();
+    if (val < 0)
+      value.insert(value.end(), -val, merge_value);
+    else
+      value.emplace_back(val);
+  }
+  return true;
+}
+
 #undef GET_VALUES_MACRO
 
 bool

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -218,31 +218,31 @@ ReaderMapping::get_compressed(const char* key, std::vector<unsigned int>& value,
   assert_is_array(m_doc, *sx);
   value.clear();
   const auto& item = sx->as_array();
-  int multiplier = 0;
+  int repeater = 0;
   for (size_t i = 1; i < item.size(); ++i)
   {
     assert_is_integer(m_doc, item[i]);
 
     const int val = item[i].as_int();
-    if (multiplier)
+    if (repeater)
     {
       if (val < 0)
       {
         raise_exception(m_doc, item[i], "expected positive integer after multiplier");
       }
-      value.insert(value.end(), multiplier, val);
-      multiplier = 0;
+      value.insert(value.end(), repeater, val);
+      repeater = 0;
     }
     else if (val < 0)
     {
-      multiplier = -val;
+      repeater = -val;
     }
     else
     {
       value.push_back(val);
     }
   }
-  if (multiplier)
+  if (repeater)
   {
     raise_exception(m_doc, item.back(), "expected positive integer after multiplier");
   }

--- a/src/util/reader_mapping.cpp
+++ b/src/util/reader_mapping.cpp
@@ -157,6 +157,7 @@ ReaderMapping::get(const char* key, std::string& value, const std::optional<cons
     assert_is_array(m_doc, *sx);                                        \
     value.clear();                                                      \
     auto const& item = sx->as_array();                                  \
+    value.reserve(item.size());                                         \
     for (size_t i = 1; i < item.size(); ++i)                            \
     {                                                                   \
       assert_##checker(m_doc, item[i]);                                 \
@@ -218,6 +219,8 @@ ReaderMapping::get_compressed(const char* key, std::vector<unsigned int>& value,
   assert_is_array(m_doc, *sx);
   value.clear();
   const auto& item = sx->as_array();
+  value.reserve(item.size());
+
   int repeater = 0;
   for (size_t i = 1; i < item.size(); ++i)
   {
@@ -228,7 +231,7 @@ ReaderMapping::get_compressed(const char* key, std::vector<unsigned int>& value,
     {
       if (val < 0)
       {
-        raise_exception(m_doc, item[i], "expected positive integer after multiplier");
+        raise_exception(m_doc, item[i], "expected positive integer after repeater");
       }
       value.insert(value.end(), repeater, val);
       repeater = 0;
@@ -244,7 +247,7 @@ ReaderMapping::get_compressed(const char* key, std::vector<unsigned int>& value,
   }
   if (repeater)
   {
-    raise_exception(m_doc, item.back(), "expected positive integer after multiplier");
+    raise_exception(m_doc, item.back(), "expected positive integer after repeater");
   }
   return true;
 }

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -54,7 +54,7 @@ public:
   bool get(const char* key, std::vector<std::string>& value, const std::optional<std::vector<std::string>>& default_value = std::nullopt) const;
   bool get(const char* key, std::vector<unsigned int>& value, const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 
-  // Reads vector by using the absolute value of any negative integer values as a repeater for the next value.
+  // Reads vector by using the absolute value of any negative integer value as a repeater for the next value.
   bool get_compressed(const char* key, std::vector<unsigned int>& value,
                       const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -54,7 +54,7 @@ public:
   bool get(const char* key, std::vector<std::string>& value, const std::optional<std::vector<std::string>>& default_value = std::nullopt) const;
   bool get(const char* key, std::vector<unsigned int>& value, const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 
-  // Reads vector by using any negative integer values as a multiplier for the next value.
+  // Reads vector by using the absolute value of any negative integer values as a repeater for the next value.
   bool get_compressed(const char* key, std::vector<unsigned int>& value,
                       const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -54,6 +54,9 @@ public:
   bool get(const char* key, std::vector<std::string>& value, const std::optional<std::vector<std::string>>& default_value = std::nullopt) const;
   bool get(const char* key, std::vector<unsigned int>& value, const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 
+  // Reads vector by merging all negative values into "merge_value", repeated as much as the absolute value of the negative value.
+  bool get_merge(const char* key, std::vector<unsigned int>& value, unsigned int merge_value) const;
+
   bool get(const char* key, std::optional<ReaderMapping>&) const;
   bool get(const char* key, std::optional<ReaderCollection>&) const;
 

--- a/src/util/reader_mapping.hpp
+++ b/src/util/reader_mapping.hpp
@@ -54,8 +54,9 @@ public:
   bool get(const char* key, std::vector<std::string>& value, const std::optional<std::vector<std::string>>& default_value = std::nullopt) const;
   bool get(const char* key, std::vector<unsigned int>& value, const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 
-  // Reads vector by merging all negative values into "merge_value", repeated as much as the absolute value of the negative value.
-  bool get_merge(const char* key, std::vector<unsigned int>& value, unsigned int merge_value) const;
+  // Reads vector by using any negative integer values as a multiplier for the next value.
+  bool get_compressed(const char* key, std::vector<unsigned int>& value,
+                      const std::optional<std::vector<unsigned int>>& default_value = std::nullopt) const;
 
   bool get(const char* key, std::optional<ReaderMapping>&) const;
   bool get(const char* key, std::optional<ReaderCollection>&) const;

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -258,7 +258,7 @@ Writer::write_compressed(const std::string& name, const std::vector<unsigned int
   unsigned int repeated_value = 0;
   for (size_t i = 0; i < value.size(); ++i)
   {
-    if (repeater > 0 && value[i] == repeated_value)
+    if (repeater && value[i] == repeated_value)
     {
       ++repeater;
     }

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -249,54 +249,37 @@ Writer::write(const std::string& name, const sexp::Value& value)
 }
 
 void
-Writer::write_compressed(const std::string& name, const std::vector<unsigned int>& value, int width)
+Writer::write_compressed(const std::string& name, const std::vector<unsigned int>& value)
 {
   indent();
   *out << '(' << name;
-  if (width > 0)
-  {
-    *out << "\n";
-    indent();
-  }
 
-  int count = 0;
   int repeater = 0;
   unsigned int repeated_value = 0;
-  for (const auto& i : value)
+  for (size_t i = 0; i < value.size(); ++i)
   {
-    const bool width_limit = (width > 0 && count >= width);
-
-    ++count;
-    if (repeater > 0 && i == repeated_value)
+    if (repeater > 0 && value[i] == repeated_value)
     {
       ++repeater;
     }
     else
     {
       if (repeater > 1)
-        *out << -repeater << " " << repeated_value << (width_limit ? "" : " ");
-      else if (repeater == 1)
-        *out << repeated_value << (width_limit ? "" : " ");
-
-      repeater = 1;
-      repeated_value = i;
-    }
-
-    if (width > 0 && count >= width)
-    {
-      if (repeater > 1)
         *out << -repeater << " " << repeated_value;
       else if (repeater == 1)
         *out << repeated_value;
 
-      count = 0;
-      repeater = 0;
-      repeated_value = 0;
+      if (i != value.size() - 1)
+        *out << " ";
 
-      *out << "\n";
-      indent();
+      repeater = 1;
+      repeated_value = value[i];
     }
   }
+  if (repeater > 1)
+    *out << " " << -repeater << " " << repeated_value;
+  else if (repeater == 1)
+    *out << " " << repeated_value;
 
   *out << ")\n";
 }

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -260,38 +260,38 @@ Writer::write_compressed(const std::string& name, const std::vector<unsigned int
   }
 
   int count = 0;
-  int multiplier = 0;
-  unsigned int multiplied_value = 0;
+  int repeater = 0;
+  unsigned int repeated_value = 0;
   for (const auto& i : value)
   {
     const bool width_limit = (width > 0 && count >= width);
 
     ++count;
-    if (multiplier > 0 && i == multiplied_value)
+    if (repeater > 0 && i == repeated_value)
     {
-      ++multiplier;
+      ++repeater;
     }
     else
     {
-      if (multiplier > 1)
-        *out << -multiplier << " " << multiplied_value << (width_limit ? "" : " ");
-      else if (multiplier == 1)
-        *out << multiplied_value << (width_limit ? "" : " ");
+      if (repeater > 1)
+        *out << -repeater << " " << repeated_value << (width_limit ? "" : " ");
+      else if (repeater == 1)
+        *out << repeated_value << (width_limit ? "" : " ");
 
-      multiplier = 1;
-      multiplied_value = i;
+      repeater = 1;
+      repeated_value = i;
     }
 
     if (width > 0 && count >= width)
     {
-      if (multiplier > 1)
-        *out << -multiplier << " " << multiplied_value;
-      else if (multiplier == 1)
-        *out << multiplied_value;
+      if (repeater > 1)
+        *out << -repeater << " " << repeated_value;
+      else if (repeater == 1)
+        *out << repeated_value;
 
       count = 0;
-      multiplier = 0;
-      multiplied_value = 0;
+      repeater = 0;
+      repeated_value = 0;
 
       *out << "\n";
       indent();

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -252,31 +252,36 @@ void
 Writer::write_compressed(const std::string& name, const std::vector<unsigned int>& value)
 {
   indent();
+  if (value.empty())
+  {
+    *out << '(' << name << ')\n';
+    return;
+  }
   *out << '(' << name << ' ';
 
   int repeater = 0;
   unsigned int repeated_value = 0;
-  for (size_t i = 0; i < value.size(); ++i)
+  for (const auto& i : value)
   {
-    if (repeater && value[i] == repeated_value)
+    if (repeater && i == repeated_value)
     {
       ++repeater;
     }
     else
     {
       if (repeater > 1)
-        *out << -repeater << ' ' << repeated_value << (i == value.size() - 1 ? "" : " ");
+        *out << -repeater << ' ' << repeated_value << ' ';
       else if (repeater == 1)
-        *out << repeated_value << (i == value.size() - 1 ? "" : " ");
+        *out << repeated_value << ' ';
 
       repeater = 1;
-      repeated_value = value[i];
+      repeated_value = i;
     }
   }
   if (repeater > 1)
-    *out << ' ' << -repeater << ' ' << repeated_value;
-  else if (repeater == 1)
-    *out << ' ' << repeated_value;
+    *out << -repeater << ' ' << repeated_value;
+  else
+    *out << repeated_value;
 
   *out << ")\n";
 }

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -252,7 +252,7 @@ void
 Writer::write_compressed(const std::string& name, const std::vector<unsigned int>& value)
 {
   indent();
-  *out << '(' << name;
+  *out << '(' << name << ' ';
 
   int repeater = 0;
   unsigned int repeated_value = 0;
@@ -265,21 +265,18 @@ Writer::write_compressed(const std::string& name, const std::vector<unsigned int
     else
     {
       if (repeater > 1)
-        *out << -repeater << " " << repeated_value;
+        *out << -repeater << ' ' << repeated_value << (i == value.size() - 1 ? "" : " ");
       else if (repeater == 1)
-        *out << repeated_value;
-
-      if (i != value.size() - 1)
-        *out << " ";
+        *out << repeated_value << (i == value.size() - 1 ? "" : " ");
 
       repeater = 1;
       repeated_value = value[i];
     }
   }
   if (repeater > 1)
-    *out << " " << -repeater << " " << repeated_value;
+    *out << ' ' << -repeater << ' ' << repeated_value;
   else if (repeater == 1)
-    *out << " " << repeated_value;
+    *out << ' ' << repeated_value;
 
   *out << ")\n";
 }

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -249,6 +249,58 @@ Writer::write(const std::string& name, const sexp::Value& value)
 }
 
 void
+Writer::write_merge(const std::string& name, const std::vector<unsigned int>& value, unsigned int merge_value, int width)
+{
+  indent();
+  *out << '(' << name;
+  if (width > 0)
+  {
+    *out << "\n";
+    indent();
+  }
+
+  int count = 0;
+  int merge_count = 0;
+  for (const auto& i : value)
+  {
+    const bool merge_value_match = (i == merge_value);
+    if (merge_value_match)
+    {
+      ++merge_count;
+    }
+    else
+    {
+      if (merge_count)
+      {
+        *out << -merge_count << " ";
+        merge_count = 0;
+      }
+      *out << i;
+    }
+    ++count;
+
+    if (width > 0 && count >= width)
+    {
+      count = 0;
+      if (merge_count)
+      {
+        *out << -merge_count;
+        merge_count = 0;
+      }
+
+      *out << "\n";
+      indent();
+    }
+    else if (!merge_value_match)
+    {
+      *out << " ";
+    }
+  }
+
+  *out << ")\n";
+}
+
+void
 Writer::write_escaped_string(const std::string& str)
 {
   *out << '"';

--- a/src/util/writer.cpp
+++ b/src/util/writer.cpp
@@ -254,7 +254,7 @@ Writer::write_compressed(const std::string& name, const std::vector<unsigned int
   indent();
   if (value.empty())
   {
-    *out << '(' << name << ')\n';
+    *out << '(' << name << ")\n";
     return;
   }
   *out << '(' << name << ' ';

--- a/src/util/writer.hpp
+++ b/src/util/writer.hpp
@@ -50,7 +50,7 @@ public:
   void write(const std::string& name, const sexp::Value& value);
   // add more write-functions when needed...
 
-  // Writes vector by using negative integer values as multipliers for repeating values.
+  // Writes vector by using negative integer values as repeaters for repeating values.
   void write_compressed(const std::string& name, const std::vector<unsigned int>& value, int width = 0);
 
   void end_list(const std::string& listname);

--- a/src/util/writer.hpp
+++ b/src/util/writer.hpp
@@ -50,8 +50,8 @@ public:
   void write(const std::string& name, const sexp::Value& value);
   // add more write-functions when needed...
 
-  // Writes vector by merging all occurences of "merge_value" into -{occurences}.
-  void write_merge(const std::string& name, const std::vector<unsigned int>& value, unsigned int merge_value, int width = 0);
+  // Writes vector by using negative integer values as multipliers for repeating values.
+  void write_compressed(const std::string& name, const std::vector<unsigned int>& value, int width = 0);
 
   void end_list(const std::string& listname);
 

--- a/src/util/writer.hpp
+++ b/src/util/writer.hpp
@@ -51,7 +51,7 @@ public:
   // add more write-functions when needed...
 
   // Writes vector by using negative integer values as repeaters for repeating values.
-  void write_compressed(const std::string& name, const std::vector<unsigned int>& value, int width = 0);
+  void write_compressed(const std::string& name, const std::vector<unsigned int>& value);
 
   void end_list(const std::string& listname);
 

--- a/src/util/writer.hpp
+++ b/src/util/writer.hpp
@@ -50,6 +50,9 @@ public:
   void write(const std::string& name, const sexp::Value& value);
   // add more write-functions when needed...
 
+  // Writes vector by merging all occurences of "merge_value" into -{occurences}.
+  void write_merge(const std::string& name, const std::vector<unsigned int>& value, unsigned int merge_value, int width = 0);
+
   void end_list(const std::string& listname);
 
 private:


### PR DESCRIPTION
`TileMap` tiles are now saved with the help of negative integers, the absolute value of each one being a multiplier for the next value (ex. "0 0 0 0 0 5 5 5" -> "-5 0 -3 5").

Newline separation for tiles in file based on `TileMap` width is no longer supported to save off additional file size.

Examples:

* `0 0 0 0 0 0 45 1 1 1 1 3 3 3 3 3 0 0` -> `-6 0 45 -4 1 -5 3 -2 0`
* `0 0 0 0 0 43 12 12 12 12 12 1 1 1 5` -> `-5 0 43 -5 12 -3 1 5`

Results from re-saving some levels from "The Crystal Catacombs":

* **Worldmap**: 1.5MiB -> 74.9KiB
* "The Journey Begins Again": 409.2KiB -> 27.7KiB
* "Fjord of Fortitude": 319.1KiB -> 48.9KiB
* "A Light in the Darkness": 613.3KiB -> 183.9KiB
* "Light and Magic": 456KiB -> 163.0KiB