### PR TITLE
Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to GitHub workflows

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -75,7 +75,8 @@ jobs:
             cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWARNINGS=ON -DWERROR=ON  \
                      -DBUILD_TESTS=ON -DINSTALL_SUBDIR_SHARE=share/supertux2   \
                      -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=/usr \
-                     -DINSTALL_SUBDIR_BIN=bin # -DGLBINDING_ENABLED=$GLBINDING
+                     -DINSTALL_SUBDIR_BIN=bin # -DGLBINDING_ENABLED=$GLBINDING \
+                     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                                             # TODO: Uncomment whenever possible
             make -j3 VERBOSE=1
             make install DESTDIR="/tmp/supertux" VERBOSE=1

--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -180,7 +180,8 @@ jobs:
                    -DWARNINGS=ON -DWERROR=ON -DGLBINDING_ENABLED=$GLBINDING    \
                    -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=/usr   \
                    -DBUILD_DOCUMENTATION=$MAKE_DOCS -DINSTALL_SUBDIR_BIN=bin   \
-                   -DINSTALL_SUBDIR_SHARE=share/supertux2 -DENABLE_DISCORD=ON
+                   -DINSTALL_SUBDIR_SHARE=share/supertux2 -DENABLE_DISCORD=ON. \
+                   -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build and install
         working-directory: build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,7 +94,8 @@ jobs:
                    -DWARNINGS=ON -DWERROR=ON -DGLBINDING_ENABLED=$GLBINDING    \
                    -DENABLE_DISCORD=ON -DCMAKE_INSTALL_MESSAGE=NEVER           \
                    -DCMAKE_INSTALL_PREFIX=/usr -DINSTALL_SUBDIR_BIN=bin        \
-                   -DINSTALL_SUBDIR_SHARE=share/supertux2
+                   -DINSTALL_SUBDIR_SHARE=share/supertux2                      \
+                   -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build and install
         working-directory: build

--- a/.github/workflows/scripting.yml
+++ b/.github/workflows/scripting.yml
@@ -57,7 +57,7 @@ jobs:
           cmake --version
           mkdir build
           cd build
-          cmake .. -DBUILD_DOCUMENTATION_WITH_SCRIPTING=ON
+          cmake .. -DBUILD_DOCUMENTATION_WITH_SCRIPTING=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           make
 
       - name: Generate scripting reference

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -58,7 +58,7 @@ jobs:
           mkdir build
           cd build
           # TODO: Re-add -DWERROR=ON when warnings will be fixed
-          emcmake cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DWARNINGS=ON ..
+          emcmake cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DWARNINGS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
 
       - name: Sync data folder
         working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:/vcpkg/installed
-          key: ${{ runner.os }}-${{ matrix.arch }}-dependencies-${{ hashFiles('.github/workflows/windows.yml') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-deps-${{ hashFiles('.github/workflows/windows.yml') }}
 
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
           cmake --version
           mkdir build
           cd build
-          cmake .. -G "Visual Studio 17 2022" -A $Env:ARCH.replace("x86", "Win32") "-DGLBINDING_ENABLED=$Env:GLBINDING" -DENABLE_DISCORD=ON -DVCPKG_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DHAVE_SDL=true -DPACKAGE_VCREDIST=true "-DCMAKE_BUILD_TYPE=$Env:BUILD_TYPE" -DBUILD_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake .. -G "Visual Studio 17 2022" -A $Env:ARCH.replace("x86", "Win32") "-DGLBINDING_ENABLED=$Env:GLBINDING" -DENABLE_DISCORD=ON -DVCPKG_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DHAVE_SDL=true -DPACKAGE_VCREDIST=true "-DCMAKE_BUILD_TYPE=$Env:BUILD_TYPE" -DBUILD_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM="3.5"
 
       - name: Build and install
         working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
           cmake --version
           mkdir build
           cd build
-          cmake .. -G "Visual Studio 17 2022" -A $Env:ARCH.replace("x86", "Win32") "-DGLBINDING_ENABLED=$Env:GLBINDING" -DENABLE_DISCORD=ON -DVCPKG_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DHAVE_SDL=true -DPACKAGE_VCREDIST=true "-DCMAKE_BUILD_TYPE=$Env:BUILD_TYPE" -DBUILD_TESTS=ON
+          cmake .. -G "Visual Studio 17 2022" -A $Env:ARCH.replace("x86", "Win32") "-DGLBINDING_ENABLED=$Env:GLBINDING" -DENABLE_DISCORD=ON -DVCPKG_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DHAVE_SDL=true -DPACKAGE_VCREDIST=true "-DCMAKE_BUILD_TYPE=$Env:BUILD_TYPE" -DBUILD_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build and install
         working-directory: build


### PR DESCRIPTION
This should fix the CI builds that error and preemptively fix those that haven't errored yet because they're not yet on CMake version 4.

Let's see...