### PR TITLE
Use ubuntu-latest for CI builds

### DIFF
--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -21,7 +21,7 @@ if [ "$SOURCE" = "ON" ]; then
     cpack --config CPackSourceConfig.cmake -G TGZ;
 fi
 
-if ([ "$OS_NAME" = "ubuntu-20.04" ] || [ "$OS_NAME" = "ubuntu-18.04" ]) && [ "$PACKAGE" = "ON" ]; then
+if ([ "$OS_NAME" = "ubuntu-latest" ] || [ "$OS_NAME" = "ubuntu-18.04" ]) && [ "$PACKAGE" = "ON" ]; then
     ../.ci_scripts/build_appimage.sh
     # extract built appimages for uploading
     mv ~/out/* .

--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [32, 64]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         compiler: [gcc, clang]
         build_type: [Debug, Release]
         glbinding: [ON, OFF]
@@ -40,7 +40,7 @@ jobs:
           - arch: 32
             glbinding: ON
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             build_type: Release
             compiler: gcc
             arch: 64
@@ -48,7 +48,7 @@ jobs:
             release: ON
             source: ON
             documentation: ON
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             build_type: Debug
             compiler: gcc
             arch: 64
@@ -103,14 +103,14 @@ jobs:
       - name: Install 32-bit dependencies
         if: ${{ matrix.arch == 32 }}
         env:
-          DOWNGRADE_PCRE: ${{ matrix.os == 'ubuntu-20.04' && '1' || '' }}
+          DOWNGRADE_PCRE: ${{ matrix.os == 'ubuntu-latest' && '1' || '' }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
 
           if [ "$DOWNGRADE_PCRE" ]; then
             # Github is adding a lot of unnecessary deb.sury.org
-            # packages into ubuntu-20.04, this causes
+            # packages into ubuntu-latest, this causes
             # libharfbuzz-dev:i386 to fail due to issues related to
             # libpcre2-8-0 from deb.sury.org. Remove all that and
             # downgrade to official versions.
@@ -170,7 +170,7 @@ jobs:
           GLBINDING: ${{ matrix.glbinding }}
           # FIXME: GoogleTest isn't detected by CMake on Ubuntu 18.04
           # (also check the step that invokes the tests with ./test_supertux2)
-          TESTS: ${{ matrix.os == 'ubuntu-20.04' }}
+          TESTS: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           cmake --version
           $CXX --version
@@ -191,7 +191,7 @@ jobs:
       - name: Run tests
         # FIXME: GoogleTest isn't detected by CMake on Ubuntu 18.04
         # (also check the step that invokes CMake with -DBUILD_TESTS)
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         working-directory: build
         run: ./test_supertux2
 

--- a/.github/workflows/translation_templates.yml
+++ b/.github/workflows/translation_templates.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   update-all-templates:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout SuperTux repository
         uses: actions/checkout@v4

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   update-all-translations:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout SuperTux repository
         uses: actions/checkout@v4

--- a/.github/workflows/ubuntu-touch.yml
+++ b/.github/workflows/ubuntu-touch.yml
@@ -39,7 +39,7 @@ jobs:
           - arch: arm64
             build_type: Debug
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   update-wiki-repo:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the .wiki repo
         uses: actions/checkout@v4


### PR DESCRIPTION
I just got an e-mail from Github mentioning that the ubuntu 20.04 runner will be unsupported on April 1, 2025.

This PR updates all workflows to ubuntu-latest.