### PR TITLE
Stop spawn fade timer on level reset

### DIFF
--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -119,6 +119,7 @@ GameSession::reset_level()
   m_activated_checkpoint = nullptr;
   m_pause_target_timer = false;
   m_spawn_with_invincibility = false;
+  m_spawn_fade_timer.stop();
 
   m_data_table.clear();
 }


### PR DESCRIPTION
This avoids teleporting Tux to the door's target spawnpoint when a level reset is done right after the door has been triggered.

Fixes #3206