### PR TITLE
WIP: Determine object type from sprite filename if sprite not found

### DIFF
--- a/src/badguy/bouncing_snowball.cpp
+++ b/src/badguy/bouncing_snowball.cpp
@@ -99,6 +99,18 @@ BouncingSnowball::get_types() const
   };
 }
 
+bool 
+BouncingSnowball::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if(sprite_name.find("images/creatures/fatbat/fatbat.sprite") != std::string::npos)
+  {
+    type = "fatbat";
+    return true;
+  }
+
+  return false;
+}
+
 std::string
 BouncingSnowball::get_default_sprite_name() const
 {

--- a/src/badguy/bouncing_snowball.hpp
+++ b/src/badguy/bouncing_snowball.hpp
@@ -42,6 +42,7 @@ public:
   virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(BouncingSnowball)); }
 
   virtual GameObjectTypes get_types() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   virtual std::string get_default_sprite_name() const override;
 
   virtual void after_editor_set() override;

--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -81,6 +81,24 @@ Crusher::get_types() const
   };
 }
 
+bool
+Crusher::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("krosh") != std::string::npos)
+  {
+    type = "ice-krosh";
+    return true;
+  }
+  if ((sprite_name.find("rock_crusher") != std::string::npos) ||
+      (sprite_name.find("moss_crusher") != std::string::npos))
+  {
+    type = "rock-crush";
+    return true;
+  }
+
+  return false;
+}
+
 std::string
 Crusher::get_default_sprite_name() const
 {

--- a/src/badguy/crusher.hpp
+++ b/src/badguy/crusher.hpp
@@ -74,6 +74,7 @@ public:
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   std::string get_default_sprite_name() const override;
 
   virtual void on_flip(float height) override;

--- a/src/badguy/darttrap.cpp
+++ b/src/badguy/darttrap.cpp
@@ -172,6 +172,18 @@ DartTrap::get_types() const
   };
 }
 
+bool
+DartTrap::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("darttrap.sprite") != std::string::npos)
+  {
+    type = "skull";
+    return true;
+  }
+
+  return false;
+}
+
 std::string
 DartTrap::get_default_sprite_name() const
 {

--- a/src/badguy/darttrap.hpp
+++ b/src/badguy/darttrap.hpp
@@ -38,6 +38,7 @@ public:
 
   virtual ObjectSettings get_settings() override;
   virtual GameObjectTypes get_types() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   virtual std::string get_default_sprite_name() const override;
   virtual void kill_fall() override;
 

--- a/src/badguy/flame.cpp
+++ b/src/badguy/flame.cpp
@@ -101,6 +101,24 @@ Flame::get_default_sprite_name() const
   }
 }
 
+bool
+Flame::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name == "images/creatures/flame/ghostflame.sprite")
+  {
+    type = "ghost";
+    return true;
+  }
+
+  if (sprite_name == "images/creatures/flame/iceflame.sprite")
+  {
+    type = "ice";
+    return true;
+  }
+
+  return false;
+}
+
 ObjectSettings
 Flame::get_settings()
 {

--- a/src/badguy/flame.hpp
+++ b/src/badguy/flame.hpp
@@ -47,6 +47,7 @@ public:
   static std::string display_name() { return _("Flame"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(Flame)); }
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
   virtual void stop_looping_sounds() override;
   virtual void play_looping_sounds() override;

--- a/src/badguy/jumpy.cpp
+++ b/src/badguy/jumpy.cpp
@@ -67,6 +67,18 @@ Jumpy::get_default_sprite_name() const
   }
 }
 
+bool
+Jumpy::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("wooden.sprite") != std::string::npos)
+  {
+    type = "wooden";
+    return true;
+  }
+
+  return false;
+}
+
 void
 Jumpy::collision_solid(const CollisionHit& chit)
 {

--- a/src/badguy/jumpy.hpp
+++ b/src/badguy/jumpy.hpp
@@ -43,6 +43,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
 protected:
   virtual std::vector<Direction> get_allowed_directions() const override;

--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -78,6 +78,18 @@ MrIceBlock::get_default_sprite_name() const
 }
 
 bool
+MrIceBlock::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name == "images/creatures/laptop/laptop.sprite")
+  {
+    type = "laptop";
+    return true;
+  }
+
+  return false;
+}
+
+bool
 MrIceBlock::is_freezable() const
 {
   return m_type == LAPTOP;

--- a/src/badguy/mriceblock.hpp
+++ b/src/badguy/mriceblock.hpp
@@ -55,6 +55,7 @@ public:
 
   virtual GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
   bool can_break();
 

--- a/src/badguy/smartball.cpp
+++ b/src/badguy/smartball.cpp
@@ -49,6 +49,18 @@ SmartBall::get_default_sprite_name() const
 }
 
 bool
