### PR TITLE
Isolate toolbar code from the rest of the editor code and move to a new class

### DIFF
--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -24,6 +24,7 @@
 
 #include "editor/overlay_widget.hpp"
 #include "editor/tilebox.hpp"
+#include "editor/toolbar_widget.hpp"
 #include "editor/toolbox_widget.hpp"
 #include "editor/layers_widget.hpp"
 #include "editor/scroller_widget.hpp"
@@ -95,11 +96,11 @@ public:
   inline World* get_world() const { return m_world.get(); }
 
   inline TileSet* get_tileset() const { return m_tileset; }
+  inline EditorToolboxWidget* get_toolbox_widget() const { return m_toolbox_widget; }
+  inline EditorToolbarWidget* get_toolbar_widget() const { return m_toolbar_widget; }
   inline EditorTilebox& get_tilebox() const { return m_toolbox_widget->get_tilebox(); }
   inline TileSelection* get_selected_tiles() const { return get_tilebox().get_tiles(); }
   inline std::string get_selected_object_class() const { return get_tilebox().get_object(); }
-
-  void toggle_tile_object_mode();
 
   inline EditorTilebox::InputType get_tileselect_input_type() const { return get_tilebox().get_input_type(); }
 
@@ -118,6 +119,7 @@ public:
     m_levelfile = levelfile;
     m_reload_request = true;
   }
+  bool save_level(const std::string& filename = "", bool switch_file = false);
 
   std::string get_level_directory() const;
 
@@ -206,7 +208,6 @@ private:
    *                    filename; subsequest saves will by default save to the
    *                    new filename.
    */
-  bool save_level(const std::string& filename = "", bool switch_file = false);
   void test_level(const std::optional<std::pair<std::string, Vector>>& test_pos);
   void update_keyboard(const Controller& controller);
   void keep_camera_in_bounds();
@@ -263,12 +264,10 @@ private:
   std::vector<std::unique_ptr<Widget> > m_widgets;
   std::vector<std::unique_ptr<InterfaceControl>> m_controls;
 
-  EditorToolbarButtonWidget* m_undo_widget;
-  EditorToolbarButtonWidget* m_redo_widget;
-
   EditorOverlayWidget* m_overlay_widget;
   EditorToolboxWidget* m_toolbox_widget;
   EditorLayersWidget* m_layers_widget;
+  EditorToolbarWidget* m_toolbar_widget;
 
   TypedUID<GameObject> m_selected_object;
 
@@ -279,9 +278,6 @@ private:
 
   float m_scroll_speed;
   float m_new_scale;
-
-  float m_widgets_width;
-  float m_widgets_width_offset;
 
   Vector m_mouse_pos;
 

