### PR TITLE
Implement up and down direction for swimming fish

### DIFF
--- a/src/badguy/fish_chasing.cpp
+++ b/src/badguy/fish_chasing.cpp
@@ -89,7 +89,10 @@ FishChasing::active_update(float dt_sec) {
   const Vector p2 = player->get_bbox().get_middle();
   const Vector dist = (p2 - p1);
   const bool is_player_in_water = player->is_swimming() || player->is_swimboosting() || player->is_water_jumping();
-  const bool is_facing_player = (m_dir == Direction::LEFT && dist.x <= 0.0f) || (m_dir == Direction::RIGHT && dist.x >= 0.0f );
+  const bool is_facing_player = (m_dir == Direction::LEFT && dist.x <= 0.0f)
+                             || (m_dir == Direction::RIGHT && dist.x >= 0.0f )
+                             || (m_dir == Direction::UP && dist.y <= 0.0f )
+                             || (m_dir == Direction::DOWN && dist.y >= 0.0f );
   const bool can_see_player = Sector::get().free_line_of_sight(p1,p2, true, this);
 
   switch (m_chase_state)

--- a/src/badguy/fish_chasing.cpp
+++ b/src/badguy/fish_chasing.cpp
@@ -108,7 +108,10 @@ FishChasing::active_update(float dt_sec) {
     break;
   case FOUND:
     if (!m_frozen)
-      set_action("notice", m_dir, 1);
+    {
+      Direction dir = m_physic.get_velocity_x() <= 0.f ? Direction::LEFT : Direction::RIGHT;
+      set_action("notice", dir, 1);
+    }
 
     if (std::abs(glm::length(m_physic.get_velocity())) >= 1.f) {
       m_physic.set_velocity(m_physic.get_velocity() / 1.25f);

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -79,6 +79,18 @@ FishSwimming::get_allowed_directions() const
   return { Direction::AUTO, Direction::LEFT, Direction::RIGHT, Direction::UP, Direction::DOWN };
 }
 
+void
+FishSwimming::after_editor_set()
+{
+  MovingSprite::after_editor_set();
+
+  if (m_start_dir == Direction::RIGHT || m_start_dir == Direction::DOWN) {
+      set_action("swim-right");
+  } else {
+      set_action("swim-left");
+  }
+}
+
 ObjectSettings
 FishSwimming::get_settings()
 {

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -73,6 +73,12 @@ FishSwimming::get_default_sprite_name() const
   }
 }
 
+std::vector<Direction>
+FishSwimming::get_allowed_directions() const
+{
+  return { Direction::AUTO, Direction::LEFT, Direction::RIGHT, Direction::UP, Direction::DOWN };
+}
+
 ObjectSettings
 FishSwimming::get_settings()
 {
@@ -88,9 +94,49 @@ FishSwimming::get_settings()
 void
 FishSwimming::initialize()
 {
-  m_physic.set_velocity_x(m_dir == Direction::LEFT ? -128.f : 128.f);
+  setup_velocity();
   set_action("swim", m_dir);
   m_state = FishYState::BALANCED;
+}
+
+void
+FishSwimming::setup_velocity()
+{
+  switch (m_dir) {
+    case Direction::LEFT:
+      m_physic.set_velocity_x(-128.f);
+      break;
+    case Direction::RIGHT:
+      m_physic.set_velocity_x(128.f);
+      break;
+    case Direction::UP:
+      m_physic.set_velocity_y(-128.f);
+      set_action("swim-right", -1);
+      break;
+    case Direction::DOWN:
+      m_physic.set_velocity_y(128.f);
+      set_action("swim-right", -1);
+      break;
+    default:
+      break;
+  }
+}
+
+bool
+FishSwimming::is_frontal_hit(const CollisionHit& hit) const
+{
+  switch (m_dir) {
+    case Direction::LEFT:
+      return hit.left;
+    case Direction::RIGHT:
+      return hit.right;
+    case Direction::UP:
+      return hit.top;
+    case Direction::DOWN:
+      return hit.bottom;
+    default:
+      return false;
+  }
 }
 
 void
@@ -103,7 +149,7 @@ FishSwimming::collision_solid(const CollisionHit& hit)
   {
     if (m_in_water)
     {
-      if (hit.left || hit.right)
+      if (is_frontal_hit(hit))
         turn_around();
     }
     else
@@ -124,8 +170,7 @@ FishSwimming::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
   if (m_beached_timer.started())
      collision_solid(hit);
 
-  if (!m_frozen && !m_beached_timer.started() &&
-    ((hit.left && (m_dir == Direction::LEFT)) || (hit.right && (m_dir == Direction::RIGHT))))
+  if (!m_frozen && !m_beached_timer.started() && is_frontal_hit(hit))
     turn_around();
 
   BadGuy::collision_badguy(badguy, hit);
@@ -175,14 +220,26 @@ FishSwimming::active_update(float dt_sec) {
   {
     if (m_state == FishYState::DISRUPTED)
     {
-      if (std::abs(m_physic.get_velocity_y()) >= 5.f) {
-        m_physic.set_velocity_y(m_physic.get_velocity_y() / 1.25f);
-      }
-      else
-      {
-        m_state = FishYState::BALANCED;
-        m_physic.set_velocity_y(0.f);
-        m_start_position.y = get_pos().y;
+      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT) {
+        if (std::abs(m_physic.get_velocity_y()) >= 5.f) {
+          m_physic.set_velocity_y(m_physic.get_velocity_y() / 1.25f);
+        }
+        else
+        {
+          m_state = FishYState::BALANCED;
+          m_physic.set_velocity_y(0.f);
+          m_start_position.y = get_pos().y;
+        }
+      } else {
+        if (std::abs(m_physic.get_velocity_x()) >= 5.f) {
+          m_physic.set_velocity_x(m_physic.get_velocity_x() / 1.25f);
+        }
+        else
+        {
+          m_state = FishYState::BALANCED;
+          m_physic.set_velocity_x(0.f);
+          m_start_position.x = get_pos().x;
+        }
       }
     }
     else
@@ -192,20 +249,54 @@ FishSwimming::active_update(float dt_sec) {
       {
         yspeed = yspeed * -1.f;
       }
-      m_physic.set_velocity_y(yspeed);
+      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT) {
+        m_physic.set_velocity_y(yspeed);
+      }
+      else
+      {
+        if (m_physic.get_velocity_x() > 0 && yspeed < 0) {
+          set_action("swim-left", -1);
+        }
+        else if (m_physic.get_velocity_x() < 0 && yspeed > 0)
+        {
+          set_action("swim-right", -1);
+        }
+        m_physic.set_velocity_x(yspeed);
+      }
     }
   }
 
   if (!m_beached_timer.started())
   {
     // Handle x-velocity related functionality.
-    float goal_x_velocity = m_dir == Direction::LEFT ? -128.f : 128.f;
-    if (m_dir != Direction::LEFT && get_pos().x > (m_start_position.x + m_radius - 20.f))
-      goal_x_velocity = -128.f;
-    if (m_dir != Direction::RIGHT && get_pos().x < (m_start_position.x - m_radius + 20.f))
-      goal_x_velocity = 128.f;
-
-    maintain_velocity(goal_x_velocity);
+    switch (m_dir) {
+      case Direction::LEFT: {
+        float goal_x_velocity = -128.f;
+        if (get_pos().x < (m_start_position.x - m_radius + 20.f))
+          goal_x_velocity = 128.f;
+        maintain_velocity_x(goal_x_velocity);
+      } break;
+      case Direction::RIGHT: {
+        float goal_x_velocity = 128.f;
+        if (get_pos().x > (m_start_position.x + m_radius - 20.f))
+          goal_x_velocity = -128.f;
+        maintain_velocity_x(goal_x_velocity);
+      } break;
+      case Direction::UP: {
+        float goal_y_velocity = -128.f;
+        if (get_pos().y < (m_start_position.y - m_radius + 20.f))
+          goal_y_velocity = 128.f;
+        maintain_velocity_y(goal_y_velocity);
+      } break;
+      case Direction::DOWN: {
+        float goal_y_velocity = 128.f;
+        if (get_pos().y > (m_start_position.y + m_radius - 20.f))
+          goal_y_velocity = -128.f;
+        maintain_velocity_y(goal_y_velocity);
+      } break;
+      default:
+        break;
+    }
   }
 }
 
@@ -236,13 +327,13 @@ FishSwimming::turn_around()
   if (m_frozen)
     return;
 
-  m_dir = (m_dir == Direction::LEFT ? Direction::RIGHT : Direction::LEFT);
+  m_dir = invert_dir(m_dir);
   set_action("swim", m_dir);
-  m_physic.set_velocity_x(m_dir == Direction::LEFT ? -128.f : 128.f);
+  setup_velocity();
 }
 
 void
-FishSwimming::maintain_velocity(float goal_x_velocity)
+FishSwimming::maintain_velocity_x(float goal_x_velocity)
 {
   if (m_frozen || !m_in_water)
     return;
@@ -279,6 +370,45 @@ FishSwimming::maintain_velocity(float goal_x_velocity)
   {
     m_dir = Direction::LEFT;
     set_action("swim-left", -1);
+  }
+}
+
+void
+FishSwimming::maintain_velocity_y(float goal_y_velocity)
+{
+  if (m_frozen || !m_in_water)
+    return;
+
+  float current_y_velocity = m_physic.get_velocity_y();
+  /* We're very close to our target speed. Just set it to avoid oscillation. */
+  if ((current_y_velocity > (goal_y_velocity - 5.0f)) &&
+    (current_y_velocity < (goal_y_velocity + 5.0f)))
+  {
+    m_physic.set_velocity_y(goal_y_velocity);
+    m_physic.set_acceleration_y(0.0);
+  }
+  /* Check if we're going too slow or even in the wrong direction. */
+  else if (((goal_y_velocity <= 0.0f) && (current_y_velocity > goal_y_velocity)) ||
+    ((goal_y_velocity > 0.0f) && (current_y_velocity < goal_y_velocity))) {
+    m_physic.set_acceleration_y(goal_y_velocity);
+  }
+  /* Check if we're going too fast. */
+  else if (((goal_y_velocity <= 0.0f) && (current_y_velocity < goal_y_velocity)) ||
+    ((goal_y_velocity > 0.0f) && (current_y_velocity > goal_y_velocity))) {
+    m_physic.set_acceleration_y((-1.f) * goal_y_velocity);
+  }
+  else {
+    /* The above should have covered all cases. */
+    assert(false);
+  }
+
+  if ((m_dir == Direction::UP) && (m_physic.get_velocity_y() > 0.0f))
+  {
+    m_dir = Direction::DOWN;
+  }
+  else if ((m_dir == Direction::DOWN) && (m_physic.get_velocity_y() < 0.0f))
+  {
+    m_dir = Direction::UP;
   }
 }
 

--- a/src/badguy/fish_swimming.hpp
+++ b/src/badguy/fish_swimming.hpp
@@ -31,6 +31,7 @@ public:
   virtual HitResponse collision_badguy(BadGuy& badguy, const CollisionHit& hit) override;
   virtual void update(float dt_sec) override;
   virtual void active_update(float dt_sec) override;
+  virtual void after_editor_set() override;
 
   virtual void freeze() override;
   virtual void unfreeze(bool melt = true) override;

--- a/src/badguy/fish_swimming.hpp
+++ b/src/badguy/fish_swimming.hpp
@@ -41,13 +41,15 @@ public:
   virtual std::string get_display_name() const override { return display_name(); }
   virtual std::string get_overlay_size() const override { return "2x1"; }
   virtual GameObjectClasses get_class_types() const override { return BadGuy::get_class_types().add(typeid(FishSwimming)); }
+  virtual std::vector<Direction> get_allowed_directions() const override;
   virtual ObjectSettings get_settings() override;
 
   virtual GameObjectTypes get_types() const override;
   virtual std::string get_default_sprite_name() const override;
 
   void turn_around();
-  void maintain_velocity(float goal_x_velocity);
+  void maintain_velocity_x(float goal_x_velocity);
+  void maintain_velocity_y(float goal_y_velocity);
 
 protected:
   enum Type {
@@ -65,6 +67,9 @@ protected:
   Timer m_beached_timer;
   Timer m_float_timer;
   float m_radius;
+
+  bool is_frontal_hit(const CollisionHit& hit) const;
+  void setup_velocity();
 
 private:
   FishSwimming(const FishSwimming&) = delete;


### PR DESCRIPTION
fixes #2573 

I hate the implementation but some compromise has to be done in order to fit it into 0.7.0. To make the code nicer, I need all the following:
* A transpose-action sprite modifier, to make the fish visually facing up or down.
* Make the chasing fish use 4 different rotations instead of just 2.
* A better interoperability between vectors and directions. There should be at least functions to obtain a unit vector from direction and a direction from vector.

As this seems as a bigger task, the question is, whether it makes sense to put it into 0.7.0 or not. There are three options:
1) Merge this PR as it is and then report these tasks as a bug to be solved in 0.7.1.
2) Postpone whole this stuff to 0.7.1
3) Add these tasks to the scope to 0.7.0 and then provide a proper solution.