+SmartBall::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("kirby.sprite") != std::string::npos)
+  {
+    type = "pumpkin";
+    return true;
+  }
+
+  return false;
+}
+
+bool
 SmartBall::is_freezable() const
 {
   return m_type == PUMPKIN;

--- a/src/badguy/smartball.hpp
+++ b/src/badguy/smartball.hpp
@@ -38,6 +38,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
 protected:
   virtual bool collision_squished(MovingObject& object) override;

--- a/src/badguy/snowball.cpp
+++ b/src/badguy/snowball.cpp
@@ -58,6 +58,24 @@ SnowBall::get_default_sprite_name() const
 }
 
 bool
+SnowBall::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("kirby.sprite") != std::string::npos)
+  {
+    type = "bumpkin";
+    return true;
+  }
+
+  if (sprite_name.find("bsod.sprite") != std::string::npos)
+  {
+    type = "bsod";
+    return true;
+  }
+
+  return false;
+}
+
+bool
 SnowBall::is_freezable() const
 {
   return m_type == BUMPKIN || m_type == BSOD;

--- a/src/badguy/snowball.hpp
+++ b/src/badguy/snowball.hpp
@@ -36,6 +36,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
 protected:
   virtual bool collision_squished(MovingObject& object) override;

--- a/src/badguy/stalactite.cpp
+++ b/src/badguy/stalactite.cpp
@@ -176,6 +176,18 @@ Stalactite::get_default_sprite_name() const
   }
 }
 
+bool
+Stalactite::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("forest_stalactite") != std::string::npos)
+  {
+    type = "rock";
+    return true;
+  }
+
+  return false;
+}
+
 void
 Stalactite::kill_fall()
 {

--- a/src/badguy/stalactite.hpp
+++ b/src/badguy/stalactite.hpp
@@ -42,6 +42,7 @@ public:
   static std::string display_name() { return _("Stalactite"); }
   virtual std::string get_display_name() const override { return display_name(); }
   virtual GameObjectClasses get_class_types() const override { return StickyBadguy::get_class_types().add(typeid(Stalactite)); }
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
   virtual ObjectSettings get_settings() override;
 

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -192,6 +192,30 @@ BonusBlock::get_default_sprite_name() const
   }
 }
 
+bool
+BonusBlock::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("orangeblock") != std::string::npos)
+  {
+    type = "orange";
+    return true;
+  }
+
+  if (sprite_name.find("purpleblock") != std::string::npos)
+  {
+    type = "purple";
+    return true;
+  }
+
+  if (sprite_name.find("retroblock") != std::string::npos)
+  {
+    type = "retro";
+    return true;
+  }
+
+  return false;
+}
+
 void
 BonusBlock::on_type_change(int old_type)
 {

--- a/src/object/bonus_block.hpp
+++ b/src/object/bonus_block.hpp
@@ -65,6 +65,7 @@ public:
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   std::string get_default_sprite_name() const override;
 
   int get_coins_worth() const override;

--- a/src/object/brick.cpp
+++ b/src/object/brick.cpp
@@ -73,6 +73,18 @@ Brick::get_default_sprite_name() const
   }
 }
 
+bool
+Brick::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("retro_brick") != std::string::npos)
+  {
+    type = "retro";
+    return true;
+  }
+
+  return false;
+}
+
 void
 Brick::hit(Player& player)
 {

--- a/src/object/brick.hpp
+++ b/src/object/brick.hpp
@@ -36,6 +36,7 @@ public:
   virtual GameObjectClasses get_class_types() const override { return Block::get_class_types().add(typeid(Brick)); }
 
   GameObjectTypes get_types() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   std::string get_default_sprite_name() const override;
 
   void try_break(Player* player, bool slider = false);

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -83,6 +83,18 @@ Coin::get_default_sprite_name() const
   }
 }
 
+bool
+Coin::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("retro_coin") != std::string::npos)
+  {
+    type = "retro";
+    return true;
+  }
+
+  return false;
+}
+
 void
 Coin::finish_construction()
 {

--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -47,6 +47,7 @@ public:
 
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   std::string get_default_sprite_name() const override;
 
   virtual void after_editor_set() override;

--- a/src/object/powerup.cpp
+++ b/src/object/powerup.cpp
@@ -102,6 +102,72 @@ PowerUp::get_default_sprite_name() const
   }
 }
 
