### PR TITLE
Fix addon MD5 buffer overflow

### DIFF
--- a/src/addon/md5.cpp
+++ b/src/addon/md5.cpp
@@ -161,7 +161,7 @@ std::string MD5::hex_digest() {
   for (i=0; i<16; i++)
   {
     char* so = s + i * 2;
-    snprintf(so, sizeof(so), "%02x", digest[i]);
+    snprintf(so, 3, "%02x", digest[i]);
   }
 
   s[32]='\0';

--- a/src/addon/md5.cpp
+++ b/src/addon/md5.cpp
@@ -164,8 +164,6 @@ std::string MD5::hex_digest() {
     snprintf(so, 3, "%02x", digest[i]);
   }
 
-  s[32]='\0';
-
   // Create string from 's'
   std::string s_str = std::string(s);
   delete[] s;


### PR DESCRIPTION
The original code was using `sizeof(so)` which, on my machine, is returning `8`. This causes the game to try to write to a point past `so[32]`, causing a buffer overflow.
This PR simply hardcodes the size to 3 (as each char is always 1 byte large, theres 2 chars inserted via the format + 1 NULL char). This makes it not buffer overflow without breaking existing addon functionality.