### PR TITLE
Fixes #517 - Add a button with the ability to hide/single layers

### DIFF
--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -51,6 +51,7 @@ class Editor final : public Screen,
 {
 public:
   static bool is_active();
+  inline EditorLayersWidget* get_layers_widget() const { return m_layers_widget; }
 
 private:
   static bool is_autosave_file(const std::string& filename) {

--- a/src/editor/layers_widget.cpp
+++ b/src/editor/layers_widget.cpp
@@ -495,10 +495,14 @@ EditorLayersWidget::set_selected_tilemap(TileMap* tilemap)
 {
   TileMap* selected_tilemap = get_selected_tilemap();
   if (selected_tilemap)
+  {
     selected_tilemap->m_editor_active = false;
+    selected_tilemap->set_alpha(0.5f);
+  }
 
   m_selected_tilemap = tilemap->get_uid();
   tilemap->m_editor_active = true;
+  tilemap->set_alpha(1.0f);
 }
 
 Vector

--- a/src/editor/object_menu.cpp
+++ b/src/editor/object_menu.cpp
@@ -54,6 +54,20 @@ ObjectMenu::refresh()
     }
   }
 
+  TileMap* selected_tilemap = m_editor.get_layers_widget()->get_selected_tilemap();
+  if (m_object != selected_tilemap) 
+  {
+    float current_alpha = static_cast<TileMap*>(m_object)->get_alpha();
+    if (current_alpha > 0.0f) 
+    {
+      add_entry(MNID_HIDE_LAYER, _("Hide Layer"));
+    } 
+    else 
+    {
+      add_entry(MNID_HIDE_LAYER, _("Show Layer"));
+    }
+  }
+
   if (!m_object->is_up_to_date())
   {
     add_hl();
@@ -85,6 +99,25 @@ ObjectMenu::menu_action(MenuItem& item)
         m_object->update_version();
         refresh();
       });
+      break;
+    
+    case MNID_HIDE_LAYER:
+      if (m_object) 
+      {
+        TileMap* tilemap = static_cast<TileMap*>(m_object);
+        float current_alpha = tilemap->get_alpha();
+        if (current_alpha > 0.0f) 
+        {
+          tilemap->set_alpha(0.0f);
+        } 
+        else 
+        {
+          tilemap->set_alpha(1.0f);
+        }
+        m_editor.m_reactivate_request = true;
+        refresh();
+      }
+      MenuManager::instance().pop_menu();
       break;
 
     case MNID_PATCH_NOTES:

--- a/src/editor/object_menu.hpp
+++ b/src/editor/object_menu.hpp
@@ -29,6 +29,7 @@ class ObjectMenu final : public Menu
 public:
   enum {
     MNID_UPDATE,
+    MNID_HIDE_LAYER,
     MNID_PATCH_NOTES,
     MNID_REMOVE,
     MNID_REMOVEFUNCTION,


### PR DESCRIPTION
The Supertux level editor did not have a button to
hide individual layers.
Now this button is at the end of each layer menu.
The button does not appear on the selected layer,
as it does not make sense to hide the selected layer.
When someone decides to hide a layer other than
the selected one and then switches to it, that layer is shown
again. In addition, after hiding a layer, if the hidden layer
menu is opened again, instead of the hide layer button,
a show layer button appears.
The default opacity of 0.5 was kept as the default,
so that users do not find it strange or have to press
this implemented button.

Closes #517

Co-authored-by: Filipe Oleacu <filipeoleacu04@tecnico.ulisboa.pt>