### PR TITLE
Fixes #3208: bounce mriceblock to bonusblock by bumper doesn't go back

### DIFF
--- a/src/badguy/mriceblock.cpp
+++ b/src/badguy/mriceblock.cpp
@@ -166,6 +166,9 @@ MrIceBlock::collision_solid(const CollisionHit& hit)
       m_dir = (m_dir == Direction::LEFT) ? Direction::RIGHT : Direction::LEFT;
       SoundManager::current()->play("sounds/iceblock_bump.wav", get_pos());
       m_physic.set_velocity_x(-m_physic.get_velocity_x() * .975f);
+    } else if ((hit.left && m_dir == Direction::RIGHT) || (hit.right && m_dir == Direction::LEFT)) {
+      SoundManager::current()->play("sounds/iceblock_bump.wav", get_pos());
+      m_physic.set_velocity_x(-m_physic.get_velocity_x() * .975f);
     }
     set_action("flat", m_dir, /* loops = */ -1);
     if (fabsf(m_physic.get_velocity_x()) < walk_speed * 1.5f)


### PR DESCRIPTION
When a MrIceBlock is kicked into a trampoline, it bounces back facing backwards. The collision_solid() function, when the MrIceBlock's state is KICKED (which is the case), didn't expect to receive a hit from the right while facing left, and vice-versa. I added that condition and made it so it plays the collision sound and goes back, just like normal, but skips the flipping orientation, as it should slide forward and not backwards.
Video demonstration: https://www.youtube.com/watch?v=oAgOuTEf52w

Closes #3208