### PR TITLE
Don't assert ssq_vm if the VM exits

### DIFF
--- a/src/squirrel/supertux_api.cpp
+++ b/src/squirrel/supertux_api.cpp
@@ -164,8 +164,7 @@ static bool check_cutscene()
 static SQInteger wait(HSQUIRRELVM vm, float seconds, bool forced = false)
 {
   ssq::VM* ssq_vm = ssq::VM::get(vm);
-  assert(ssq_vm);
-  if (ssq_vm && !ssq_vm->isThread()) return 0;
+  if ((!ssq_vm) || (ssq_vm && !ssq_vm->isThread())) return 0;
 
   if (!forced)
   {
@@ -312,7 +311,7 @@ static void load_level(const std::string& filename)
 static void import(HSQUIRRELVM vm, const std::string& filename)
 {
   ssq::VM* ssq_vm = ssq::VM::get(vm);
-  assert(ssq_vm);
+  if (!ssq_vm) return;
 
   IFileStream in(filename);
   ssq_vm->run(ssq_vm->compileSource(in, filename.c_str()));


### PR DESCRIPTION
As an example, the logo is missing on world1/intro.stl which causes the wait call to fail since ssq_vm is null. Just return instead.

Fixes #3337, #3323 (maybe), #3295. Possibly fixes #3190 but unsure.

Not sure why so many people play with debug builds :-)