### PR TITLE
Let squished enemies fade out instead of vanishing instantly

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -42,6 +42,7 @@
 static const float SQUISH_TIME = 2;
 static const float GEAR_TIME = 2;
 static const float BURN_TIME = 1;
+static const float FADEOUT_TIME = 0.2f;
 
 static const float X_OFFSCREEN_DISTANCE = 1280;
 static const float Y_OFFSCREEN_DISTANCE = 800;
@@ -77,7 +78,8 @@ BadGuy::BadGuy(const Vector& pos, Direction direction, const std::string& sprite
   m_is_active_flag(),
   m_state_timer(),
   m_on_ground_flag(false),
-  m_colgroup_active(COLGROUP_MOVING)
+  m_colgroup_active(COLGROUP_MOVING),
+  m_alpha_before_fadeout(1.0f)
 {
   SoundManager::current()->preload("sounds/squish.wav");
   SoundManager::current()->preload("sounds/fall.wav");
@@ -315,12 +317,18 @@ BadGuy::update(float dt_sec)
     case STATE_SQUISHED:
       m_is_active_flag = false;
       if (m_state_timer.check()) {
-        remove_me();
+        m_alpha_before_fadeout = m_sprite->get_alpha();
+        set_state(STATE_SQUISHED_FADING_OUT);
         break;
       }
       m_col.set_movement(m_physic.get_movement(dt_sec));
       break;
-
+    case STATE_SQUISHED_FADING_OUT:
+      if (m_state_timer.check())
+        remove_me();
+      else
+        m_sprite->set_alpha(m_alpha_before_fadeout - (m_alpha_before_fadeout * m_state_timer.get_progress()));
+      break;
     case STATE_MELTING: {
       m_is_active_flag = false;
       m_col.set_movement(m_physic.get_movement(dt_sec));
@@ -759,6 +767,9 @@ BadGuy::set_state(State state_)
       break;
     case STATE_SQUISHED:
       m_state_timer.start(SQUISH_TIME);
+      break;
+    case STATE_SQUISHED_FADING_OUT:
+      m_state_timer.start(FADEOUT_TIME);
       break;
     case STATE_GEAR:
       m_state_timer.start(GEAR_TIME);

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -165,6 +165,7 @@ protected:
     STATE_INACTIVE,
     STATE_ACTIVE,
     STATE_SQUISHED,
+    STATE_SQUISHED_FADING_OUT,
     STATE_FALLING,
     STATE_BURNING,
     STATE_MELTING,
@@ -321,6 +322,9 @@ private:
 
   /** CollisionGroup the badguy should be in while active */
   CollisionGroup m_colgroup_active;
+
+  /** The alpha value at the time the Badguy begins to fadeout */
+  float m_alpha_before_fadeout;
 
 private:
   BadGuy(const BadGuy&) = delete;


### PR DESCRIPTION
Squished enemies will now fadeout instead of vanishing instantly. This looks a bit smoother and is more aligned with the melting or burning animation.