### PR TITLE
Improve `FishSwimming`'s behaviour

### DIFF
--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -297,7 +297,7 @@ FishSwimming::active_update(float dt_sec)
           const float velocity_half_life_sec = 0.2f;
 
           float damping_multiplier = 1.0f;
-          if (dt_sec > 0.0f && velocity_half_life_sec > 0.0f)
+          if (dt_sec > 0.0f && velocity_half_life_sec)
           {
             damping_multiplier = std::pow(0.5f, dt_sec / velocity_half_life_sec);
           }

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -290,6 +290,15 @@ FishSwimming::active_update(float dt_sec)
             set_action("swim-right", -1);
           }
         }
+
+        if (std::abs(m_physic.get_velocity_x()) >= 5.f)
+        {
+          m_physic.set_velocity_x(m_physic.get_velocity_x() / 1.25f);
+        }
+        else if (m_physic.get_velocity_x() != 0.f) 
+        {
+          m_physic.set_velocity_x(0.f);
+        }
       }
     }
   }

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -121,20 +121,20 @@ FishSwimming::setup_velocity()
 {
   switch (m_dir)
   {
-  case Direction::LEFT:
-    m_physic.set_velocity_x(-FISH_PATROL_SPEED);
-    break;
-  case Direction::RIGHT:
-    m_physic.set_velocity_x(FISH_PATROL_SPEED);
-    break;
-  case Direction::UP:
-    m_physic.set_velocity_y(-FISH_PATROL_SPEED);
-    break;
-  case Direction::DOWN:
-    m_physic.set_velocity_y(FISH_PATROL_SPEED);
-    break;
-  default:
-    break;
+    case Direction::LEFT:
+      m_physic.set_velocity_x(-FISH_PATROL_SPEED);
+      break;
+    case Direction::RIGHT:
+      m_physic.set_velocity_x(FISH_PATROL_SPEED);
+      break;
+    case Direction::UP:
+      m_physic.set_velocity_y(-FISH_PATROL_SPEED);
+      break;
+    case Direction::DOWN:
+      m_physic.set_velocity_y(FISH_PATROL_SPEED);
+      break;
+    default:
+      break;
   }
 }
 
@@ -143,16 +143,16 @@ FishSwimming::is_frontal_hit(const CollisionHit& hit) const
 {
   switch (m_dir)
   {
-  case Direction::LEFT:
-    return hit.left;
-  case Direction::RIGHT:
-    return hit.right;
-  case Direction::UP:
-    return hit.top;
-  case Direction::DOWN:
-    return hit.bottom;
-  default:
-    return false;
+    case Direction::LEFT:
+      return hit.left;
+    case Direction::RIGHT:
+      return hit.right;
+    case Direction::UP:
+      return hit.top;
+    case Direction::DOWN:
+      return hit.bottom;
+    default:
+      return false;
   }
 }
 
@@ -200,10 +200,10 @@ FishSwimming::update(float dt_sec)
 {
   // Don't allow dying by going below the sector.
   if (BadGuy::get_state() != STATE_FALLING && !m_frozen &&
-    m_in_water && get_bbox().get_bottom() >= Sector::get().get_height())
+      m_in_water && get_bbox().get_bottom() >= Sector::get().get_height())
   {
     set_pos(Vector(get_bbox().get_left(),
-      Sector::get().get_height() - m_col.m_bbox.get_height()));
+            Sector::get().get_height() - m_col.m_bbox.get_height()));
   }
   BadGuy::update(dt_sec);
   //m_col.set_movement(m_physic.get_movement(dt_sec));

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -297,7 +297,7 @@ FishSwimming::active_update(float dt_sec)
           const float velocity_half_life_sec = 0.2f;
 
           float damping_multiplier = 1.0f;
-          if (dt_sec > 0.0f && velocity_half_life_sec)
+          if (dt_sec > 0.0f)
           {
             damping_multiplier = std::pow(0.5f, dt_sec / velocity_half_life_sec);
           }

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -23,8 +23,9 @@
 #include "supertux/tile.hpp"
 #include "util/reader_mapping.hpp"
 
