### PR TITLE
Kill player on crusher's impact

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2374,7 +2374,7 @@ Player::collision_solid(const CollisionHit& hit)
   }
 
   if (hit.crush)
-    kill(false);
+    kill(true);
 
   if ((hit.left && m_boost < 0.f) || (hit.right && m_boost > 0.f))
     m_boost = 0.f;


### PR DESCRIPTION
Fixing player getting pushed in wall when standing on icebreaker (or by anything else) by killing the player instantly which also is bit more realistic. Closes #3314
Edit: Sorry for writing the same pull request again, I moved the branch as I found out I accidentally wanted to merge my master branch.