### PR TITLE
Extrapolate camera and Tux position in worldmap

### DIFF
--- a/src/worldmap/camera.cpp
+++ b/src/worldmap/camera.cpp
@@ -66,6 +66,26 @@ Camera::update(float dt_sec)
   m_panning = false;
 }
 
+Vector
+Camera::get_offset(float time_offset) const
+{
+  Vector target_pos = get_camera_pos_for_tux(time_offset);
+  clamp_camera_position(target_pos);
+  if (!m_panning) {
+    return target_pos;
+  }
+
+  float pan_time_remaining = m_pan_time_remaining - time_offset;
+  if (pan_time_remaining > 0) {
+    // Smoothly interpolate the camera's position.
+    float f = pan_time_remaining / m_pan_time_full;
+    f = 0.5f - 0.5f * cosf(math::PI * f);
+    return f * m_pan_startpos + (1.0f - f) * target_pos;
+  } else {
+    return target_pos;
+  }
+}
+
 void
 Camera::pan()
 {
@@ -81,12 +101,12 @@ Camera::pan()
 }
 
 Vector
-Camera::get_camera_pos_for_tux() const
+Camera::get_camera_pos_for_tux(float time_offset) const
 {
   auto& tux = m_worldmap_sector.get_singleton_by_type<Tux>();
 
   Vector camera_offset_(0.0f, 0.0f);
-  Vector tux_pos = tux.get_pos();
+  Vector tux_pos = tux.get_pos(time_offset);
   camera_offset_.x = tux_pos.x - static_cast<float>(SCREEN_WIDTH) / 2.0f;
   camera_offset_.y = tux_pos.y - static_cast<float>(SCREEN_HEIGHT) / 2.0f;
   return camera_offset_;

--- a/src/worldmap/camera.hpp
+++ b/src/worldmap/camera.hpp
@@ -33,10 +33,10 @@ public:
   void pan();
   inline bool is_panning() const { return m_panning; }
 
-  inline Vector get_offset() const { return m_camera_offset; }
+  Vector get_offset(float time_offset = 0.0f) const;
 
 private:
-  Vector get_camera_pos_for_tux() const;
+  Vector get_camera_pos_for_tux(float time_offset = 0.0f) const;
   void clamp_camera_position(Vector& c) const;
 
 private:

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -89,7 +89,7 @@ Tux::draw(DrawingContext& context)
     log_debug << "Bonus type not handled in worldmap." << std::endl;
     m_sprite->set_action("large-stop");
   }
-  m_sprite->draw(context.color(), get_pos(), LAYER_OBJECTS + 1);
+  m_sprite->draw(context.color(), get_pos(context.get_time_offset()), LAYER_OBJECTS + 1);
 }
 
 std::string
@@ -112,24 +112,30 @@ Tux::get_action_prefix_for_bonus(const BonusType& bonus) const
 }
 
 Vector
-Tux::get_pos() const
+Tux::get_pos(float time_offset) const
 {
   float x = m_tile_pos.x * 32;
   float y = m_tile_pos.y * 32;
 
+  // This can overshoot slightly when going around corners, but clamping
+  // `offset` to avoid this would introduce a slightly more noticeable pause
+  // at each tile. Both symptoms could be avoided by looking ahead one tile in
+  // the worldmap to determine which direction Tux will move when offset > 32.f.
+  float offset = m_offset + (m_moving ? TUXSPEED * time_offset : 0.0f);
+
   switch (m_direction)
   {
     case Direction::WEST:
-      x -= m_offset - 32;
+      x -= offset - 32;
       break;
     case Direction::EAST:
-      x += m_offset - 32;
+      x += offset - 32;
       break;
     case Direction::NORTH:
-      y -= m_offset - 32;
+      y -= offset - 32;
       break;
     case Direction::SOUTH:
-      y += m_offset - 32;
+      y += offset - 32;
       break;
     case Direction::NONE:
       break;

--- a/src/worldmap/tux.hpp
+++ b/src/worldmap/tux.hpp
@@ -48,7 +48,7 @@ public:
   inline bool get_ghost_mode() const { return m_ghost_mode; }
 
   inline bool is_moving() const { return m_moving; }
-  Vector get_pos() const;
+  Vector get_pos(float time_offset = 0.0f) const;
   Vector get_axis() const;
   inline Vector get_tile_pos() const { return m_tile_pos; }
   inline void set_initial_pos(const Vector& pos) { m_initial_tile_pos = pos / 32.f; }

--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -151,6 +151,10 @@ void
 WorldMap::draw(Compositor& compositor)
 {
   auto& context = compositor.make_context();
+
+  if (MenuManager::instance().is_active()) {
+    context.set_time_offset(0.0f);
+  }
   m_sector->draw(context);
 }
 

--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -182,7 +182,7 @@ WorldMapSector::draw(DrawingContext& context)
   }
 
   context.push_transform();
-  context.set_translation(m_camera->get_offset());
+  context.set_translation(m_camera->get_offset(context.get_time_offset()));
 
   GameObjectManager::draw(context);
 


### PR DESCRIPTION
This change extrapolates the camera and Tux position in the worldmap when the "Frame Prediction" option is on.
When the game is rendered at high frame rates and Tux is moving, the motion of the camera should appear smoother and the background may look very slightly clearer due to reduced eye tracking blur.
