### PR TITLE
Fixes #3079 Buttjump bonusblock runs script twice & unports trampoline

### DIFF
--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -616,7 +616,7 @@ BonusBlock::try_drop(Player *player)
     }
     case Content::PORTABLE_TRAMPOLINE:
     {
-      Sector::get().add<Trampoline>(get_pos() + Vector(0, 32), false);
+      Sector::get().add<Trampoline>(get_pos() + Vector(0, 32), Trampoline::PORTABLE);
       countdown = true;
       break;
     }

--- a/src/object/bonus_block.cpp
+++ b/src/object/bonus_block.cpp
@@ -616,7 +616,7 @@ BonusBlock::try_drop(Player *player)
     }
     case Content::PORTABLE_TRAMPOLINE:
     {
-      Sector::get().add<Trampoline>(get_pos() + Vector(0, 32), true);
+      Sector::get().add<Trampoline>(get_pos() + Vector(0, 32), false);
       countdown = true;
       break;
     }
@@ -638,7 +638,7 @@ BonusBlock::try_drop(Player *player)
   if (play_upgrade_sound)
     SoundManager::current()->play("sounds/upgrade.wav", get_pos(), UPGRADE_SOUND_GAIN);
 
-  if (!m_script.empty()) { // Scripts always run if defined.
+  if (!m_script.empty() && countdown) { // Scripts always run if defined.
     Sector::get().run_script(m_script, "powerup-script");
   }
 


### PR DESCRIPTION
When someone buttjumps onto a bonus_block it calls the try_drop function in which some objects on that function would call try_open, another function on which it would run a script, then come back to try_drop and run the script again since the condition to run the script didn't include countdown, the bool that checks if try_open is called, so I just added it to the condition.
Then for the trampoline error the add function had the position that the trampoline is created and an enum (1 or 0, or respectivelly true or false) which was incorrect and creating the wrong trampoline, so I just changed from true, which created a stationary trampoline, to a false, a portable one.

Closes #3079