### PR TITLE
Fixes #3210 - Stalactite landing on a trampoline

### DIFF
--- a/src/badguy/stalactite.cpp
+++ b/src/badguy/stalactite.cpp
@@ -101,9 +101,6 @@ Stalactite::collision_solid(const CollisionHit& hit)
   if (state == STALACTITE_FALLING) {
     if (hit.bottom) squish();
   }
-  if (state == STALACTITE_SQUISHED) {
-    m_physic.set_velocity_y(0);
-  }
 }
 
 HitResponse


### PR DESCRIPTION
The stalactite's death animation did not bounce on the trampoline like other enemies do. Instead, it caused the trampoline to repeat its bouncing sound and animation for a short period of time. Now the stalactite's death animation bounces on the trampoline like other enemies do, instead of remaining still on the trampoline. To do this, I deleted a line in stalactite.cpp that changed the stalactite's vertical speed to 0.

Closes #3210