--- a/src/editor/toolbar_widget.cpp
+++ b/src/editor/toolbar_widget.cpp
@@ -1,0 +1,300 @@
+//  SuperTux
+//  Copyright (C) 2015 Hume2 <teratux.mail@gmail.com>
+//                2024 Vankata453
+//                2025 Tobias Markus <tobbi.bugs@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "editor/toolbar_widget.hpp"
+
+#include "editor/button_widget.hpp"
+#include "editor/editor.hpp"
+#include "editor/tilebox.hpp"
+#include "editor/tool_icon.hpp"
+#include "gui/menu_manager.hpp"
+#include "gui/mousecursor.hpp"
+#include "gui/menu.hpp"
+#include "gui/notification.hpp"
+#include "math/util.hpp"
+#include "supertux/colorscheme.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
+#include "supertux/level.hpp"
+#include "supertux/menu/menu_storage.hpp"
+#include "supertux/resources.hpp"
+#include "util/gettext.hpp"
+#include "video/drawing_context.hpp"
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
+
+using InputType = EditorTilebox::InputType;
+
+EditorToolbarWidget::EditorToolbarWidget(Editor& editor) :
+  m_editor(editor),
+  m_undo_widget(),
+  m_redo_widget(),
+  m_widgets(),
+  m_widgets_width(0.f),
+  m_widgets_width_offset(0.f)
+{
+    std::array<std::unique_ptr<EditorToolbarButtonWidget>, 8> general_widgets = {
+    // Undo button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/undo.png",
+        std::bind(&Editor::undo, Editor::current()),
+        _("Undo"),
+        Sizef(32.f, 32.f)),
+
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/redo.png",
+        std::bind(&Editor::redo, Editor::current()),
+        _("Redo"),
+        Sizef(32.f, 32.f)),
+
+    // Grid button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/grid_button.png",
+      [this] {
+        auto& snap_grid_size = g_config->editor_selected_snap_grid_size;
+        if (snap_grid_size == 0)
+        {
+          if(!g_config->editor_render_grid)
+          {
+            snap_grid_size = 3;
+          }
+          g_config->editor_render_grid = !g_config->editor_render_grid;
+        }
+        else
+          snap_grid_size--;
+      },
+      _("Change / Toggle grid size")),
+
+    // Play button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/play_button.png",
+      [this] { Editor::current()->m_test_request = true; },
+      _("Test level")),
+
+    // Save button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/save.png",
+      [this] {
+        if (Editor::current()->save_level())
+        {
+          auto notif = std::make_unique<Notification>("save_level_notif", 5.f);
+          notif->set_text(_("Level saved!"));
+          MenuManager::instance().set_notification(std::move(notif));
+        }
+      },
+      _("Save level")),
+
+    // Mode button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/toggle_tile_object_mode.png",
+      std::bind(&EditorToolbarWidget::toggle_tile_object_mode, this),
+      _("Toggle between object and tile mode")),
+
+    // Mouse select button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/arrow.png",
+      [this]() {
+        Editor::current()->get_toolbox_widget()->set_mouse_tool();
+      },
+      _("Select or move the object under the mouse")),
+
+    // Rubber button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/rubber.png",
+      [this]() {
+        Editor::current()->get_toolbox_widget()->set_rubber_tool();
+      },
+      _("Delete the tile or object under the mouse"))
+  };
+
+  std::array<std::unique_ptr<EditorToolbarButtonWidget>, 4> tile_mode_widgets = {
+    // Select mode mouse
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/select-mode0.png",
+    [this] {
+      Editor::current()->get_toolbox_widget()->set_tileselect_select_mode(0);
+    },
+    _("Draw mode (The current tool applies to the tile under the mouse)")),
+
+    // Select mode area
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/select-mode1.png",
+      [this] {
+        Editor::current()->get_toolbox_widget()->set_tileselect_select_mode(1);
+      },
+      _("Box draw mode (The current tool applies to an area / box drawn with the mouse)")),
+
+    // Select mode fill button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/select-mode2.png",
+      [this] {
+        Editor::current()->get_toolbox_widget()->set_tileselect_select_mode(2);
+      },
+      _("Fill mode (The current tool applies to the empty area in the enclosed space that was clicked)")),
+
+    // Select mode same button
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/select-mode3.png",
+      [this] {
+        Editor::current()->get_toolbox_widget()->set_tileselect_select_mode(3);
+      },
+      _("Replace mode (The current tool applies to all tiles that are the same tile as the one under the mouse)")),
+  };
+
+  std::array<std::unique_ptr<EditorToolbarButtonWidget>, 2> object_mode_widgets = {
+    // Select mode
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/move-mode0.png",
+      [this] {
+        Editor::current()->get_toolbox_widget()->set_tileselect_move_mode(0);
+      },
+      _("Select mode (Clicking selects the object under the mouse)")),
+
+    // Duplicate mode
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/move-mode1.png",
+      [this] {
+        Editor::current()->get_toolbox_widget()->set_tileselect_move_mode(1);
+      },
+      _("Duplicate mode (Clicking duplicates the object under the mouse)")),
+  };
+
+  size_t i = 0;
+  for (auto &widget : general_widgets)
+  {
+    Vector pos(32 * i, 0);
+    widget->set_position(pos);
+    widget->set_flat(true);
+    m_widgets.insert(m_widgets.begin() + i, std::move(widget));
+    ++i;
+  }
+
+  for (auto &widget : tile_mode_widgets)
+  {
+    Vector pos(32 * i, 0);
+    widget->set_position(pos);
+    widget->set_flat(true);
+    widget->set_visible_in_object_mode(false);
+    widget->set_visible(false);
+    m_widgets.insert(m_widgets.begin() + i, std::move(widget));
+    ++i;
+  }
+
+  for (auto &widget : object_mode_widgets)
+  {
+    Vector pos(32 * (i - tile_mode_widgets.size()), 0);
+    widget->set_position(pos);
+    widget->set_flat(true);
+    widget->set_visible_in_tile_mode(false);
+    widget->set_visible(false);
+    m_widgets.insert(m_widgets.begin() + i, std::move(widget));
+    ++i;
+  }
+  m_widgets_width = 32.f * (i - std::max(tile_mode_widgets.size(), object_mode_widgets.size()) - 2);
+
+  m_undo_widget = reinterpret_cast<EditorToolbarButtonWidget*>(m_widgets[0].get());
+  m_redo_widget = reinterpret_cast<EditorToolbarButtonWidget*>(m_widgets[1].get());
+  m_undo_widget->set_disabled(true);
+  m_redo_widget->set_disabled(true);
+
+  // auto code_widget = std::make_unique<EditorToolbarButtonWidget>(
+  //   "images/engine/editor/select-mode3.png", Vector(320, 0), [this] {
+  //     std::ostringstream level_ostream;
+  //     Writer output_writer(level_ostream);
+  //     m_level->save(output_writer);
+  //     auto level_content = level_ostream.str();
+  //     MenuManager::instance().push_menu(std::make_unique<ScriptMenu>(&level_content));
+  //     log_warning << level_content << std::endl;
+  //   });
+  // m_widgets.insert(m_widgets.begin() + 10, std::move(code_widget));
+}
+
+void
+EditorToolbarWidget::toggle_tile_object_mode()
+{
+  int i = 0;
+  auto& tilebox = Editor::current()->get_toolbox_widget()->get_tilebox();
+  const auto& input_type = tilebox.get_input_type();
+
+  if (input_type == InputType::OBJECT) // Object mode -> Tile mode
+  {
+    Editor::current()->select_last_tilegroup();
+    for(const auto& toolbar_button : m_widgets)
+    {
+      toolbar_button->set_visible(toolbar_button->get_visible_in_tile_mode());
+    }
+    Editor::current()->get_toolbox_widget()->set_tileselect_select_mode(0);
+  }
+  else // Tile mode -> Object mode
+  {
+    Editor::current()->select_last_objectgroup();
+    for(const auto& toolbar_button : m_widgets)
+    {
+      toolbar_button->set_visible(toolbar_button->get_visible_in_object_mode());
+  	}
+    Editor::current()->get_toolbox_widget()->set_tileselect_move_mode(0);
+  }
+
+  for (const auto& toolbar_button : m_widgets)
+  {
+    if (toolbar_button->get_visible())
+      ++i;
+	}
+
+  m_widgets_width = i * 32.f;
+}
+
+bool
+EditorToolbarWidget::event(const SDL_Event& ev)
+{
+  for(const auto& widget : m_widgets)
+  {
+    if (widget->event(ev))
+      return true;
+  }
+  return false;
+}
+
+void
+EditorToolbarWidget::update(float dt_sec)
+{
+  for(const auto& widget : m_widgets)
+  {
+    widget->update(dt_sec);
+  }
+}
+
+void
+EditorToolbarWidget::draw(DrawingContext& context)
+{
+  if (!g_config->editor_show_toolbar_widgets)
+    return;
+
+  context.color().set_blur(g_config->editor_blur);
+  context.color().draw_filled_rect(
+    {-g_config->menuroundness, -g_config->menuroundness, m_widgets_width + m_widgets_width_offset, 32},
+    Color(0.2f, 0.2f, 0.2f, 0.5f),
+    math::clamp(g_config->menuroundness, 0.f, 16.f),
+    LAYER_GUI - 5);
+  context.color().set_blur(0);
+
+  for(const auto& widget : m_widgets)
+  {
+    widget->draw(context);
+  }
+}
+
+void
+EditorToolbarWidget::set_undo_disabled(bool state)
+{
+  if (m_undo_widget)
+    m_undo_widget->set_disabled(state);
+}
+
+void
+EditorToolbarWidget::set_redo_disabled(bool state)
+{
+  if (m_redo_widget)
+    m_redo_widget->set_disabled(state);
+}

