### PR TITLE
Fixes #3199 - Coins carry support for Owl enemy

### DIFF
--- a/src/object/coin.hpp
+++ b/src/object/coin.hpp
@@ -20,13 +20,15 @@
 #include "object/path_object.hpp"
 #include "object/moving_sprite.hpp"
 #include "supertux/physic.hpp"
+#include "object/portable.hpp"
 
 class Path;
 class PathWalker;
 class TileMap;
 
 class Coin : public MovingSprite,
-             public PathObject
+             public PathObject,
+             public Portable
 {
   friend class HeavyCoin;
 
@@ -45,6 +47,9 @@ public:
   virtual std::string get_display_name() const override { return display_name(); }
   virtual GameObjectClasses get_class_types() const override { return MovingSprite::get_class_types().add(typeid(PathObject)).add(typeid(Coin)); }
 
+  virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
+  virtual void ungrab(MovingObject& object, Direction dir) override;
+
   virtual ObjectSettings get_settings() override;
   GameObjectTypes get_types() const override;
   std::string get_default_sprite_name() const override;
@@ -62,6 +67,17 @@ public:
   virtual void on_flip(float height) override;
 
   void collect();
+
+protected:
+  bool m_on_ground;
+  bool m_on_ice;
+  bool m_at_ceiling;
+  Vector m_last_movement;
+  std::string m_on_grab_script;
+  std::string m_on_ungrab_script;
+  bool m_running_grab_script;
+  bool m_running_ungrab_script;
+  float m_last_sector_gravity;
 
 private:
   enum Type {

--- a/src/object/coin_explode.cpp
+++ b/src/object/coin_explode.cpp
@@ -18,19 +18,52 @@
 
 #include "math/random.hpp"
 #include "object/coin.hpp"
+#include "sprite/sprite.hpp"
+#include "sprite/sprite_manager.hpp"
 #include "supertux/sector.hpp"
 
 #include <list>
 
 CoinExplode::CoinExplode(const Vector& pos, bool count_stats, const std::string& sprite) :
+  GameObject("coin-explode"),
   m_sprite(sprite),
   position(pos),
   m_count_stats(count_stats)
 {
 }
 
+CoinExplode::CoinExplode(const ReaderMapping& reader) :
+  GameObject(reader),
+  m_sprite("images/objects/coin/coin.sprite"),
+  position(),
+  m_count_stats(true)
+{
+  reader.get("x", position.x);
+  reader.get("y", position.y);
+  bool emerge = false;
+}
+
 void
-CoinExplode::update(float )
+CoinExplode::update(float dt_sec)
+{
+  if (is_grabbed()) 
+    // Don't do anything while being carried
+    return;
+}
+
+void
+CoinExplode::draw(DrawingContext& context)
+{
+  // Draw the coin sprite so it's visible
+  auto sprite = SpriteManager::current()->create(m_sprite);
+  if (sprite) 
+  {
+    sprite->draw(context.color(), position, LAYER_OBJECTS);
+  }
+}
+
+void
+CoinExplode::explode()
 {
   float mag = 100.0f; // Magnitude at which coins are thrown.
   float rand = 30.0f; // Max variation to be subtracted from the magnitude.
@@ -53,8 +86,22 @@ CoinExplode::update(float )
 }
 
 void
-CoinExplode::draw(DrawingContext &)
+CoinExplode::grab(MovingObject& object, const Vector& pos, Direction dir)
 {
+  position = pos;
+  Portable::grab(object, pos, dir);
 }
+
+void
+CoinExplode::ungrab(MovingObject& object, Direction dir)
+{
+  position = object.get_pos();
+  
+  // Explode immediately when ungrabbed
+  explode();
+  
+  Portable::ungrab(object, dir);
+}
+
 
 /* EOF */

--- a/src/object/coin_explode.hpp
+++ b/src/object/coin_explode.hpp
@@ -19,23 +19,37 @@
 
 #include "math/vector.hpp"
 #include "supertux/game_object.hpp"
+#include "object/portable.hpp"
+#include "util/reader_mapping.hpp"
 
-class CoinExplode final : public GameObject
+class CoinExplode final : public GameObject,
+                          public Portable
 {
 public:
   CoinExplode(const Vector& pos, bool count_stats = true,
               const std::string& sprite_path = "images/objects/coin/coin.sprite");
+  CoinExplode(const ReaderMapping& reader);
   virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(CoinExplode)); }
+  static std::string class_name() { return "coin_explode"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Coin Explode"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+  virtual bool is_portable() const override { return true; }
+  
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual bool is_saveable() const override {
     return false;
   }
+  
+  virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
+  virtual void ungrab(MovingObject& object, Direction dir) override;
 
 private:
   std::string m_sprite;
   Vector position;
   const bool m_count_stats;
+  void explode();
 };
 
 #endif

--- a/src/object/coin_rain.cpp
+++ b/src/object/coin_rain.cpp
@@ -39,9 +39,35 @@ CoinRain::CoinRain(const Vector& pos, bool emerge, bool count_stats, const std::
   }
 }
 
