### PR TITLE
Improved Crusher's check for end of recovery

### DIFF
--- a/src/badguy/crusher.cpp
+++ b/src/badguy/crusher.cpp
@@ -242,6 +242,18 @@ Crusher::should_finish_crushing(const CollisionHit& hit) const
 }
 
 bool
+Crusher::should_finish_recovering(const CollisionHit& hit) const
+{
+  if (m_dir == CrusherDirection::ALL)
+    return hit.bottom || hit.top || hit.left || hit.right;
+
+  return ((m_dir == CrusherDirection::VERTICAL   || m_dir == CrusherDirection::DOWN)  && hit.top)    ||
+         ((m_dir == CrusherDirection::VERTICAL   || m_dir == CrusherDirection::UP)    && hit.bottom) ||
+         ((m_dir == CrusherDirection::HORIZONTAL || m_dir == CrusherDirection::LEFT)  && hit.right)  ||
+         ((m_dir == CrusherDirection::HORIZONTAL || m_dir == CrusherDirection::RIGHT) && hit.left);
+}
+
+bool
 Crusher::is_recovery_path_clear_of_crushers() const
 {
   Rectf current_bbox = get_bbox();
@@ -1022,7 +1034,7 @@ Crusher::collision_solid(const CollisionHit& hit)
   {
     crushed(hit, true);
   }
-  else if (m_state == RECOVERING)
+  else if (m_state == RECOVERING && should_finish_recovering(hit))
   {
     idle();
   }

--- a/src/badguy/crusher.hpp
+++ b/src/badguy/crusher.hpp
@@ -97,6 +97,7 @@ public:
 private:
   bool should_crush();
   bool should_finish_crushing(const CollisionHit& hit) const;
+  bool should_finish_recovering(const CollisionHit& hit) const;
   bool has_recovered();
   Rectf get_detect_box(CrusherDirection dir = CrusherDirection::ALL);
 


### PR DESCRIPTION
Check only relevant directions when checking for end of recovery.

Fixes #3407