### PR TITLE
Remove `set_gamma`, `exit_screen` and `set_next_worldmap` scripting functions

### DIFF
--- a/src/squirrel/supertux_api.cpp
+++ b/src/squirrel/supertux_api.cpp
@@ -296,18 +296,6 @@ static void load_worldmap(const std::string& filename, const std::string& sector
 }
 /**
  * @scripting
- * @description Switches to a different worldmap after unloading the current one, after ""exit_screen()"" is called.
- * @param string $dirname The world directory, where the "worldmap.stwm" file is located.
- * @param string $sector Forced sector to spawn in the worldmap on. Leave empty to use last sector from savegame.
- * @param string $spawnpoint Forced spawnpoint to spawn in the worldmap on. Leave empty to use last position from savegame.
- */
-static void set_next_worldmap(const std::string& dirname, const std::string& sector, const std::string& spawnpoint)
-{
-  // TODO: remove this function
-  GameManager::current()->set_next_worldmap(dirname, sector, spawnpoint);
-}
-/**
- * @scripting
  * @description Loads and displays a level (on next screenswitch), using the savegame of the current level.
  * @param string $filename
  */
@@ -851,7 +839,6 @@ void register_supertux_scripting_api(ssq::VM& vm)
   vm.addFunc("__", &scripting::Globals::translate_plural);
   vm.addFunc("display_text_file", &scripting::Globals::display_text_file);
   vm.addFunc("load_worldmap", &scripting::Globals::load_worldmap);
-  vm.addFunc("set_next_worldmap", &scripting::Globals::set_next_worldmap);
   vm.addFunc("load_level", &scripting::Globals::load_level);
   vm.addFunc("import", &scripting::Globals::import);
   vm.addFunc("debug_collrects", &scripting::Globals::debug_collrects);

--- a/src/squirrel/supertux_api.cpp
+++ b/src/squirrel/supertux_api.cpp
@@ -303,7 +303,7 @@ static void load_worldmap(const std::string& filename, const std::string& sector
  */
 static void set_next_worldmap(const std::string& dirname, const std::string& sector, const std::string& spawnpoint)
 {
- //TODO: remove this function
+  // TODO: remove this function
   GameManager::current()->set_next_worldmap(dirname, sector, spawnpoint);
 }
 /**

--- a/src/squirrel/supertux_api.cpp
+++ b/src/squirrel/supertux_api.cpp
@@ -219,14 +219,6 @@ static SQInteger wait_for_screenswitch(HSQUIRRELVM vm)
   auto squirrelvm = ssq::VM::getMain(vm).getForeignPtr<SquirrelVirtualMachine>();
   return squirrelvm->wait_for_screenswitch(vm);
 }
-/**
- * @scripting
- * @description Exits the currently running screen (for example, force exits from worldmap or scrolling text).
- */
-static void exit_screen()
-{
-  ScreenManager::current()->pop_screen();
-}
 
 /**
  * @scripting
@@ -311,6 +303,7 @@ static void load_worldmap(const std::string& filename, const std::string& sector
  */
 static void set_next_worldmap(const std::string& dirname, const std::string& sector, const std::string& spawnpoint)
 {
+ //TODO: remove this function
   GameManager::current()->set_next_worldmap(dirname, sector, spawnpoint);
 }
 /**
@@ -594,16 +587,6 @@ static void warp(float offset_x, float offset_y)
 
 /**
  * @scripting
- * @description Adjusts the gamma.
- * @param float $gamma
- */
-static void set_gamma(float gamma)
-{
-  VideoSystem::current()->set_gamma(gamma);
-}
-
-/**
- * @scripting
  * @description Returns a random integer.
  */
 static int rand()
@@ -862,7 +845,6 @@ void register_supertux_scripting_api(ssq::VM& vm)
   vm.addFunc("check_cutscene", &scripting::Globals::check_cutscene);
   vm.addFunc("wait", &scripting::Globals::wait);
   vm.addFunc("wait_for_screenswitch", &scripting::Globals::wait_for_screenswitch);
-  vm.addFunc("exit_screen", &scripting::Globals::exit_screen);
   vm.addFunc("translate", &scripting::Globals::translate);
   vm.addFunc("_", &scripting::Globals::translate);
   vm.addFunc("translate_plural", &scripting::Globals::translate_plural);
@@ -893,7 +875,6 @@ void register_supertux_scripting_api(ssq::VM& vm)
   vm.addFunc("restart", &scripting::Globals::restart);
   vm.addFunc("gotoend", &scripting::Globals::gotoend);
   vm.addFunc("warp", &scripting::Globals::warp);
-  vm.addFunc("set_gamma", &scripting::Globals::set_gamma);
   vm.addFunc("rand", &scripting::Globals::rand);
   vm.addFunc("set_title_frame", &scripting::Globals::set_title_frame);
 

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -34,8 +34,7 @@
 #include "worldmap/worldmap.hpp"
 
 GameManager::GameManager() :
-  m_savegame(),
-  m_next_worldmap()
+  m_savegame()
 {
 }
 

--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -106,30 +106,4 @@ GameManager::start_worldmap(const World& world, const std::string& worldmap_file
   return true;
 }
 
-bool
-GameManager::load_next_worldmap()
-{
-  if (!m_next_worldmap)
-    return false;
-
-  const auto next_worldmap = std::move(*m_next_worldmap);
-  m_next_worldmap.reset();
-
-  std::unique_ptr<World> world = World::from_directory(next_worldmap.world);
-  if (!world)
-  {
-    log_warning << "Cannot load world '" << next_worldmap.world << "'" <<  std::endl;
-    return false;
-  }
-
-  return start_worldmap(*world, "", next_worldmap.sector, next_worldmap.spawnpoint); // New world, new savegame.
-}
-
-void
-GameManager::set_next_worldmap(const std::string& world, const std::string& sector,
-                               const std::string& spawnpoint)
-{
-  m_next_worldmap.emplace(world, sector, spawnpoint);
-}
-
 /* EOF */

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -20,6 +20,7 @@
 #include "util/currenton.hpp"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "math/vector.hpp"

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -19,7 +19,6 @@
 
 #include "util/currenton.hpp"
 
-#include <optional>
 #include <memory>
 #include <string>
 
@@ -40,27 +39,8 @@ public:
   void start_level(const World& world, const std::string& level_filename,
                    const std::optional<std::pair<std::string, Vector>>& start_pos = std::nullopt);
 
-  bool load_next_worldmap();
-  void set_next_worldmap(const std::string& world, const std::string& sector = "",
-                         const std::string& spawnpoint = "");
-
-private:
-  struct NextWorldMap
-  {
-    NextWorldMap(const std::string& w, const std::string& s,
-                 const std::string& sp) :
-      world(w), sector(s), spawnpoint(sp)
-    {}
-
-    const std::string world;
-    const std::string sector;
-    const std::string spawnpoint;
-  };
-
 private:
   std::unique_ptr<Savegame> m_savegame;
-
-  std::optional<NextWorldMap> m_next_worldmap;
 
 private:
   GameManager(const GameManager&) = delete;

--- a/src/video/null/null_video_system.cpp
+++ b/src/video/null/null_video_system.cpp
@@ -106,12 +106,6 @@ NullVideoSystem::get_vsync() const
 }
 
 void
