### PR TITLE
WIP: Separating collision system into multiple groups

### DIFF
--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -705,7 +705,7 @@ CrusherRoot::CrusherRoot(Vector position, Crusher::Direction direction, float de
   }
   else
   {
-    m_col.m_group = COLGROUP_DISABLED;
+    set_group(COLGROUP_DISABLED);
   }
 }
 
@@ -765,7 +765,7 @@ CrusherRoot::update(float dt_sec)
 void
 CrusherRoot::start_animation()
 {
-  m_col.m_group = COLGROUP_TOUCHABLE;
+  set_group(COLGROUP_TOUCHABLE);
 
   switch (m_direction)
   {

--- a/src/collision/collision_system.hpp
+++ b/src/collision/collision_system.hpp
@@ -19,11 +19,14 @@
 #define HEADER_SUPERTUX_COLLISION_COLLISION_SYSTEM_HPP
 
 #include <vector>
+#include <map>
 #include <memory>
+#include <unordered_map>
 #include <variant>
 #include <stdint.h>
 
 #include "collision/collision.hpp"
+#include "collision/collision_group.hpp"
 #include "supertux/tile.hpp"
 #include "math/fwd.hpp"
 
@@ -47,7 +50,9 @@ public:
   CollisionSystem(Sector& sector);
 
   void add(CollisionObject* object);
+  void add_to_collision_buckets(CollisionObject* object);
   void remove(CollisionObject* object);
+  void remove_from_collision_buckets(CollisionObject* object);
 
   /** Draw collision shapes for debugging */
   void draw(DrawingContext& context);
@@ -111,6 +116,23 @@ private:
   Sector& m_sector;
 
   std::vector<CollisionObject*>  m_objects;
+
+  enum CollisionPart {
+    // Corresponds to:
+    // Part 1: COLGROUP_MOVING vs COLGROUP_STATIC and tilemap.
+    // Part 2: COLGROUP_MOVING vs tile attributes.
+    // Contains objects in collision groups COLGROUP_MOVING, COLGROUP_MOVING_STATIC, COLGROUP_ONLY_STATIC
+    MOVING_MOVING_STATIC_ONLY_STATIC,
+
+    // Corresponds to Part 2.5: COLGROUP_MOVING vs COLGROUP_TOUCHABLE etc.
+    // Contains objects in collision groups COLGROUP_MOVING and COLGROUP_MOVING_STATIC
+    MOVING_MOVING_STATIC,
+
+    // Contains objects in collision group COLGROUP_TOUCHABLE
+    TOUCHABLE
+  };
+
+  std::unordered_map<CollisionPart, std::vector<CollisionObject*> > m_objects_by_collision_part;
 
   std::shared_ptr<CollisionGroundMovementManager> m_ground_movement_manager;
 

--- a/src/object/ambient_sound.cpp
+++ b/src/object/ambient_sound.cpp
@@ -39,7 +39,7 @@ AmbientSound::AmbientSound(const ReaderMapping& mapping) :
   m_volume(),
   m_has_played_sound(false)
 {
-  m_col.m_group = COLGROUP_DISABLED;
+  set_group(COLGROUP_DISABLED);
 
   float w, h;
   mapping.get("x", m_col.m_bbox.get_left(), 0.0f);
@@ -65,7 +65,7 @@ AmbientSound::AmbientSound(const Vector& pos, float radius, float vol, const std
   m_volume(vol),
   m_has_played_sound(false)
 {
-  m_col.m_group = COLGROUP_DISABLED;
+  set_group(COLGROUP_DISABLED);
 
   m_col.m_bbox.set_pos(pos);
   m_col.m_bbox.set_size(32, 32);

--- a/src/object/invisible_wall.cpp
+++ b/src/object/invisible_wall.cpp
@@ -32,7 +32,7 @@ InvisibleWall::InvisibleWall(const ReaderMapping& mapping):
 
   m_col.m_bbox.set_size(width, height);
 
-  m_col.m_group = COLGROUP_STATIC;
+  set_group(COLGROUP_STATIC);
 }
 
 ObjectSettings

--- a/src/object/spotlight.cpp
+++ b/src/object/spotlight.cpp
@@ -67,7 +67,7 @@ Spotlight::Spotlight(const ReaderMapping& mapping) :
   m_layer(0),
   m_enabled(true)
 {
-  m_col.m_group = COLGROUP_DISABLED;
+  set_group(COLGROUP_DISABLED);
 
   mapping.get("x", m_col.m_bbox.get_left(), 0.0f);
   mapping.get("y", m_col.m_bbox.get_top(), 0.0f);

--- a/src/supertux/moving_object.hpp
+++ b/src/supertux/moving_object.hpp
@@ -22,6 +22,7 @@
 #include "collision/collision_hit.hpp"
 #include "collision/collision_object.hpp"
 #include "math/rectf.hpp"
+#include "supertux/sector.hpp"
 
 class Dispenser;
 class Sector;
@@ -157,7 +158,16 @@ public:
 protected:
   void set_group(CollisionGroup group)
   {
+    /*if (Sector::current() != nullptr)
+    {
+      Sector::current()->remove_from_collision_buckets(&m_col);
+    }*/
     m_col.m_group = group;
+    /*
+    if (Sector::current() != nullptr)
+    {
+      Sector::current()->add_to_collision_buckets(&m_col);
+    }*/
   }
 
 protected:

--- a/src/supertux/player_status.cpp
+++ b/src/supertux/player_status.cpp
@@ -403,7 +403,7 @@ PlayerStatus::PocketPowerUp::PocketPowerUp(BonusType bonustype, Vector pos):
   physic.set_velocity_y(-325.f);
   physic.set_gravity_modifier(0.4f);
   set_layer(LAYER_FOREGROUND1);
-  m_col.m_group = COLGROUP_DISABLED;
+  set_group(COLGROUP_DISABLED);
 }
 
 void
@@ -422,7 +422,7 @@ PlayerStatus::PocketPowerUp::update(float dt_sec)
   {
     m_visible = true;
     m_blink_timer.stop();
-    m_col.m_group = COLGROUP_TOUCHABLE;
+    set_group(COLGROUP_TOUCHABLE);
   }
 
   if (m_blink_timer.check())

--- a/src/supertux/sector.cpp
+++ b/src/supertux/sector.cpp
@@ -735,6 +735,18 @@ Sector::get_nearby_objects(const Vector& center, float max_distance) const
 }
 
 void
+Sector::add_to_collision_buckets(CollisionObject* object)
+{
+  m_collision_system->add_to_collision_buckets(object);
+}
+
+void
+Sector::remove_from_collision_buckets(CollisionObject* object)
+{
+  m_collision_system->remove_from_collision_buckets(object);
+}
+
+void
 Sector::stop_looping_sounds()
 {
   for (auto& object : get_objects()) {

--- a/src/supertux/sector.hpp
+++ b/src/supertux/sector.hpp
@@ -212,6 +212,9 @@ public:
   /** globally changes solid tilemaps' tile ids */
   void change_solid_tiles(uint32_t old_tile_id, uint32_t new_tile_id);
 
+  void add_to_collision_buckets(CollisionObject* object);
+  void remove_from_collision_buckets(CollisionObject* object);
+
   /**
    * @scripting
    * Sets the sector's gravity.


### PR DESCRIPTION
Here's something that I've been thinking about: Instead of iterating over all objects, we could group the possible objects together, depending on what type of collision group they have and then only iterate over those matching the collision group we care about. 

I don't honestly know how much faster this is. All I know is: It crashes. It crashes all the time. And I have no idea why.

So, if anyone wants to check this out and submit fixes to this PR, feel free.

Also, terminology-wise: `collision part` and `collision bucket` are the same thing.