### PR TITLE
Update camera's screen size on update() instead of previous draw()

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -173,8 +173,6 @@ Editor::draw(Compositor& compositor)
           camera.move((m_mouse_pos - Vector(static_cast<float>(SCREEN_WIDTH - 128),
                                             static_cast<float>(SCREEN_HEIGHT - 32)) / 2.f) / CAMERA_ZOOM_FOCUS_PROGRESSION);
 
-        // Update the camera's screen size variable, so it can properly be kept in sector bounds.
-        camera.draw(context);
         keep_camera_in_bounds();
       }
       m_new_scale = 0.f;

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -348,15 +348,17 @@ Camera::update(float dt_sec)
 void
 Camera::keep_in_bounds(const Rectf& bounds)
 {
+  Sizef screen_size = Sizef(static_cast<float>(SCREEN_WIDTH), static_cast<float>(SCREEN_HEIGHT)) / get_current_scale();
+
   // Determines the difference between normal and scaled translation.
-  const Vector scale_factor = (m_screen_size.as_vector() * (get_current_scale() - 1.f)) / 2.f;
+  const Vector scale_factor = (screen_size.as_vector() * (get_current_scale() - 1.f)) / 2.f;
 
   // Keep the translation's scaled position in provided bounds.
-  m_translation.x = (bounds.get_width() > m_screen_size.width ?
-      math::clamp(m_translation.x + scale_factor.x, bounds.get_left(), bounds.get_right() - m_screen_size.width) :
+  m_translation.x = (bounds.get_width() > screen_size.width ?
+      math::clamp(m_translation.x + scale_factor.x, bounds.get_left(), bounds.get_right() - screen_size.width) :
       bounds.get_left());
-  m_translation.y = (bounds.get_height() > m_screen_size.height ?
-      math::clamp(m_translation.y + scale_factor.y, bounds.get_top(), bounds.get_bottom() - m_screen_size.height) :
+  m_translation.y = (bounds.get_height() > screen_size.height ?
+      math::clamp(m_translation.y + scale_factor.y, bounds.get_top(), bounds.get_bottom() - screen_size.height) :
       bounds.get_top());
 
   // Remove any scale factor we may have added in the checks above.

--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -299,20 +299,14 @@ Camera::scroll_to(const Vector& goal, float scrolltime)
 }
 
 void
-Camera::draw(DrawingContext& context)
-{
-  context.push_transform();
-  context.transform().scale = get_current_scale();
-
-  m_screen_size = Sizef(context.get_width(),
-                        context.get_height());
-
-  context.pop_transform();
-}
-
-void
 Camera::update(float dt_sec)
 {
+  // Fetch the current screen size from the VideoSystem. The main loop always
+  // processes input and window events, updates game logic, and then draws zero
+  // or more frames, in that order, so this screen size will be used by the next
+  // draw() operation.
+  m_screen_size = Sizef(static_cast<float>(SCREEN_WIDTH), static_cast<float>(SCREEN_HEIGHT)) / get_current_scale();
+
   // Minimum scale should be set during the update sequence; else, reset it.
   m_enfore_minimum_scale = false;
 

--- a/src/object/camera.hpp
+++ b/src/object/camera.hpp
@@ -58,7 +58,7 @@ public:
   /** \addtogroup GameObject
       @{ */
   virtual void update(float dt_sec) override;
-  virtual void draw(DrawingContext& ) override;
+  virtual void draw(DrawingContext& ) override {}
 
   virtual bool is_singleton() const override { return true; }
   virtual bool is_saveable() const override;


### PR DESCRIPTION
These changes ensure the screen size used in Camera::update() will match that used by the next ::draw(), instead of sometimes being one frame behind when the SuperTux window is resized. They also may ensure that when the scale is being changed over time, the scale-divided screen size observed by Squirrel will update more frequently. By reducing the number of public functions which can modify the Camera state, they should make Camera very slightly easier to refactor.