### PR TITLE
Support X/Y position periods for autotile "alt-id"s

### DIFF
--- a/data/images/autotiles.satc
+++ b/data/images/autotiles.satc
@@ -36,7 +36,7 @@
 ;;   The alternative id : (id 123456)
 ;;   The X/Y period : (period-x 2 1) / (period-y 2 0)
 ;;     Both contain 2 unsigned integer values: first is the divider and second is
-;;     the desired remainder after dividing the X/Y position in the tile, relative
+;;     the desired remainder after dividing the X/Y position of the tile, relative
 ;;     to its tilemap.
 ;;   The weight : (weight 0.2)
 ;;     The weight is the odds of this tile to happen. 0 is never, 1 is always.

--- a/data/images/autotiles.satc
+++ b/data/images/autotiles.satc
@@ -34,12 +34,18 @@
 ;;  V
 ;; Contains :
 ;;   The alternative id : (id 123456)
+;;   The X/Y period : (period-x 2 1) / (period-y 2 0)
+;;     Both contain 2 unsigned integer values: first is the divider and second is
+;;     the desired remainder after dividing the X/Y position in the tile, relative
+;;     to its tilemap.
 ;;   The weight : (weight 0.2)
 ;;     The weight is the odds of this tile to happen. 0 is never, 1 is always.
 ;;     The autotile's default ID's odds of occuring are (1 - sum of all weights).
 ;;     Ideally, the sum of all weights for an autotile should be below 1. If it
 ;;     is 1, the the regular ID for that autotile will never occur. If it is
 ;;     greater than 1, then certains alt ID's might never occur either.
+;;
+;;   NOTE: For an "alt-id" to be chosen, all of its conditions ("period", random "weight") must be met.
 ;;
 ;; ===== MASK INFO =====
 ;;
@@ -6344,7 +6350,6 @@
       (solid #t)
       (mask "*0****0*")
     )
-  
   )
   
   (autotileset
@@ -6356,7 +6361,13 @@
       (id 4566)
       (alt-id
         (id 4565)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4565)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111111")
@@ -6368,8 +6379,6 @@
       
       (mask "01011*0*")
       (mask "*0*11010")
-      
-      
     )
     
     ;; LEFT
@@ -6377,7 +6386,13 @@
       (id 4564)
       (alt-id
         (id 4557)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4557)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "*1101*11")
@@ -6394,7 +6409,13 @@
       (id 4567)
       (alt-id
         (id 4558)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4558)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11*1011*")
@@ -6420,7 +6441,6 @@
       (solid #t)
       (mask "*0*01*11")
       (mask "01001*11")
-      
     )
     
     ;; TOP CENTER
@@ -6428,7 +6448,13 @@
       (id 4569)
       (alt-id
         (id 4555)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4555)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (alt-id
         (id 4554)
@@ -6473,15 +6499,13 @@
       (id 4580)
       (alt-id
         (id 4577)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
       )
       (alt-id
-        (id 4579)
-        (weight -1)
-      )
-      (alt-id
-        (id 4576)
-        (weight -1)
+        (id 4577)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111*0*")
@@ -6509,7 +6533,13 @@
       (id 4592)
       (alt-id
         (id 4570)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4570)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111110")
@@ -6534,7 +6564,13 @@
       (id 4593)
       (alt-id
         (id 4571)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4571)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111011")
@@ -6559,7 +6595,13 @@
       (id 4581)
       (alt-id
         (id 4559)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4559)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11011111")
@@ -6584,7 +6626,13 @@
       (id 4582)
       (alt-id
         (id 4560)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4560)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "01111111")
@@ -6739,7 +6787,13 @@
       (id 4480)
       (alt-id
         (id 4479)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4479)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111111")
@@ -6760,7 +6814,13 @@
       (id 4478)
       (alt-id
         (id 4467)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4467)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "*1101*11")
@@ -6777,7 +6837,13 @@
       (id 4481)
       (alt-id
         (id 4468)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4468)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11*1011*")
@@ -6811,15 +6877,13 @@
       (id 4483)
       (alt-id
         (id 4465)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
       )
       (alt-id
-        (id 4482)
-        (weight -1)
-      )
-      (alt-id
-        (id 4464)
-        (weight -1)
+        (id 4465)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "*0*11111")
@@ -6856,7 +6920,13 @@
       (id 4498)
       (alt-id
         (id 4495)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4495)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (alt-id
         (id 4497)
@@ -6892,7 +6962,13 @@
       (id 4514)
       (alt-id
         (id 4484)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4484)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111110")
@@ -6917,7 +6993,13 @@
       (id 4515)
       (alt-id
         (id 4485)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4485)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11111011")
@@ -6942,7 +7024,13 @@
       (id 4499)
       (alt-id
         (id 4469)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4469)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "11011111")
