### PR TITLE
Fix crash when removing tilemap in level editor

### DIFF
--- a/src/editor/object_menu.cpp
+++ b/src/editor/object_menu.cpp
@@ -108,8 +108,8 @@ ObjectMenu::menu_action(MenuItem& item)
     case MNID_REMOVE:
       m_editor.delete_markers();
       m_editor.m_reactivate_request = true;
-      MenuManager::instance().pop_menu();
       m_object->remove_me();
+      MenuManager::instance().pop_menu();
       break;
 
     case MNID_REMOVEFUNCTION:


### PR DESCRIPTION
As pop_menu() in MenuManager frees the ObjectMenu which actually invoked the pop_menu(), m_object and all other members are not valid anymore. Therefore, pop_menu() needs to be the last thing to call in the menu_action.

Fixes #3117