+CoinRain::CoinRain(const ReaderMapping& reader) :
+  GameObject(reader),
+  sprite(SpriteManager::current()->create("images/objects/coin/coin.sprite")),
+  m_sprite_path("images/objects/coin/coin.sprite"),
+  position(),
+  emerge_distance(0),
+  timer(),
+  counter(0),
+  drop(0),
+  m_count_stats(true)
+{
+  reader.get("x", position.x);
+  reader.get("y", position.y);
+  bool emerge = false;
+  reader.get("emerge", emerge);
+  
+  if (emerge) 
+  {
+    emerge_distance = static_cast<float>(sprite->get_height());
+  }
+}
+
 void
 CoinRain::update(float dt_sec)
 {
+  if (is_grabbed()) 
+    // Don't do anything while being carried
+    return;
+
   // First a single (untouchable) coin flies up above the sector.
   if (position.y > -32){
     float dist = -500 * dt_sec;
@@ -79,6 +105,25 @@ CoinRain::draw(DrawingContext& context)
     layer = LAYER_OBJECTS + 5;
   }
   sprite->draw(context.color(), position, layer);
+}
+
+void
+CoinRain::grab(MovingObject& object, const Vector& pos, Direction dir)
+{
+  position = pos;
+  Portable::grab(object, pos, dir);
+}
+
+void
+CoinRain::ungrab(MovingObject& object, Direction dir)
+{
+  // Reset counter to start coin rain effect
+  counter = 0;
+  drop = 0;
+  timer.stop();
+  
+  position = object.get_pos();
+  Portable::ungrab(object, dir);
 }
 
 /* EOF */

--- a/src/object/coin_rain.hpp
+++ b/src/object/coin_rain.hpp
@@ -20,19 +20,34 @@
 #include "math/vector.hpp"
 #include "sprite/sprite_ptr.hpp"
 #include "supertux/game_object.hpp"
+#include "object/portable.hpp"
 #include "supertux/timer.hpp"
+#include "util/reader_mapping.hpp"
 
-class CoinRain final : public GameObject
+class CoinRain final :  public GameObject,
+                        public Portable
 {
 public:
   CoinRain(const Vector& pos, bool emerge=false, bool count_stats = true,
            const std::string& sprite_path = "images/objects/coin/coin.sprite");
+  CoinRain(const ReaderMapping& reader);
   virtual GameObjectClasses get_class_types() const override { return GameObject::get_class_types().add(typeid(CoinRain)); }
+
+  static std::string class_name() { return "coin_rain"; }
+  virtual std::string get_class_name() const override { return class_name(); }
+  static std::string display_name() { return _("Coin Rain"); }
+  virtual std::string get_display_name() const override { return display_name(); }
+  
   virtual void update(float dt_sec) override;
   virtual void draw(DrawingContext& context) override;
   virtual bool is_saveable() const override {
     return false;
   }
+
+  virtual bool is_portable() const override { return true; }
+  
+  virtual void grab(MovingObject& object, const Vector& pos, Direction dir) override;
+  virtual void ungrab(MovingObject& object, Direction dir) override;
 
 private:
   SpritePtr sprite;

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -96,6 +96,8 @@
 #include "object/custom_particle_system.hpp"
 #include "object/custom_particle_system_file.hpp"
 #include "object/coin.hpp"
+#include "object/coin_explode.hpp"
+#include "object/coin_rain.hpp"
 #include "object/conveyor_belt.hpp"
 #include "object/decal.hpp"
 #include "object/display_effect.hpp"
@@ -266,7 +268,9 @@ GameObjectFactory::init_factories()
   add_factory<ConveyorBelt>("conveyor-belt");
   add_factory<CustomParticleSystem>("particles-custom");
   add_factory<CustomParticleSystemFile>("particles-custom-file");
-  add_factory<Coin>("coin", OBJ_PARAM_DISPENSABLE);
+  add_factory<Coin>("coin", OBJ_PARAM_PORTABLE | OBJ_PARAM_DISPENSABLE);
+  add_factory<CoinRain>("coin_rain", OBJ_PARAM_PORTABLE | OBJ_PARAM_DISPENSABLE);
+  add_factory<CoinExplode>("coin_explode", OBJ_PARAM_PORTABLE | OBJ_PARAM_DISPENSABLE);
   add_factory<Decal>("decal", OBJ_PARAM_WORLDMAP);
   add_factory<Explosion>("explosion", OBJ_PARAM_DISPENSABLE);
   add_factory<FallBlock>("fallblock", OBJ_PARAM_DISPENSABLE);


### PR DESCRIPTION
Added the possibility for the owl to carry three new types
of objects, coin, coin rain and coin explosion.
Since the owl cannot visually carry a coin rain or a
coin explosion, then visually the owl for these types carries
a single coin, but then when the owl ungrabs the coin,
the behavior is of a coin rain or a coin explosion respectively.
The coin drop is activated when the tux approaches.

Closes #3199