### PR TITLE
Add new badguy: Pogo Snowball

### DIFF
--- a/src/badguy/pogo_snowball.cpp
+++ b/src/badguy/pogo_snowball.cpp
@@ -1,0 +1,48 @@
+#include "badguy/pogo_snowball.hpp"
+
+#include "sprite/sprite_manager.hpp"
+#include "supertux/object_factory.hpp"
+
+static const float JUMP_INTERVAL = 1.5f;   // Time between jumps
+static const float JUMP_SPEED = -350.0f;    // Upward velocity (negative = up)
+
+PogoSnowball::PogoSnowball(const ReaderMapping& reader) :
+  BadGuy(reader, "images/creatures/snowball/snowball.sprite"),
+  m_jump_timer(0.0f)
+{
+  // Reuse the standard snowball sprite (walking animation gives a nice "boing" feel)
+}
+
+void
+PogoSnowball::initialize()
+{
+  m_physic.enable_gravity(true);
+  m_physic.set_velocity(0.0f, 0.0f);
+  m_dir = Direction::LEFT;  // Just for sprite facing; doesn't move horizontally
+  set_action("left");
+}
+
+void
+PogoSnowball::active_update(float dt_sec)
+{
+  if (on_ground())
+  {
+    m_jump_timer += dt_sec;
+    if (m_jump_timer >= JUMP_INTERVAL)
+    {
+      m_jump_timer = 0.0f;
+      m_physic.set_velocity_y(JUMP_SPEED);
+      // Optional: play a small sound effect here if you want
+      // SoundManager::current()->play("sounds/boing.wav", get_pos());
+    }
+  }
+  else
+  {
+    // Reset timer while in air to sync jumps properly
+    m_jump_timer = 0.0f;
+  }
+
+  BadGuy::active_update(dt_sec);
+}
+
+int ADD_TO_OBJECT_FACTORY(PogoSnowball);

--- a/src/badguy/pogo_snowball.hpp
+++ b/src/badguy/pogo_snowball.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "badguy/badguy.hpp"
+
+class PogoSnowball final : public BadGuy
+{
+public:
+  PogoSnowball(const ReaderMapping& reader);
+
+  virtual void initialize() override;
+  virtual void active_update(float dt_sec) override;
+
+  static std::string class_name() { return "pogo_snowball"; }
+  static std::string display_name() { return _("Pogo Snowball"); }
+
+  virtual bool is_freezable() const override { return true; }
+  virtual bool is_flammable() const override { return false; }
+
+private:
+  float m_jump_timer;
+};

--- a/src/supertux/game_object_factory.cpp
+++ b/src/supertux/game_object_factory.cpp
@@ -21,6 +21,7 @@
 #include "audio/sound_source.hpp"
 #include "badguy/angrystone.hpp"
 #include "badguy/bouncing_snowball.hpp"
+#include "badguy/pogo_snowball.hpp"
 #include "badguy/captainsnowball.hpp"
 #include "badguy/corrupted_granito.hpp"
 #include "badguy/corrupted_granito_big.hpp"
@@ -176,6 +177,7 @@ GameObjectFactory::init_factories()
   m_adding_badguys = true;
   add_factory<AngryStone>("angrystone");
   add_factory<BouncingSnowball>("bouncingsnowball", OBJ_PARAM_DISPENSABLE);
+  add_factory<PogoSnowball>("pogo_snowball");
   add_factory<CaptainSnowball>("captainsnowball", OBJ_PARAM_DISPENSABLE);
   add_type_factory<CorruptedGranito>("skullyhop", CorruptedGranito::SKULLYHOP); // Backward compatibility
   add_factory<CorruptedGranito>("corrupted_granito", OBJ_PARAM_DISPENSABLE);


### PR DESCRIPTION
Adds a fun new enemy: Pogo Snowball!

- A stationary snowball that hops straight up periodically (every 1.5 seconds when on ground)
- Reuses the existing snowball.sprite (no new graphics required)
- Normal BadGuy mechanics: squishable by jumping on top, hurts Tux on side contact
- Fully registered and appears in the level editor under Badguys as "Pogo Snowball"
- Level usage: <badguy type="pogo_snowball" x="400" y="300"/>

Tested locally in editor and gameplay. Additive only — no breaking changes.