### PR TITLE
Debug option to hide player HUD (including `LevelTime` counter)

### DIFF
--- a/src/object/level_time.cpp
+++ b/src/object/level_time.cpp
@@ -23,6 +23,7 @@
 
 #include "editor/editor.hpp"
 #include "object/player.hpp"
+#include "supertux/debug.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/resources.hpp"
 #include "supertux/sector.hpp"
@@ -104,8 +105,9 @@ LevelTime::update(float dt_sec)
 void
 LevelTime::draw(DrawingContext& context)
 {
-  if (Editor::is_active())
+  if (g_debug.hide_player_hud || Editor::is_active())
     return;
+
   context.push_transform();
   context.set_translation(Vector(0, 0));
   context.transform().scale = 1.f;

--- a/src/supertux/debug.cpp
+++ b/src/supertux/debug.cpp
@@ -26,6 +26,7 @@ Debug::Debug() :
   show_worldmap_path(false),
   draw_redundant_frames(false),
   show_toolbox_tile_ids(false),
+  hide_player_hud(false),
   m_use_bitmap_fonts(false),
   m_game_speed_multiplier(1.0f)
 {

--- a/src/supertux/debug.hpp
+++ b/src/supertux/debug.hpp
@@ -39,7 +39,11 @@ public:
   // vaguely measure the impact of code changes which should increase the FPS
   bool draw_redundant_frames;
 
+  /** Draw tile IDs in editor toolbox */
   bool show_toolbox_tile_ids;
+
+  /** Do not draw PlayerStatusHUD and LevelTime */
+  bool hide_player_hud;
 
 private:
   /** Use old bitmap fonts instead of TTF */

--- a/src/supertux/menu/debug_menu.cpp
+++ b/src/supertux/menu/debug_menu.cpp
@@ -74,6 +74,7 @@ DebugMenu::DebugMenu() :
              []{ return g_debug.get_use_bitmap_fonts(); },
              [](bool value){ g_debug.set_use_bitmap_fonts(value); });
   add_toggle(-1, _("Show Tile IDs in Editor Toolbox"), &g_debug.show_toolbox_tile_ids);
+  add_toggle(-1, _("Hide Player HUD"), &g_debug.hide_player_hud);
   
   add_entry(_("Reload Resources"), &Resources::reload_all)
     .set_help(_("Reloads all fonts, textures, sprites and tilesets."));

--- a/src/supertux/player_status_hud.cpp
+++ b/src/supertux/player_status_hud.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "sprite/sprite_manager.hpp"
+#include "supertux/debug.hpp"
 #include "supertux/game_object.hpp"
 #include "supertux/level.hpp"
 #include "supertux/player_status.hpp"
@@ -60,7 +61,7 @@ PlayerStatusHUD::update(float dt_sec)
 void
 PlayerStatusHUD::draw(DrawingContext& context)
 {
-  if (Editor::is_active())
+  if (g_debug.hide_player_hud || Editor::is_active())
     return;
 
   if ((displayed_coins == DISPLAYED_COINS_UNSET) ||


### PR DESCRIPTION
A new debug option "Hide Player HUD" has been added. It's pretty straightforward - if enabled, `PlayerStatusHUD` and `LevelTime` are not drawn.

Useful for recording clips from the game that focus more on environment/ambience than raw gameplay.