### PR TITLE
Fix notorious crash when switching worlds

### DIFF
--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -44,6 +44,9 @@ public:
 public:
   WorldMap(const std::string& filename, Savegame& savegame,
            const std::string& force_sector = "", const std::string& force_spawnpoint = "");
+  
+  void load(const std::string& filename, Savegame& savegame,
+            const std::string& force_sector = "", const std::string& force_spawnpoint = "");
 
   void setup() override;
   void leave() override;
@@ -81,7 +84,7 @@ public:
   inline void set_initial_spawnpoint(const std::string& spawnpoint) { m_force_spawnpoint = spawnpoint; }
 
   inline const std::string& get_title() const { return m_name; }
-  inline Savegame& get_savegame() const { return m_savegame; }
+  inline Savegame& get_savegame() const { return *m_savegame; }
   inline const std::string& get_levels_path() const { return m_levels_path; }
 
   WorldMapSector* get_sector(const std::string& name) const;
@@ -107,7 +110,7 @@ private:
 
   std::string m_force_spawnpoint;
 
-  Savegame& m_savegame;
+  Savegame* m_savegame;
   TileSet* m_tileset;
 
   std::string m_name;
@@ -115,7 +118,7 @@ private:
   std::string m_levels_path;
 
   /* A worldmap, scheduled to change to next frame. */
-  std::unique_ptr<WorldMap> m_next_worldmap;
+  bool m_next_worldmap;
 
   /** Passive map message variables */
   std::string m_passive_message;
@@ -125,6 +128,10 @@ private:
   bool m_enter_level;
   bool m_in_level;
   bool m_in_world_select;
+  
+  std::string m_next_filename;
+  std::string m_next_force_sector;
+  std::string m_next_force_spawnpoint;
 
 private:
   WorldMap(const WorldMap&) = delete;

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -355,7 +355,7 @@ WorldMapSector::update(float dt_sec)
                                     level_->get_pos().y +  8 - m_camera->get_offset().y);
           std::string levelfile = m_parent.m_levels_path + level_->get_level_filename();
 
-          auto game_session = std::make_unique<GameSession>(levelfile, m_parent.m_savegame, &level_->get_statistics());
+          auto game_session = std::make_unique<GameSession>(levelfile, m_parent.get_savegame(), &level_->get_statistics());
           game_session->restart_level();
 
           // update state and savegame

--- a/src/worldmap/worldmap_state.cpp
+++ b/src/worldmap/worldmap_state.cpp
@@ -317,7 +317,7 @@ WorldMapState::save_state() const
     log_warning << "Failed to save worldmap state: " << err.what() << std::endl;
   }
 
-  m_worldmap.m_savegame.save();
+  m_worldmap.get_savegame().save();
 }
 
 } // namespace worldmap


### PR DESCRIPTION
Previously, the WorldMap::change() method would create a unique pointer that replaces the which would clobber the Currenton state of the worldmap by pushing a new screen. However, this screws up the Currenton instance making it null at some point due to how it's freed.

This changes how the WorldMap initializes. WorldMap::change() instead simply changes it's state in-place.

May fix some other occasional issues that occured with the WorldMap.

Fixes #3280, #3130, etc...

Testing encouraged.