### PR TITLE
Add CI file for MacOS Intel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,6 +83,15 @@ jobs:
                        openal-soft sdl2 sdl2_image libraqm freetype libpng \
                        glib gtk-doc zlib physfs fmt
 
+          install_name_tool -change \
+            '@rpath/libsharpyuv.0.dylib' \
+            /usr/local/opt/webp/lib/libsharpyuv.0.dylib \
+            /usr/local/opt/webp/lib/libwebp.7.dylib
+          install_name_tool -change \
+            '@rpath/libjxl_cms.0.11.dylib' \
+            /usr/local/opt/jpeg-xl/lib/libjxl_cms.0.11.dylib \
+            /usr/local/opt/jpeg-xl/lib/libjxl.dylib
+
           # Something funky happens with freetype if mono is left
           sudo mv /Library/Frameworks/Mono.framework                           \
                   /Library/Frameworks/Mono.framework-disabled


### PR DESCRIPTION
Shamelessly done using Github Copilot.

Due to the switch to MacOS 14 in our latest CI builds, the generated builds don't work on older Intel systems, such as the one I'm using.

After a somewhat [lengthy coding session with Github co-pilot](https://github.com/tobbi/supertux/pull/5), I finally had something in a working state.