### PR TITLE
Use system-native cursor for custom cursor

### DIFF
--- a/src/gui/mousecursor.hpp
+++ b/src/gui/mousecursor.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include <SDL_mouse.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "config.h"
@@ -60,6 +62,7 @@ public:
 
 private:
   void apply_state(MouseCursorState state);
+  void set_cursor_action(const std::string& action);
 
 private:
   MouseCursorState m_state;
@@ -68,6 +71,8 @@ private:
   int m_x, m_y;
   bool m_mobile_mode;
   SurfacePtr m_icon;
+  
+  std::unordered_map<std::string, std::shared_ptr<SDL_Cursor>> m_cursors;
 
 private:
   MouseCursor(const MouseCursor&) = delete;

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -79,6 +79,7 @@ Config::Config() :
   confirmation_dialog(false),
   pause_on_focusloss(true),
   custom_mouse_cursor(true),
+  custom_system_cursor(true),
   do_release_check(false),
   disable_network(true),
   custom_title_levels(true),
@@ -152,6 +153,7 @@ Config::load()
   config_mapping.get("confirmation_dialog", confirmation_dialog);
   config_mapping.get("pause_on_focusloss", pause_on_focusloss);
   config_mapping.get("custom_mouse_cursor", custom_mouse_cursor);
+  config_mapping.get("custom_system_cursor", custom_system_cursor);
   config_mapping.get("do_release_check", do_release_check);
   config_mapping.get("disable_network", disable_network);
   config_mapping.get("custom_title_levels", custom_title_levels);
@@ -373,6 +375,7 @@ Config::save()
   writer.write("confirmation_dialog", confirmation_dialog);
   writer.write("pause_on_focusloss", pause_on_focusloss);
   writer.write("custom_mouse_cursor", custom_mouse_cursor);
+  writer.write("custom_system_cursor", custom_system_cursor);
   writer.write("do_release_check", do_release_check);
   writer.write("disable_network", disable_network);
   writer.write("custom_title_levels", custom_title_levels);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -111,6 +111,7 @@ public:
   bool confirmation_dialog;
   bool pause_on_focusloss;
   bool custom_mouse_cursor;
+  bool custom_system_cursor;
   bool do_release_check;
   bool disable_network;
   bool custom_title_levels;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -465,7 +465,8 @@ Main::init_video()
   SDLSurfacePtr icon = SDLSurface::from_file(icon_fname);
   VideoSystem::current()->set_icon(*icon);
 
-  SDL_ShowCursor(g_config->custom_mouse_cursor ? 0 : 1);
+  SDL_ShowCursor(
+    (g_config->custom_mouse_cursor && !g_config->custom_system_cursor) ? SDL_DISABLE : SDL_ENABLE);
 
   log_info << (g_config->use_fullscreen?"fullscreen ":"window ")
            << " Window: "     << g_config->window_size

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -227,6 +227,8 @@ OptionsMenu::refresh()
         .set_help(_("Automatically pause the game when the window loses focus"));
 
       add_toggle(MNID_CUSTOM_CURSOR, _("Use custom mouse cursor"), &g_config->custom_mouse_cursor).set_help(_("Whether the game renders its own cursor or uses the system's cursor"));
+      
+      add_toggle(MNID_CUSTOM_CURSOR, _("Use native custom cursor"), &g_config->custom_system_cursor).set_help(_("Whether the game uses a native custom cursor or renders it in the game"));
 
 #ifndef __EMSCRIPTEN__
       if (!g_config->disable_network)


### PR DESCRIPTION
Currently, the game draws the cursor as it's own sprite. This is fine in most cases, however, this will cause some input lag when the user moves their cursor. This is because the sprite cursor is drawn on every flip, which may lag behind the actual system refresh rate.

The OS (which SDL interfaces) has it's own cursor api, and therefore is preferred, since that sets the display systems physical cursor instead of rendering our own.

The player can choose if they want the game to render the cursor or if it should be drawn natively.