### PR TITLE
[NO SQUASH] Enforce batching all render requests in SDL2_Renderer

### DIFF
--- a/src/video/sdl/sdl_video_system.cpp
+++ b/src/video/sdl/sdl_video_system.cpp
@@ -67,6 +67,7 @@ SDLVideoSystem::create_window()
   log_info << "Creating SDLVideoSystem" << std::endl;
 
   SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "2");
+  SDL_SetHint(SDL_HINT_RENDER_BATCHING, "1");
 
   create_sdl_window(0);
 


### PR DESCRIPTION
For all SDL2 Render requests, we (presumably) may not be batching it. This is noticed in the SDL Painter for functions like `SDLPainter::draw_texture` as well as other classes. This means that for our `RenderCopyEx` calls (technically, `SDL_RenderCopyExF`) as well as any shape functions, SDL was immediately passing each RenderCopy call to the GPU. Note: I believe this could be the case, though the documentation is somewhat unreliable in SDL's defense on it. It calls one case "efficient" and the other "compatible"...

With this PR, by settings a single SDL2 Renderer hint, this should result in a possible major performance boost!

They also mention on the docs that it is disabled by default due to some potential issues with usage of rendering, but after some pretty general testing, I did not spot any in particular. I would appreciate some testers that want to boot a build up and see if it at least draws stuff.

SDL3 mentioned in a PR that this is default now, but since we use SDL2 still, let's just pass this.