### PR TITLE
Save game on SDL exit

### DIFF
--- a/src/supertux/game_manager.cpp
+++ b/src/supertux/game_manager.cpp
@@ -39,6 +39,13 @@ GameManager::GameManager() :
 }
 
 void
+GameManager::save()
+{
+  if (m_savegame)
+    m_savegame->save();
+}
+
+void
 GameManager::start_level(const World& world, const std::string& level_filename,
                          const std::optional<std::pair<std::string, Vector>>& start_pos)
 {

--- a/src/supertux/game_manager.hpp
+++ b/src/supertux/game_manager.hpp
@@ -31,6 +31,8 @@ class GameManager final : public Currenton<GameManager>
 {
 public:
   GameManager();
+  
+  void save();
 
   bool start_worldmap(const World& world, const std::string& worldmap_filename = "",
                       const std::string& sector = "", const std::string& spawnpoint = "");

--- a/src/supertux/screen_manager.cpp
+++ b/src/supertux/screen_manager.cpp
@@ -31,6 +31,7 @@
 #include "supertux/constants.hpp"
 #include "supertux/controller_hud.hpp"
 #include "supertux/debug.hpp"
+#include "supertux/game_manager.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
@@ -182,6 +183,8 @@ void
 ScreenManager::quit(std::unique_ptr<ScreenFade> screen_fade)
 {
   Integration::close_all();
+
+  GameManager::current()->save();
 
 #ifdef __EMSCRIPTEN__
   g_config->save();


### PR DESCRIPTION
The game does not bother saving when the user exits the game via the window (or keybinds, etc). This fixes that.