### PR TITLE
Fix relative paths with the Particle Editor

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -265,7 +265,12 @@ Editor::update(float dt_sec, const Controller& controller)
     m_particle_editor_request = false;
     std::unique_ptr<Screen> screen(new ParticleEditor());
     if (m_particle_editor_filename)
-      static_cast<ParticleEditor*>(screen.get())->open("particles/" + *m_particle_editor_filename);
+    {
+      // realpath() is necessary for particle files outside the particles/ folder
+      std::string path = physfsutil::realpath("particles/" + *m_particle_editor_filename);
+
+      static_cast<ParticleEditor*>(screen.get())->open(path);
+    }
     ScreenManager::current()->push_screen(std::move(screen));
     return;
   }

--- a/src/object/custom_particle_system_file.cpp
+++ b/src/object/custom_particle_system_file.cpp
@@ -20,6 +20,7 @@
 
 #include "editor/editor.hpp"
 #include "gui/menu_manager.hpp"
+#include "physfs/util.hpp"
 #include "util/reader.hpp"
 #include "util/reader_document.hpp"
 #include "util/reader_mapping.hpp"
@@ -66,7 +67,10 @@ CustomParticleSystemFile::update_data()
 {
   try
   {
-    auto doc = ReaderDocument::from_file("particles/" + ((m_filename == "") ? "default.stcp" : m_filename));
+    // realpath() is necessary for particle files outside the particles/ folder
+    std::string path = physfsutil::realpath("particles/" + ((m_filename == "") ? "default.stcp" : m_filename));
+
+    auto doc = ReaderDocument::from_file(path);
     auto root = doc.get_root();
     auto mapping = root.get_mapping();
 

--- a/src/supertux/menu/particle_editor_menu.cpp
+++ b/src/supertux/menu/particle_editor_menu.cpp
@@ -21,6 +21,7 @@
 #include "gui/menu_filesystem.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
+#include "physfs/util.hpp"
 #include "supertux/level.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -107,8 +108,11 @@ ParticleEditorMenu::menu_action(MenuItem& item)
         "/particles",
         true,
         [](const std::string& new_filename) {
-          ParticleEditor::current()->open("/particles/" +
+          // realpath() is necessary for particle files outside the particles/ folder
+          std::string path = physfsutil::realpath("/particles/" +
                                         ParticleEditor::current()->m_filename);
+
+          ParticleEditor::current()->open(path);
           MenuManager::instance().clear_menu_stack();
         }
       ));

--- a/src/supertux/menu/particle_editor_open.cpp
+++ b/src/supertux/menu/particle_editor_open.cpp
@@ -20,6 +20,7 @@
 #include "gui/dialog.hpp"
 #include "gui/menu_item.hpp"
 #include "gui/menu_manager.hpp"
+#include "physfs/util.hpp"
 #include "supertux/level.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -55,11 +56,17 @@ ParticleEditorOpen::~ParticleEditorOpen()
 void
 ParticleEditorOpen::menu_action(MenuItem& item)
 {
+  std::string path;
+
   switch (item.get_id())
   {
     case MNID_OPEN:
       std::replace(m_filename.begin(), m_filename.end(), '\\', '/');
-      ParticleEditor::current()->open("/particles/" + m_filename);
+
+      // realpath() is necessary for particle files outside the particles/ folder
+      path = physfsutil::realpath("/particles/" + m_filename);
+
+      ParticleEditor::current()->open(path);
       MenuManager::instance().clear_menu_stack();
       break;
 


### PR DESCRIPTION
Relative paths make the game panic about insecure filenames when they contain '..'; when a custom particle file located outside the particles/ root folder was selected in the editor, and the object was used to 'Open in Particle Editor', the game would crash.

The best fix would've been to dodge the need for relative paths entirely, but that would prevent the settings from opening by default in the particles/ folder. This is, I believe, the second best fix.