### PR TITLE
Allow referencing actual keys the player uses inside strings

### DIFF
--- a/src/supertux/menu/keyboard_menu.cpp
+++ b/src/supertux/menu/keyboard_menu.cpp
@@ -74,7 +74,7 @@ KeyboardMenu::KeyboardMenu(InputManager& input_manager, int player_id) :
 }
 
 std::string
-KeyboardMenu::get_key_name(SDL_Keycode key) const
+KeyboardMenu::get_key_name(SDL_Keycode key)
 {
   switch (key) {
     case SDLK_UNKNOWN:
@@ -108,7 +108,7 @@ KeyboardMenu::get_key_name(SDL_Keycode key) const
     case SDLK_LGUI:
       return _("Left Command");
     default:
-      return SDL_GetKeyName(static_cast<SDL_Keycode>(key));
+      return SDL_GetKeyName(key);
   }
 }
 
@@ -140,7 +140,7 @@ KeyboardMenu::refresh()
 
   if (g_config->developer_mode && m_player_id == 0)
   {
-    for(const auto& control: developer_controls)
+    for(const auto& control : developer_controls)
     {
       refresh_control(control);
     }

--- a/src/supertux/menu/keyboard_menu.hpp
+++ b/src/supertux/menu/keyboard_menu.hpp
@@ -29,7 +29,7 @@ public:
   KeyboardMenu(InputManager& input_manager, int player_id = 0);
 
   void refresh() override;
-  std::string get_key_name(SDL_Keycode key) const;
+  static std::string get_key_name(SDL_Keycode key);
   void menu_action(MenuItem& item) override;
 
 private:


### PR DESCRIPTION
This PR allows for referencing actual player keys inside texts, like info boxes etc.

The syntax is `{keyref up}` or instead of `up` you can name any of the other keys in SuperTux.

Unfortunately, this currently only works for one mention of `{keyref}` per string. This needs to be fixed in order to support multiple mentions. 