### PR TITLE
Fix MD5 digest

### DIFF
--- a/src/addon/md5.cpp
+++ b/src/addon/md5.cpp
@@ -161,10 +161,10 @@ std::string MD5::hex_digest() {
   for (i=0; i<16; i++)
   {
     char* so = s + i * 2;
-    snprintf(so, sizeof(so), "%02x", digest[i]);
+    snprintf(so, 3 /* 2 chars + terminating NULL */, "%02x", digest[i]);
   }
 
-  s[32]='\0';
+  // Already null-terminated from the last snprintf
 
   // Create string from 's'
   std::string s_str = std::string(s);


### PR DESCRIPTION
Commit c04b46a58a mistakenly used `snprintf(str, sizeof(str), ...)` with `sizeof` instead of `strlen`.

Since using `strlen` would add a header, and since we know both the buffer length and the length of the printed string, the size can simply be hardcoded (2 characters + 1 terminating NULL character, which will be overwritten for each printf except the last).

I've also removed the now-unneeded manual terminating null byte.