### PR TITLE
Move frame prediction logic for camera from Sector to Camera

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -529,8 +529,6 @@ Editor::update(float dt_sec, const Controller& controller)
     m_new_scale = 0.f;
   }
 
-  m_sector->pause_camera_interpolation();
-
   camera.update(dt_sec);
 }
 

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -20,6 +20,7 @@
 #include "editor/layer_object.hpp"
 
 #include <string>
+#include <utility>
 
 #include "math/anchor_point.hpp"
 #include "math/size.hpp"
@@ -86,9 +87,14 @@ public:
   /** reset camera position */
   void reset(const Vector& tuxpos);
 
+  /** Get the predicted translation and scale of the camera, time_offset seconds from now. */
+  std::pair<Vector, float> get_predicted_transform(float time_offset) const;
+
   /** return camera position */
   const Vector get_translation() const;
-  inline void set_translation(const Vector& translation) { m_translation = translation; }
+  inline void set_translation(const Vector& translation) {
+    m_translation = translation; reset_prediction_state();
+  }
   void set_translation_centered(const Vector& translation);
 
   void keep_in_bounds(const Rectf& bounds);
@@ -270,6 +276,10 @@ private:
   Vector get_scale_anchor_target() const;
   void reload_scale();
 
+  /** This function should be called whenever the last updates/changes
+   * to the camera should not be interpolated or extrapolated. */
+  void reset_prediction_state();
+
 private:
   Mode m_mode;
   Mode m_defaultmode;
@@ -317,6 +327,13 @@ private:
   float m_minimum_scale;
   bool m_enfore_minimum_scale;
 
+  // Remember last camera position, to linearly interpolate camera position
+  // when drawing frames that are predicted forward a fraction of a game step.
+  // This is somewhat of a hack: ideally these variables would not be necessary
+  // and one could predict the next camera scale/translation directly from the
+  // current camera member variable values.
+  Vector m_last_translation;
+  float m_last_scale;
 private:
   Camera(const Camera&) = delete;
   Camera& operator=(const Camera&) = delete;

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -292,9 +292,6 @@ Sector::activate(const Vector& player_pos)
     if (m_init_script_run_once)
       m_init_script_run = true;
   }
-
-  // Do not interpolate camera after it has been warped
-  pause_camera_interpolation();
 }
 
 void
@@ -365,12 +362,6 @@ Sector::update(float dt_sec)
   assert(m_initialized);
 
   BIND_SECTOR(*this);
-
-  // Record last camera parameters, to allow for camera interpolation
-  Camera& camera = get_camera();
-  m_last_scale = camera.get_current_scale();
-  m_last_translation = camera.get_translation();
-  m_last_dt = dt_sec;
 
   m_squirrel_environment->update(dt_sec);
 
@@ -488,21 +479,9 @@ Sector::draw(DrawingContext& context)
   context.push_transform();
 
   Camera& camera = get_camera();
-
-  if (g_config->frame_prediction && m_last_dt > 0.f) {
-    // Interpolate between two camera settings; there are many possible ways to do this, but on
-    // short time scales all look about the same. This delays the camera position by one frame.
-    // (The proper thing to do, of course, would be not to interpolate, but instead to adjust
-    // the Camera class to extrapolate, and provide scale/translation at a given time; done
-    // right, this would make it possible to, for example, exactly sinusoidally shake the
-    // camera instead of piecewise linearly.)
-    float x = std::min(1.f, context.get_time_offset() / m_last_dt);
-    context.set_translation(camera.get_translation() * x + (1 - x) * m_last_translation);
-    context.scale(camera.get_current_scale() * x + (1 - x) * m_last_scale);
-  } else {
-    context.set_translation(camera.get_translation());
-    context.scale(camera.get_current_scale());
-  }
+  std::pair<Vector, float> transform = camera.get_predicted_transform(context.get_time_offset());
+  context.set_translation(transform.first);
+  context.scale(transform.second);
 
   GameObjectManager::draw(context);
 
@@ -746,12 +725,6 @@ Sector::stop_looping_sounds()
   for (auto& object : get_objects()) {
     object->stop_looping_sounds();
   }
-}
-
-void
-Sector::pause_camera_interpolation()
-{
-  m_last_dt = 0.;
 }
 
 void Sector::play_looping_sounds()

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -100,9 +100,6 @@ public:
   /** stops all looping sounds in whole sector. */
   void stop_looping_sounds();
 
-  /** Freeze camera position for this frame, preventing camera interpolation jumps and loops */
-  void pause_camera_interpolation();
-
   /** continues the looping sounds in whole sector. */
   void play_looping_sounds();
 
@@ -265,9 +262,6 @@ private:
 
   TextObject& m_text_object;
 
-  Vector m_last_translation; // For camera interpolation at high frame rates
-  float m_last_scale;
-  float m_last_dt;
   bool m_init_script_run;
   bool m_init_script_run_once;
 


### PR DESCRIPTION
This commit avoids interpolating the camera position when a Camera::move or other discontinuous transition is requested.

Note: jumps in the camera position that are purely driven by changes to Tux's position will continue to be interpolated. (For example, when `Tux.set_pos()` is called in `bonus1/mario.stl`.)