--- a/src/editor/toolbar_widget.hpp
+++ b/src/editor/toolbar_widget.hpp
@@ -1,0 +1,59 @@
+//  SuperTux
+//  Copyright (C) 2025 Tobias Markus <tobbi.bugs@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "editor/widget.hpp"
+
+#include <array>
+#include <memory>
+
+#include "math/rectf.hpp"
+#include "math/vector.hpp"
+#include "video/surface_ptr.hpp"
+
+class Editor;
+class EditorToolbarButtonWidget;
+
+/** The toolbar is at the top of the screen and offers easy access to the most commonly used functions of the editor. */
+class EditorToolbarWidget final : public Widget
+{
+
+public:
+  EditorToolbarWidget(Editor& editor);
+
+  virtual void draw(DrawingContext& context) override;
+  virtual void update(float dt_sec) override;
+  virtual bool event(const SDL_Event& ev) override;
+
+  void toggle_tile_object_mode();
+
+  void set_undo_disabled(bool state);
+  void set_redo_disabled(bool state);
+
+private:
+  Editor& m_editor;
+  EditorToolbarButtonWidget* m_undo_widget;
+  EditorToolbarButtonWidget* m_redo_widget;
+  std::vector<std::unique_ptr<EditorToolbarButtonWidget> > m_widgets;
+
+  float m_widgets_width;
+  float m_widgets_width_offset;
+
+private:
+  EditorToolbarWidget(const EditorToolbarWidget&) = delete;
+  EditorToolbarWidget& operator=(const EditorToolbarWidget&) = delete;
+};

--- a/src/supertux/game_object_manager.cpp
+++ b/src/supertux/game_object_manager.cpp
@@ -550,8 +550,8 @@ GameObjectManager::update_editor_buttons()
 {
   if (Editor::current())
   {
-    Editor::current()->set_undo_disabled(m_undo_stack.empty());
-    Editor::current()->set_redo_disabled(m_redo_stack.empty());
+    Editor::current()->get_toolbar_widget()->set_undo_disabled(m_undo_stack.empty());
+    Editor::current()->get_toolbar_widget()->set_redo_disabled(m_redo_stack.empty());
   }
 }
 


### PR DESCRIPTION
Since this is quite a big refactoring, I wanted to have another pair of eyes on it.