### PR TITLE
Add default arguments to add_object function call

### DIFF
--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -808,7 +808,8 @@ GameObjectManager::register_class(ssq::VM& vm)
   cls.addFunc("get_ambient_blue", &GameObjectManager::get_ambient_blue);
   cls.addFunc("set_music", &GameObjectManager::set_music);
   cls.addFunc<void, GameObjectManager, const std::string&, const std::string&,
-              float, float, const std::string&, const std::string&>("add_object", &GameObjectManager::add_object);
+              float, float, const std::string&, const std::string&>("add_object",
+                &GameObjectManager::add_object, ssq::DefaultArguments<const std::string&, const std::string&>("auto", ""));
 }
 
 /* EOF */


### PR DESCRIPTION
This adds a few default arguments to the add_object function call. Direction will default to `auto` and additional data will default to empty string.

Unfortunately, the name parameter can't be omitted because it's before a non-optional parameter (location).