### PR TITLE
Remove invalid off-script in leaf_wind.stl

### DIFF
--- a/data/levels/world2/leaf_wind.stl
+++ b/data/levels/world2/leaf_wind.stl
@@ -190,12 +190,6 @@
     )
     (switch
       (script "wind2.start();")
-      (off-script "door1.goto_node(0);
-door2.goto_node(0);
-door3.goto_node(0);
-door4.goto_node(0);
-door5.goto_node(0);
-door6.goto_node(0);")
       (sprite "/images/objects/switch/right.sprite")
       (x 8000)
       (y 1376)


### PR DESCRIPTION
The off script causes the game to crash, because door1-door6 do not exist in the level.