-NullVideoSystem::set_gamma(float gamma)
-{
-  log_info << "VideoSystem::set_gamma(" << gamma << ")" << std::endl;
-}
-
-void
 NullVideoSystem::set_title(const std::string& title)
 {
   log_info << "VideoSystem::set_icon(\"" << title << "\")" << std::endl;

--- a/src/video/null/null_video_system.hpp
+++ b/src/video/null/null_video_system.hpp
@@ -47,7 +47,6 @@ public:
 
   virtual void set_vsync(int mode) override;
   virtual int get_vsync() const override;
-  virtual void set_gamma(float gamma) override;
   virtual void set_title(const std::string& title) override;
   virtual void set_icon(const SDL_Surface& icon) override;
   virtual SDLSurfacePtr make_screenshot() override;

--- a/src/video/sdlbase_video_system.cpp
+++ b/src/video/sdlbase_video_system.cpp
@@ -52,14 +52,6 @@ SDLBaseVideoSystem::set_title(const std::string& title)
 }
 
 void
-SDLBaseVideoSystem::set_gamma(float gamma)
-{
-  Uint16 ramp[256];
-  SDL_CalculateGammaRamp(gamma, ramp);
-  SDL_SetWindowGammaRamp(m_sdl_window.get(), ramp, ramp, ramp);
-}
-
-void
 SDLBaseVideoSystem::set_icon(const SDL_Surface& icon)
 {
   SDL_SetWindowIcon(m_sdl_window.get(), const_cast<SDL_Surface*>(&icon));

--- a/src/video/sdlbase_video_system.hpp
+++ b/src/video/sdlbase_video_system.hpp
@@ -30,7 +30,6 @@ public:
 
   virtual void set_title(const std::string& title) override;
   virtual void set_icon(const SDL_Surface& icon) override;
-  virtual void set_gamma(float gamma) override;
 
   virtual Size get_window_size() const override;
   virtual void on_resize(int w, int h) override;

--- a/src/video/video_system.hpp
+++ b/src/video/video_system.hpp
@@ -72,7 +72,6 @@ public:
 
   virtual void set_vsync(int mode) = 0;
   virtual int get_vsync() const = 0;
-  virtual void set_gamma(float gamma) = 0;
   virtual void set_title(const std::string& title) = 0;
   virtual void set_icon(const SDL_Surface& icon) = 0;
   virtual SDLSurfacePtr make_screenshot() = 0;

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -23,7 +23,6 @@
 #include "physfs/util.hpp"
 #include "supertux/constants.hpp"
 #include "supertux/fadetoblack.hpp"
-#include "supertux/game_manager.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/level.hpp"
 #include "supertux/menu/menu_storage.hpp"
@@ -123,8 +122,6 @@ WorldMap::leave()
 {
   save_state();
   m_sector->leave();
-
-  GameManager::current()->load_next_worldmap();
 }
 
 


### PR DESCRIPTION
**PR description by @Vankata453:**

`set_gamma` changes the brightness of the whole screen, which could be used inaccordingly.

`exit_screen` pops the current screen, meaning it can likely be used to make levels unplayable or the game un-openeable, if used in a title screen level.

`set_next_worldmap` (added in 65da51280c38c867708b0f32eb59748c48a27181) requires the `exit_screen` function to properly work, meaning it was also removed, thus no longer allowing switching from one world to another (when was this needed anyway?)