### PR TITLE
Fix Tux' velocity on frozen enemy

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2415,6 +2415,7 @@ Player::collision(MovingObject& other, const CollisionHit& hit)
 
     if (hit.bottom && badguy->is_frozen())
       m_on_ground_flag = true;
+      m_physic.set_velocity_y(0);
   }
 
   return CONTINUE;


### PR DESCRIPTION
Addition to #3232 . Tux' velocity increased while being on a jumping frozen enemy. I fixed it by setting the velocity to zero.