### PR TITLE
Use unordered_map instead of ordered_map

### DIFF
--- a/src/sprite/sprite_manager.hpp
+++ b/src/sprite/sprite_manager.hpp
@@ -20,7 +20,7 @@
 
 #include "util/currenton.hpp"
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 
@@ -31,7 +31,7 @@ class SpriteData;
 class SpriteManager final : public Currenton<SpriteManager>
 {
 private:
-  typedef std::map<std::string, std::unique_ptr<SpriteData>> Sprites;
+  typedef std::unordered_map<std::string, std::unique_ptr<SpriteData>> Sprites;
   Sprites m_sprites;
 
 public:

--- a/src/supertux/object_factory.hpp
+++ b/src/supertux/object_factory.hpp
@@ -19,7 +19,7 @@
 #define HEADER_SUPERTUX_SUPERTUX_OBJECT_FACTORY_HPP
 
 #include <assert.h>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <functional>
 #include <vector>
@@ -37,7 +37,7 @@ private:
     std::function<std::unique_ptr<GameObject> (const ReaderMapping&)> create = nullptr;
     std::function<std::string ()> get_display_name = nullptr;
   };
-  typedef std::map<std::string, FactoryFunctions> Factories;
+  typedef std::unordered_map<std::string, FactoryFunctions> Factories;
 
   Factories factories;
   std::vector<std::string> m_badguys_names;

--- a/src/video/texture_manager.hpp
+++ b/src/video/texture_manager.hpp
@@ -18,6 +18,7 @@
 #define HEADER_SUPERTUX_VIDEO_TEXTURE_MANAGER_HPP
 
 #include <config.h>
+#include <unordered_map>
 #include <map>
 #include <memory>
 #include <ostream>
@@ -77,7 +78,7 @@ private:
 
 private:
   std::map<Texture::Key, std::weak_ptr<Texture>> m_image_textures;
-  std::map<std::string, SDLSurfacePtr> m_surfaces;
+  std::unordered_map<std::string, SDLSurfacePtr> m_surfaces;
   bool m_load_successful;
 
 private:


### PR DESCRIPTION
unordered_map is preferred over map for accessing particular elements such as we do in those instances. See https://en.cppreference.com/w/cpp/container/unordered_map