### PR TITLE
Fix Tux being permanently safe after mix of using door and scripting Tux safe

### DIFF
--- a/src/object/player.hpp
+++ b/src/object/player.hpp
@@ -567,7 +567,8 @@ public:
 
 private:
   Timer m_skidding_timer;
-  Timer m_safe_timer;
+  Timer m_post_damage_safety_timer;
+  Timer m_temp_safety_timer;
 
   /**
    * @scripting


### PR DESCRIPTION
* Use a separate timer for temporary safety instead of reusing m_is_intentionally_safe
* Split timers for post damage safety and temporary safety

Fixes #3186