### PR TITLE
Disable scheduled trigger in translations workflow

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,8 +18,8 @@
 name: translations
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * 0'
+  #schedule:
+  #  - cron:  '0 0 * * 0'
 
 jobs:
   update-all-translations:


### PR DESCRIPTION
This workflow pollutes git history very easily.
So disabling weekly retrieval from Transifex will prevent any more of these pollutions.

Translators don't need to download a new CI artifact every time they need to test, they can just edit the game's translation files with poedit or edit them with Transifex and then downloading them.