### PR TITLE
Implement ice physics for BadGuy enemies

### DIFF
--- a/src/badguy/badguy.cpp
+++ b/src/badguy/badguy.cpp
@@ -47,6 +47,10 @@ static const float FADEOUT_TIME = 0.2f;
 static const float X_OFFSCREEN_DISTANCE = 1280;
 static const float Y_OFFSCREEN_DISTANCE = 800;
 
+/** Ice physics constants (similar to player ice physics) */
+static const float BADGUY_ICE_FRICTION_MULTIPLIER = 0.1f;
+static const float BADGUY_ICE_ACCELERATION_MULTIPLIER = 0.25f;
+
 BadGuy::BadGuy(const Vector& pos, const std::string& sprite_name, int layer,
                const std::string& light_sprite_name, const std::string& ice_sprite_name,
                const std::string& fire_sprite_name) :
@@ -67,6 +71,8 @@ BadGuy::BadGuy(const Vector& pos, Direction direction, const std::string& sprite
   m_frozen(false),
   m_ignited(false),
   m_in_water(false),
+  m_on_ice(false),
+  m_ice_this_frame(false),
   m_dead_script(),
   m_melting_time(0),
   m_lightsprite(SpriteManager::current()->create(light_sprite_name)),
@@ -120,6 +126,8 @@ BadGuy::BadGuy(const ReaderMapping& reader, const std::string& sprite_name,
   m_frozen(false),
   m_ignited(false),
   m_in_water(false),
+  m_on_ice(false),
+  m_ice_this_frame(false),
   m_dead_script(),
   m_melting_time(0),
   m_lightsprite(SpriteManager::current()->create(light_sprite_name)),
@@ -440,6 +448,12 @@ BadGuy::get_allowed_directions() const
 void
 BadGuy::active_update(float dt_sec)
 {
+  // Manage ice state each frame
+  if (!m_ice_this_frame && on_ground()) {
+    m_on_ice = false;
+  }
+  m_ice_this_frame = false;
+
   if (!is_grabbed())
   {
     if (is_in_water() && m_water_affected)
@@ -455,6 +469,9 @@ BadGuy::active_update(float dt_sec)
       m_col.set_movement(m_physic.get_movement(dt_sec));
     }
   }
+
+  // Apply ice physics if on ice
+  apply_ice_physics();
 
   if (m_frozen) {
     m_sprite->stop_animation();
@@ -476,6 +493,11 @@ BadGuy::collision_tile(uint32_t tile_attributes)
   {
     m_in_water = true;
     SoundManager::current()->play("sounds/splash.ogg", get_pos());
+  }
+
+  if (tile_attributes & Tile::ICE) {
+    m_ice_this_frame = true;
+    m_on_ice = true;
   }
 
   if (tile_attributes & Tile::HURTS && is_hurtable())
@@ -710,6 +732,28 @@ BadGuy::collision_bullet(Bullet& bullet, const CollisionHit& hit)
     // In all other cases, bullets ricochet.
     bullet.ricochet(*this, hit);
     return FORCE_MOVE;
+  }
+}
+
+void
+BadGuy::apply_ice_physics()
+{
+  if (!m_on_ice || !on_ground()) return;
+  
+  float velx = m_physic.get_velocity_x();
+  // Stop very slow movement to prevent endless sliding
+  if (fabsf(velx) < 5.0f) {
+    m_physic.set_velocity_x(0);
+    m_physic.set_acceleration_x(0);
+    return;
+  }
+  
+  // Apply reduced friction when on ice
+  float friction = 50.0f * BADGUY_ICE_FRICTION_MULTIPLIER; // Base friction value
+  if (velx < 0) {
+    m_physic.set_acceleration_x(friction);
+  } else if (velx > 0) {
+    m_physic.set_acceleration_x(-friction);
   }
 }
 

--- a/src/badguy/badguy.hpp
+++ b/src/badguy/badguy.hpp
@@ -258,6 +258,9 @@ protected:
       collision_solid. */
   bool on_ground() const;
 
+  /** Apply ice physics to reduce friction when on ice */
+  void apply_ice_physics();
+
   /** Returns floor normal stored the last time when
       update_on_ground_flag was called and we touched something solid
       from above. */
@@ -299,6 +302,8 @@ protected:
   bool m_frozen;
   bool m_ignited; /**< true if this badguy is currently on fire */
   bool m_in_water; /** < true if the badguy is currently in water */
+  bool m_on_ice; /**< true if the badguy is currently on ice */
+  bool m_ice_this_frame; /**< true if the badguy touched ice this frame */
 
   std::string m_dead_script; /**< script to execute when badguy is killed */
 


### PR DESCRIPTION
Add ice slipping mechanics similar to player physics:
- Add ice state tracking (m_on_ice, m_ice_this_frame)
- Detect ice tiles in collision_tile()
- Apply reduced friction on ice surfaces
- Reset ice state each frame with proper management

Closes #733