### PR TITLE
PulsingLight: Move and change colour together with tilemap

### DIFF
--- a/src/object/pulsing_light.cpp
+++ b/src/object/pulsing_light.cpp
@@ -17,7 +17,7 @@
 #include "object/pulsing_light.hpp"
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 #include "object/tilemap.hpp"
 #include "math/random.hpp"
@@ -55,7 +55,7 @@ PulsingLight::update(float dt_sec)
 void
 PulsingLight::draw(DrawingContext& context)
 { 
-  const float alpha = min_alpha + ((max_alpha - min_alpha) * cosf(math::TAU * t / cycle_len));
+  const float alpha = min_alpha + ((max_alpha - min_alpha) * std::cos(math::TAU * t / cycle_len));
   if (parent_tilemap) {
     position = rel_position + parent_tilemap->get_offset();
     color = (rel_color * parent_tilemap->get_current_tint()).validate();

--- a/src/object/pulsing_light.cpp
+++ b/src/object/pulsing_light.cpp
@@ -19,14 +19,18 @@
 #include <assert.h>
 #include <math.h>
 
+#include "object/tilemap.hpp"
 #include "math/random.hpp"
 #include "math/util.hpp"
 
-PulsingLight::PulsingLight(const Vector& center, float cycle_len_, float min_alpha_, float max_alpha_, const Color& color_) :
+PulsingLight::PulsingLight(const Vector& center, float cycle_len_, float min_alpha_, float max_alpha_, const Color& color_, const TileMap* parent_tilemap_) :
   Light(center, color_),
   min_alpha(min_alpha_),
   max_alpha(max_alpha_),
   cycle_len(cycle_len_),
+  parent_tilemap(parent_tilemap_),
+  rel_position(center),
+  rel_color(color_),
   t(0)
 {
   assert(cycle_len > 0);
@@ -50,13 +54,17 @@ PulsingLight::update(float dt_sec)
 
 void
 PulsingLight::draw(DrawingContext& context)
-{
-  Color old_color = color;
-
-  color.alpha *= min_alpha + ((max_alpha - min_alpha) * cosf(math::TAU * t / cycle_len));
+{ 
+  const float alpha = min_alpha + ((max_alpha - min_alpha) * cosf(math::TAU * t / cycle_len));
+  if (parent_tilemap) {
+    position = rel_position + parent_tilemap->get_offset();
+    color = (rel_color * parent_tilemap->get_current_tint()).validate();
+    color.alpha *= alpha * parent_tilemap->get_alpha();
+  } else {
+    color.alpha = rel_color.alpha * alpha;
+  }
+  
   Light::draw(context);
-
-  color = old_color;
 }
 
 /* EOF */

--- a/src/object/pulsing_light.hpp
+++ b/src/object/pulsing_light.hpp
@@ -19,13 +19,15 @@
 
 #include "object/light.hpp"
 
+class TileMap;
+
 /**
  * Light source that changes alpha value to give the impression of a pulsating light
  */
 class PulsingLight final : public Light
 {
 public:
-  PulsingLight(const Vector& center, float cycle_len = 5.0, float min_alpha = 0.0, float max_alpha = 1.0, const Color& color = Color(1.0, 1.0, 1.0, 1.0));
+  PulsingLight(const Vector& center, float cycle_len = 5.0, float min_alpha = 0.0, float max_alpha = 1.0, const Color& color = Color(1.0, 1.0, 1.0, 1.0), const TileMap* parent_tilemap = nullptr);
   ~PulsingLight() override;
   virtual GameObjectClasses get_class_types() const override { return Light::get_class_types().add(typeid(PulsingLight)); }
 
@@ -36,6 +38,9 @@ protected:
   float min_alpha; /**< minimum alpha */
   float max_alpha; /**< maximum alpha */
   float cycle_len; /**< length in seconds of one cycle */
+  const TileMap* parent_tilemap; /**< A reference to Tilemap for which the PulsingLight was made for. optional */
+  Vector rel_position; /**< relative position w.r.t. tilemap */
+  Color rel_color; /**< relative color w.r.t. tilemap */
 
   float t; /**< local time in seconds */
 };

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -833,7 +833,7 @@ Sector::convert_tiles2gameobject()
         {
           // add lights for fire tiles
           uint32_t attributes = tile.get_attributes();
-          Vector pos = tm.get_tile_position(x, y) + tm_offset;
+          Vector pos = tm.get_tile_position(x, y);
           Vector center = pos + Vector(16, 16);
 
           if (attributes & Tile::FIRE) {
@@ -844,13 +844,13 @@ Sector::convert_tiles2gameobject()
                   && (tm.get_tile(x, y-1).get_attributes() != attributes || y%3 == 0)) {
                 float pseudo_rnd = static_cast<float>(static_cast<int>(pos.x) % 10) / 10;
                 add<PulsingLight>(center, 1.0f + pseudo_rnd, 0.8f, 1.0f,
-                                  (Color(1.0f, 0.3f, 0.0f, 1.0f) * tm.get_current_tint()).validate());
+                                  Color(1.0f, 0.3f, 0.0f, 1.0f), &tm);
               }
             } else {
               // torch
               float pseudo_rnd = static_cast<float>(static_cast<int>(pos.x) % 10) / 10;
               add<PulsingLight>(center, 1.0f + pseudo_rnd, 0.9f, 1.0f,
-                                (Color(1.0f, 1.0f, 0.6f, 1.0f) * tm.get_current_tint()).validate());
+                                Color(1.0f, 1.0f, 0.6f, 1.0f), &tm);
             }
           }
         }


### PR DESCRIPTION
When a tilemap has lava or torches, they create PulsingLight objects. However, these objects are stuck at the original state of the tilemaps and never update throughout the gameplay. This pull request fixes this behaviour.

Testing level:
[level2.zip](https://github.com/user-attachments/files/18311168/level2.zip)