-static const float FISH_BEACH_TIME = 5.f;
-static const float FISH_FLOAT_TIME = 2.f;
+constexpr float FISH_BEACH_TIME = 5.f;
+constexpr float FISH_FLOAT_TIME = 2.f;
+constexpr float FISH_PATROL_SPEED = 128.f;
 
 FishSwimming::FishSwimming(const ReaderMapping& reader) :
   BadGuy(reader, "images/creatures/fish/ice/bluefish.sprite"),
@@ -52,7 +53,8 @@ FishSwimming::FishSwimming(const ReaderMapping& reader, const std::string& sprit
 GameObjectTypes
 FishSwimming::get_types() const
 {
-  return {
+  return
+  {
     { "snow", _("Snow") },
     { "forest", _("Forest") },
     { "corrupted", _("Corrupted") }
@@ -64,12 +66,12 @@ FishSwimming::get_default_sprite_name() const
 {
   switch (m_type)
   {
-    case FOREST:
-      return "images/creatures/fish/forest/bluefish.sprite";
-    case CORRUPTED:
-      return "images/creatures/fish/forest/corrupted/corrupted_bluefish.sprite";
-    default:
-      return m_default_sprite_name;
+  case FOREST:
+    return "images/creatures/fish/forest/bluefish.sprite";
+  case CORRUPTED:
+    return "images/creatures/fish/forest/corrupted/corrupted_bluefish.sprite";
+  default:
+    return m_default_sprite_name;
   }
 }
 
@@ -84,10 +86,13 @@ FishSwimming::after_editor_set()
 {
   MovingSprite::after_editor_set();
 
-  if (m_start_dir == Direction::RIGHT || m_start_dir == Direction::DOWN) {
-      set_action("swim-right");
-  } else {
-      set_action("swim-left");
+  if (m_start_dir == Direction::RIGHT || m_start_dir == Direction::DOWN)
+  {
+    set_action("swim-right");
+  }
+  else
+  {
+    set_action("swim-left");
   }
 }
 
@@ -114,47 +119,48 @@ FishSwimming::initialize()
 void
 FishSwimming::setup_velocity()
 {
-  switch (m_dir) {
-    case Direction::LEFT:
-      m_physic.set_velocity_x(-128.f);
-      break;
-    case Direction::RIGHT:
-      m_physic.set_velocity_x(128.f);
-      break;
-    case Direction::UP:
-      m_physic.set_velocity_y(-128.f);
-      set_action("swim-right", -1);
-      break;
-    case Direction::DOWN:
-      m_physic.set_velocity_y(128.f);
-      set_action("swim-right", -1);
-      break;
-    default:
-      break;
+  switch (m_dir)
+  {
+  case Direction::LEFT:
+    m_physic.set_velocity_x(-FISH_PATROL_SPEED);
+    break;
+  case Direction::RIGHT:
+    m_physic.set_velocity_x(FISH_PATROL_SPEED);
+    break;
+  case Direction::UP:
+    m_physic.set_velocity_y(-FISH_PATROL_SPEED);
+    break;
+  case Direction::DOWN:
+    m_physic.set_velocity_y(FISH_PATROL_SPEED);
+    break;
+  default:
+    break;
   }
 }
 
 bool
 FishSwimming::is_frontal_hit(const CollisionHit& hit) const
 {
-  switch (m_dir) {
-    case Direction::LEFT:
-      return hit.left;
-    case Direction::RIGHT:
-      return hit.right;
-    case Direction::UP:
-      return hit.top;
-    case Direction::DOWN:
-      return hit.bottom;
-    default:
-      return false;
+  switch (m_dir)
+  {
+  case Direction::LEFT:
+    return hit.left;
+  case Direction::RIGHT:
+    return hit.right;
+  case Direction::UP:
+    return hit.top;
+  case Direction::DOWN:
+    return hit.bottom;
+  default:
+    return false;
   }
 }
 
 void
 FishSwimming::collision_solid(const CollisionHit& hit)
 {
-  if (m_frozen) {
+  if (m_frozen)
+  {
     BadGuy::collision_solid(hit);
   }
   else
@@ -180,7 +186,7 @@ HitResponse
 FishSwimming::collision_badguy(BadGuy& badguy, const CollisionHit& hit)
 {
   if (m_beached_timer.started())
-     collision_solid(hit);
+    collision_solid(hit);
 
   if (!m_frozen && !m_beached_timer.started() && is_frontal_hit(hit))
     turn_around();
@@ -194,17 +200,18 @@ FishSwimming::update(float dt_sec)
 {
   // Don't allow dying by going below the sector.
   if (BadGuy::get_state() != STATE_FALLING && !m_frozen &&
-      m_in_water && get_bbox().get_bottom() >= Sector::get().get_height())
+    m_in_water && get_bbox().get_bottom() >= Sector::get().get_height())
   {
     set_pos(Vector(get_bbox().get_left(),
-                   Sector::get().get_height() - m_col.m_bbox.get_height()));
+      Sector::get().get_height() - m_col.m_bbox.get_height()));
   }
   BadGuy::update(dt_sec);
   //m_col.set_movement(m_physic.get_movement(dt_sec));
 }
 
 void
-FishSwimming::active_update(float dt_sec) {
+FishSwimming::active_update(float dt_sec)
+{
   // Perform basic updates.
   BadGuy::active_update(dt_sec);
   m_in_water = !Sector::get().is_free_of_tiles(get_bbox(), true, Tile::WATER);
@@ -232,7 +239,8 @@ FishSwimming::active_update(float dt_sec) {
   {
     if (m_state == FishYState::DISRUPTED)
     {
-      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT) {
+      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT)
+      {
         if (std::abs(m_physic.get_velocity_y()) >= 5.f) {
           m_physic.set_velocity_y(m_physic.get_velocity_y() / 1.25f);
         }
@@ -242,8 +250,11 @@ FishSwimming::active_update(float dt_sec) {
           m_physic.set_velocity_y(0.f);
           m_start_position.y = get_pos().y;
         }
-      } else {
-        if (std::abs(m_physic.get_velocity_x()) >= 5.f) {
+      }
+      else
+      {
+        if (std::abs(m_physic.get_velocity_x()) >= 5.f)
+        {
           m_physic.set_velocity_x(m_physic.get_velocity_x() / 1.25f);
         }
         else
@@ -261,53 +272,128 @@ FishSwimming::active_update(float dt_sec) {
       {
         yspeed = yspeed * -1.f;
       }
-      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT) {
+      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT)
+      {
         m_physic.set_velocity_y(yspeed);
       }
       else
       {
-        if (m_physic.get_velocity_x() > 0 && yspeed < 0) {
-          set_action("swim-left", -1);
-        }
-        else if (m_physic.get_velocity_x() < 0 && yspeed > 0)
+        Player* player = Sector::get().get_nearest_player(get_pos());
+        if (player)
         {
-          set_action("swim-right", -1);
+          if (player->get_pos().x < get_pos().x)
+          {
+            set_action("swim-left", -1);
+          }
+          else if (player->get_pos().x > get_pos().x)
+          {
+            set_action("swim-right", -1);
+          }
         }
-        m_physic.set_velocity_x(yspeed);
       }
     }
   }
 
   if (!m_beached_timer.started())
   {
-    // Handle x-velocity related functionality.
-    switch (m_dir) {
-      case Direction::LEFT: {
-        float goal_x_velocity = -128.f;
-        if (get_pos().x < (m_start_position.x - m_radius + 20.f))
-          goal_x_velocity = 128.f;
-        maintain_velocity_x(goal_x_velocity);
-      } break;
-      case Direction::RIGHT: {
-        float goal_x_velocity = 128.f;
-        if (get_pos().x > (m_start_position.x + m_radius - 20.f))
-          goal_x_velocity = -128.f;
-        maintain_velocity_x(goal_x_velocity);
-      } break;
-      case Direction::UP: {
-        float goal_y_velocity = -128.f;
-        if (get_pos().y < (m_start_position.y - m_radius + 20.f))
-          goal_y_velocity = 128.f;
-        maintain_velocity_y(goal_y_velocity);
-      } break;
-      case Direction::DOWN: {
-        float goal_y_velocity = 128.f;
-        if (get_pos().y > (m_start_position.y + m_radius - 20.f))
-          goal_y_velocity = -128.f;
-        maintain_velocity_y(goal_y_velocity);
-      } break;
+    const float turn_initiation_offset = FISH_PATROL_SPEED / 2.0f;
+
+    // Smooth turn requires radius > initiation distance to avoid jitter.
+    bool use_smooth_turn = (m_radius > turn_initiation_offset);
+
+    if (use_smooth_turn)
+    {
+      switch (m_dir)
+      {
+      case Direction::LEFT:
+        {
+          float goal_x_velocity = -FISH_PATROL_SPEED;
+          if (get_pos().x <= (m_start_position.x - m_radius + turn_initiation_offset))
+          {
+            goal_x_velocity = FISH_PATROL_SPEED;
+          }
+          maintain_velocity_x(goal_x_velocity);
+        }
+        break;
+      case Direction::RIGHT:
+        {
+          float goal_x_velocity = FISH_PATROL_SPEED;
+          if (get_pos().x >= (m_start_position.x + m_radius - turn_initiation_offset))
+          {
+            goal_x_velocity = -FISH_PATROL_SPEED;
+          }
+          maintain_velocity_x(goal_x_velocity);
+        }
+        break;
+      case Direction::UP:
+        {
+          float goal_y_velocity = -FISH_PATROL_SPEED;
+          if (get_pos().y <= (m_start_position.y - m_radius + turn_initiation_offset))
+          {
+            goal_y_velocity = FISH_PATROL_SPEED;
+          }
+          maintain_velocity_y(goal_y_velocity);
+        }
+        break;
+      case Direction::DOWN:
+        {
+          float goal_y_velocity = FISH_PATROL_SPEED;
+          if (get_pos().y >= (m_start_position.y + m_radius - turn_initiation_offset))
+          {
+            goal_y_velocity = -FISH_PATROL_SPEED;
+          }
+          maintain_velocity_y(goal_y_velocity);
+        }
+        break;
       default:
         break;
+      }
+    }
+
+    // The radius is too small for a smooth turn; hence perform an instantanious turn
+    // in order to respect the boundary.
+    else
+    {
+      switch (m_dir)
+      {
+      case Direction::LEFT:
+        if (get_pos().x <= (m_start_position.x - m_radius))
+        {
+          turn_around();
+        }
+        break;
+      case Direction::RIGHT:
+        if (get_pos().x >= (m_start_position.x + m_radius))
+        {
+          turn_around();
+        }
+        break;
+      case Direction::UP:
+        if (get_pos().y <= (m_start_position.y - m_radius))
+        {
+          turn_around();
+        }
+        break;
+      case Direction::DOWN:
+        if (get_pos().y >= (m_start_position.y + m_radius))
+        {
+          turn_around();
+        }
+        break;
+      default:
+        break;
+      }
+
+      if (m_dir == Direction::LEFT || m_dir == Direction::RIGHT)
+      {
+        const float target_vel_x = (m_dir == Direction::LEFT) ? -FISH_PATROL_SPEED : FISH_PATROL_SPEED;
+        maintain_velocity_x(target_vel_x);
+      }
+      else if (m_dir == Direction::UP || m_dir == Direction::DOWN)
+      {
+        const float target_vel_y = (m_dir == Direction::UP) ? -FISH_PATROL_SPEED : FISH_PATROL_SPEED;
+        maintain_velocity_y(target_vel_y);
+      }
     }
   }
 }
@@ -340,7 +426,9 @@ FishSwimming::turn_around()
     return;
 
   m_dir = invert_dir(m_dir);
-  set_action("swim", m_dir);
+
+  if (m_dir != Direction::UP && m_dir != Direction::DOWN)
+    set_action("swim", m_dir);
   setup_velocity();
 }
 
@@ -353,22 +441,25 @@ FishSwimming::maintain_velocity_x(float goal_x_velocity)
   float current_x_velocity = m_physic.get_velocity_x();
   /* We're very close to our target speed. Just set it to avoid oscillation. */
   if ((current_x_velocity > (goal_x_velocity - 5.0f)) &&
-    (current_x_velocity < (goal_x_velocity + 5.0f)))
+     (current_x_velocity < (goal_x_velocity + 5.0f)))
   {
     m_physic.set_velocity_x(goal_x_velocity);
     m_physic.set_acceleration_x(0.0);
   }
   /* Check if we're going too slow or even in the wrong direction. */
   else if (((goal_x_velocity <= 0.0f) && (current_x_velocity > goal_x_velocity)) ||
-    ((goal_x_velocity > 0.0f) && (current_x_velocity < goal_x_velocity))) {
+          ((goal_x_velocity > 0.0f) && (current_x_velocity < goal_x_velocity)))
+  {
     m_physic.set_acceleration_x(goal_x_velocity);
   }
   /* Check if we're going too fast. */
   else if (((goal_x_velocity <= 0.0f) && (current_x_velocity < goal_x_velocity)) ||
-    ((goal_x_velocity > 0.0f) && (current_x_velocity > goal_x_velocity))) {
+          ((goal_x_velocity > 0.0f) && (current_x_velocity > goal_x_velocity)))
+  {
     m_physic.set_acceleration_x((-1.f) * goal_x_velocity);
   }
-  else {
+  else
+  {
     /* The above should have covered all cases. */
     assert(false);
   }
@@ -394,22 +485,25 @@ FishSwimming::maintain_velocity_y(float goal_y_velocity)
   float current_y_velocity = m_physic.get_velocity_y();
   /* We're very close to our target speed. Just set it to avoid oscillation. */
   if ((current_y_velocity > (goal_y_velocity - 5.0f)) &&
-    (current_y_velocity < (goal_y_velocity + 5.0f)))
+     (current_y_velocity < (goal_y_velocity + 5.0f)))
   {
     m_physic.set_velocity_y(goal_y_velocity);
     m_physic.set_acceleration_y(0.0);
   }
   /* Check if we're going too slow or even in the wrong direction. */
   else if (((goal_y_velocity <= 0.0f) && (current_y_velocity > goal_y_velocity)) ||
-    ((goal_y_velocity > 0.0f) && (current_y_velocity < goal_y_velocity))) {
+          ((goal_y_velocity > 0.0f) && (current_y_velocity < goal_y_velocity)))
+  {
     m_physic.set_acceleration_y(goal_y_velocity);
   }
   /* Check if we're going too fast. */
   else if (((goal_y_velocity <= 0.0f) && (current_y_velocity < goal_y_velocity)) ||
-    ((goal_y_velocity > 0.0f) && (current_y_velocity > goal_y_velocity))) {
+          ((goal_y_velocity > 0.0f) && (current_y_velocity > goal_y_velocity)))
+  {
     m_physic.set_acceleration_y((-1.f) * goal_y_velocity);
   }
-  else {
+  else
+  {
     /* The above should have covered all cases. */
     assert(false);
   }

--- a/src/badguy/fish_swimming.cpp
+++ b/src/badguy/fish_swimming.cpp
@@ -291,13 +291,24 @@ FishSwimming::active_update(float dt_sec)
           }
         }
 
-        if (std::abs(m_physic.get_velocity_x()) >= 5.f)
+        float current_vx = m_physic.get_velocity_x();
+        if (current_vx != 0.f)
         {
-          m_physic.set_velocity_x(m_physic.get_velocity_x() / 1.25f);
-        }
-        else if (m_physic.get_velocity_x() != 0.f) 
-        {
-          m_physic.set_velocity_x(0.f);
+          const float velocity_half_life_sec = 0.2f;
+
+          float damping_multiplier = 1.0f;
+          if (dt_sec > 0.0f && velocity_half_life_sec > 0.0f)
+          {
+            damping_multiplier = std::pow(0.5f, dt_sec / velocity_half_life_sec);
+          }
+
+          current_vx *= damping_multiplier;
+
+          if (std::abs(current_vx) < 0.05f)
+          {
+            current_vx = 0.f;
+          }
+          m_physic.set_velocity_x(current_vx);
         }
       }
     }


### PR DESCRIPTION
The current behavior for Direction::UP and Direction::DOWN is not desirable. Now the fish no longer sways along the X-axis and now moves strictly along the Y-axis. Previously, small radius values caused the fish to stop after a few turns due to an oversight - this now has been addressed.