+bool
+PowerUp::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("fireflower") != std::string::npos)
+  {
+    type = "fire";
+    return true;
+  }
+
+  if (sprite_name.find("iceflower") != std::string::npos)
+  {
+    type = "ice";
+    return true;
+  }
+
+  if (sprite_name.find("airflower") != std::string::npos)
+  {
+    type = "air";
+    return true;
+  }
+
+  if (sprite_name.find("earthflower") != std::string::npos)
+  {
+    type = "earth";
+    return true;
+  }
+
+  if (sprite_name.find("star") != std::string::npos)
+  {
+    type = "star";
+    return true;
+  }
+
+  if (sprite_name.find("1up") != std::string::npos)
+  {
+    type = "oneup";
+    return true;
+  }
+
+  if (sprite_name.find("potion") != std::string::npos)
+  {
+    type = "flip";
+    return true;
+  }
+
+  if (sprite_name.find("mints") != std::string::npos)
+  {
+    type = "mints";
+    return true;
+  }
+
+  if (sprite_name.find("coffee") != std::string::npos)
+  {
+    type = "coffee";
+    return true;
+  }
+
+  if (sprite_name.find("herring") != std::string::npos)
+  {
+    type = "herring";
+    return true;
+  }
+
+  return false;
+}
+
 void
 PowerUp::initialize()
 {

--- a/src/object/powerup.hpp
+++ b/src/object/powerup.hpp
@@ -42,6 +42,7 @@ public:
   PowerUp(const Vector& pos, int type);
 
   GameObjectTypes get_types() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
   std::string get_default_sprite_name() const override;
 
   virtual void update(float dt_sec) override;

--- a/src/object/trampoline.cpp
+++ b/src/object/trampoline.cpp
@@ -80,6 +80,18 @@ Trampoline::get_default_sprite_name() const
   }
 }
 
+bool
+Trampoline::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("trampoline_fix") != std::string::npos)
+  {
+    type = "stationary";
+    return true;
+  }
+
+  return false;
+}
+
 void
 Trampoline::update(float dt_sec)
 {

--- a/src/object/trampoline.hpp
+++ b/src/object/trampoline.hpp
@@ -40,6 +40,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
   void bounce();
 

--- a/src/object/unstable_tile.cpp
+++ b/src/object/unstable_tile.cpp
@@ -87,6 +87,18 @@ UnstableTile::get_default_sprite_name() const
   }
 }
 
+bool
+UnstableTile::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("castleblock.sprite") != std::string::npos)
+  {
+    type = "brick";
+    return true;
+  }
+
+  return false;
+}
+
 HitResponse
 UnstableTile::collision(MovingObject& other, const CollisionHit& )
 {

--- a/src/object/unstable_tile.hpp
+++ b/src/object/unstable_tile.hpp
@@ -45,6 +45,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
 public:
   enum Type {

--- a/src/object/weak_block.cpp
+++ b/src/object/weak_block.cpp
@@ -111,6 +111,19 @@ WeakBlock::get_default_sprite_name() const
   }
 }
 
+bool
+WeakBlock::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  if (sprite_name.find("strawbox.sprite") != std::string::npos)
+  {
+    type = "hay";
+    return true;
+  }
+
+  return false;
+}
+
+
 HitResponse
 WeakBlock::collision_bullet(Bullet& bullet, const CollisionHit& hit)
 {

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -43,6 +43,7 @@ public:
 
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
+  bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const override;
 
   virtual void on_flip(float height) override;
 

--- a/src/supertux/game_object.cpp
+++ b/src/supertux/game_object.cpp
@@ -207,6 +207,23 @@ GameObject::parse_type(const ReaderMapping& reader)
         log_warning << "Unknown type of " << get_class_name() << ": '" << type << "', using default." << std::endl;
     }
   }
+  else // Fallback / backward compatibility for older versions of SuperTux
+  {
+    std::string sprite_file;
+    if (reader.get("sprite", sprite_file))
+    {
+      // This only assigns an object type if the actual sprite
+      // file couldn't be found (so user-skinning still works.)
+      // Is this what we want?
+      if (!PHYSFS_exists(sprite_file.c_str()))
+      {
+        if (get_type_from_sprite(sprite_file, type))
+        {
+          m_type = type_id_to_value(type);
+        }
+      }
+    }
+  }
 
   on_type_change(TypeChange::INITIAL); // Initial object type initialization
 }
@@ -215,6 +232,12 @@ GameObjectTypes
 GameObject::get_types() const
 {
   return {};
+}
+
+bool
+GameObject::get_type_from_sprite(const std::string& sprite_name, std::string& type) const
+{
+  return false;
 }
 
 void

--- a/src/supertux/game_object.hpp
+++ b/src/supertux/game_object.hpp
@@ -173,6 +173,10 @@ public:
 
   /** Get all types of the object, if available. **/
   virtual GameObjectTypes get_types() const;
+
+  /** 0.6.3 backward compatibility: Get object type from sprite file */
+  virtual bool get_type_from_sprite(const std::string& sprite_name, std::string& type) const;
+
   /**
    * @scripting
    * @description Returns the type index of the object.


### PR DESCRIPTION
This is another backwards compatibility check: Some of the sprite paths changed in between version 0.6.3 and latest nightly. I've implemented something that checks the old sprite paths against a list of known earlier sprite paths and returns the proper object type in that case.

This only happens if the sprite path in question couldn't be found. To be honest, setting the object type for sprite paths that remained the same in between versions would also make sense, but the code is too flaky for that currently (e.g. we don't check the full path).

Tell me what you think.