### PR TITLE
[DON'T MERGE] Add -debug flag to hdiutil to figure out packaging failures on MacOS

### DIFF
--- a/.ci_scripts/package.sh
+++ b/.ci_scripts/package.sh
@@ -9,7 +9,7 @@ if ([ "$OS_NAME" = "macos-10.15" ] || [ "$OS_NAME" = "macos-13" ]) && [ "$PACKAG
     # https://github.com/actions/runner-images/issues/7522
     i=0
     until
-        cpack -G Bundle;
+        sudo cpack -G Bundle;
         
         base_path="/Users/runner/work/supertux/supertux/build/_CPack_Packages/Darwin/Bundle"
         maybe_target=$(find $base_path -type d -depth -mindepth 1 -maxdepth 1)


### PR DESCRIPTION
This isn't a PR that needs to get merged. I just want to see whether this works. 

Currently, our MacOS builds fail with a resource busy error a lot of times. Github support is unsure why (see https://github.com/actions/runner-images/issues/7522). 

I (hopefully) modified the cmake command to add the -verbose flag so we can see what's going on.

See https://ss64.com/mac/hdiutil.html for HDIUTIL syntax and https://cmake.org/cmake/help/v4.0/cpack_gen/dmg.html#variable:CPACK_COMMAND_HDIUTIL for the CMake variable.