### PR TITLE
Use 0.7 add-on index instead of 0.6

### DIFF
--- a/src/addon/addon_manager.cpp
+++ b/src/addon/addon_manager.cpp
@@ -41,7 +41,7 @@
 namespace {
 
 static const char* ADDON_INFO_PATH = "/addons/repository.nfo";
-static const char* ADDON_REPOSITORY_URL = "https://raw.githubusercontent.com/SuperTux/addons/master/index-0_6.nfo";
+static const char* ADDON_REPOSITORY_URL = "https://raw.githubusercontent.com/SuperTux/addons/master/index-0_7.nfo";
 
 MD5 md5_from_file(const std::string& filename)
 {


### PR DESCRIPTION
This PR makes SuperTux use the 0.7 index instead of the 0.6 one.

I added a PR to update the index here: https://github.com/SuperTux/addons/pull/52 I'm quite confused about the changes in the checksums and the state of the old 0.7 one. Does updating it to match 0.6's index break anything?