@@ -6967,7 +7055,13 @@
       (id 4500)
       (alt-id
         (id 4470)
-        (weight -1)
+        (period-x 2 0)
+        (period-y 2 0)
+      )
+      (alt-id
+        (id 4470)
+        (period-x 2 1)
+        (period-y 2 1)
       )
       (solid #t)
       (mask "01111111")

--- a/src/supertux/autotile.cpp
+++ b/src/supertux/autotile.cpp
@@ -78,12 +78,12 @@ Autotile::pick_tile(int x, int y) const
   for (const auto& pair : m_alt_tiles)
   {
     const AltConditions& cond = pair.second;
-    if (cond.weight <= 0.f && !cond.period_x.first && !cond.period_y.first)
+    if (cond.weight <= 0.f && cond.period_x.first == 0 && cond.period_y.first == 0)
       continue;
 
-    if (cond.period_x.first && x % cond.period_x.first != cond.period_x.second)
+    if (cond.period_x.first != 0 && x % cond.period_x.first != cond.period_x.second)
       continue;
-    if (cond.period_y.first && y % cond.period_y.first != cond.period_y.second)
+    if (cond.period_y.first != 0 && y % cond.period_y.first != cond.period_y.second)
       continue;
     if (cond.weight > 0.f)
     {

--- a/src/supertux/autotile.cpp
+++ b/src/supertux/autotile.cpp
@@ -36,7 +36,7 @@ AutotileMask::matches(uint8_t mask, bool center) const
 
 // Autotile.
 
-Autotile::Autotile(uint32_t tile_id, const std::vector<std::pair<uint32_t, AltCondition>>& alt_tiles, const std::vector<AutotileMask>& masks, bool solid) :
+Autotile::Autotile(uint32_t tile_id, const std::vector<std::pair<uint32_t, AltConditions>>& alt_tiles, const std::vector<AutotileMask>& masks, bool solid) :
   m_tile_id(tile_id),
   m_alt_tiles(alt_tiles),
   m_masks(std::move(masks)),
@@ -77,7 +77,7 @@ Autotile::pick_tile(int x, int y) const
 
   for (const auto& pair : m_alt_tiles)
   {
-    const AltCondition& cond = pair.second;
+    const AltConditions& cond = pair.second;
     if (!cond.period_x.first && !cond.period_y.first && cond.weight <= 0.f)
       continue;
 

--- a/src/supertux/autotile.cpp
+++ b/src/supertux/autotile.cpp
@@ -78,7 +78,7 @@ Autotile::pick_tile(int x, int y) const
   for (const auto& pair : m_alt_tiles)
   {
     const AltConditions& cond = pair.second;
-    if (!cond.period_x.first && !cond.period_y.first && cond.weight <= 0.f)
+    if (cond.weight <= 0.f && !cond.period_x.first && !cond.period_y.first)
       continue;
 
     if (cond.period_x.first && x % cond.period_x.first != cond.period_x.second)

--- a/src/supertux/autotile.hpp
+++ b/src/supertux/autotile.hpp
@@ -40,7 +40,7 @@ private:
 class Autotile final
 {
 public:
-  struct AltCondition final
+  struct AltConditions final
   {
     std::pair<uint32_t, uint32_t> period_x;
     std::pair<uint32_t, uint32_t> period_y;
@@ -49,7 +49,7 @@ public:
 
 public:
   Autotile(uint32_t tile_id,
-    const std::vector<std::pair<uint32_t, AltCondition>>& alt_tiles,
+    const std::vector<std::pair<uint32_t, AltConditions>>& alt_tiles,
     const std::vector<AutotileMask>& masks,
     bool solid);
 
@@ -68,14 +68,14 @@ public:
   uint8_t get_first_mask() const;
 
   /** Returns all possible tiles for this autotile */
-  inline const std::vector<std::pair<uint32_t, AltCondition>>& get_all_tile_ids() const { return m_alt_tiles; }
+  inline const std::vector<std::pair<uint32_t, AltConditions>>& get_all_tile_ids() const { return m_alt_tiles; }
 
   /** Returns true if the "center" bool of masks are true. All masks of given Autotile must have the same value for their "center" property.*/
   inline bool is_solid() const { return m_solid; }
 
 private:
   uint32_t m_tile_id;
-  std::vector<std::pair<uint32_t, AltCondition>> m_alt_tiles;
+  std::vector<std::pair<uint32_t, AltConditions>> m_alt_tiles;
   std::vector<AutotileMask> m_masks;
   bool m_solid;
 

--- a/src/supertux/autotile.hpp
+++ b/src/supertux/autotile.hpp
@@ -40,8 +40,16 @@ private:
 class Autotile final
 {
 public:
+  struct AltCondition final
+  {
+    std::pair<uint32_t, uint32_t> period_x;
+    std::pair<uint32_t, uint32_t> period_y;
+    float weight;
+  };
+
+public:
   Autotile(uint32_t tile_id,
-    const std::vector<std::pair<uint32_t, float>>& alt_tiles,
+    const std::vector<std::pair<uint32_t, AltCondition>>& alt_tiles,
     const std::vector<AutotileMask>& masks,
     bool solid);
 
@@ -60,14 +68,14 @@ public:
   uint8_t get_first_mask() const;
 
   /** Returns all possible tiles for this autotile */
-  inline const std::vector<std::pair<uint32_t, float>>& get_all_tile_ids() const { return m_alt_tiles; }
+  inline const std::vector<std::pair<uint32_t, AltCondition>>& get_all_tile_ids() const { return m_alt_tiles; }
 
   /** Returns true if the "center" bool of masks are true. All masks of given Autotile must have the same value for their "center" property.*/
   inline bool is_solid() const { return m_solid; }
 
 private:
   uint32_t m_tile_id;
-  std::vector<std::pair<uint32_t, float>> m_alt_tiles;
+  std::vector<std::pair<uint32_t, AltCondition>> m_alt_tiles;
   std::vector<AutotileMask> m_masks;
   bool m_solid;
 

--- a/src/supertux/autotile_parser.cpp
+++ b/src/supertux/autotile_parser.cpp
@@ -138,7 +138,7 @@ Autotile*
 AutotileParser::parse_autotile(const ReaderMapping& reader, bool corner)
 {
   std::vector<AutotileMask> autotile_masks;
-  std::vector<std::pair<uint32_t, float>> alt_ids;
+  std::vector<std::pair<uint32_t, Autotile::AltCondition>> alt_ids;
 
   uint32_t tile_id;
   if (!reader.get("id", tile_id))
@@ -196,17 +196,27 @@ AutotileParser::parse_autotile(const ReaderMapping& reader, bool corner)
 
       alt_id += m_offset;
 
-      float weight = 0.0f;
-      if (!alt_reader.get("weight", weight))
+      if (!alt_id)
+        continue;
+
+      std::vector<uint32_t> period_x = { 0, 0 };
+      std::vector<uint32_t> period_y = { 0, 0 };
+      float weight = 0.f;
+      alt_reader.get("period-x", period_x);
+      alt_reader.get("period-y", period_y);
+      alt_reader.get("weight", weight);
+
+      if (period_x.size() != 2 || period_y.size() != 2)
       {
-        log_warning << "No weight for alt tile id" << std::endl;
+        log_warning << "X/Y period for alt tile must contain exactly 2 values" << std::endl;
         continue;
       }
 
-      if (alt_id != 0 && weight != 0.0f)
-      {
-        alt_ids.push_back(std::pair<uint32_t, float>(alt_id, weight));
-      }
+      alt_ids.push_back(std::pair<uint32_t, Autotile::AltCondition>(alt_id, {
+          { period_x[0], period_x[1] },
+          { period_y[0], period_y[1] },
+          weight
+        }));
     }
     else if (iter.get_key() != "id" && iter.get_key() != "solid")
     {

--- a/src/supertux/autotile_parser.cpp
+++ b/src/supertux/autotile_parser.cpp
@@ -138,7 +138,7 @@ Autotile*
 AutotileParser::parse_autotile(const ReaderMapping& reader, bool corner)
 {
   std::vector<AutotileMask> autotile_masks;
-  std::vector<std::pair<uint32_t, Autotile::AltCondition>> alt_ids;
+  std::vector<std::pair<uint32_t, Autotile::AltConditions>> alt_ids;
 
   uint32_t tile_id;
   if (!reader.get("id", tile_id))
@@ -212,7 +212,7 @@ AutotileParser::parse_autotile(const ReaderMapping& reader, bool corner)
         continue;
       }
 
-      alt_ids.push_back(std::pair<uint32_t, Autotile::AltCondition>(alt_id, {
+      alt_ids.push_back(std::pair<uint32_t, Autotile::AltConditions>(alt_id, {
           { period_x[0], period_x[1] },
           { period_y[0], period_y[1] },
           weight


### PR DESCRIPTION
Autotile "alt-id"s now support the "period-x" and "period-y" properties, which contain 2 unsigned integer values: first is the divider and second is the desired remainder after dividing the X/Y position of the tile, relative to its tilemap. If the desired remainder is matched, the condition is passed.

NOTE: For an "alt-id" to be chosen, all of its conditions ("period", random "weight") must be met.

This PR takes advantage of these new position periods to achieve proper castle autotiling with line tiles.