### PR TITLE
LeafShot: Move parse_type to KamikazeSnowball

### DIFF
--- a/src/badguy/kamikazesnowball.cpp
+++ b/src/badguy/kamikazesnowball.cpp
@@ -27,6 +27,7 @@ namespace{
 KamikazeSnowball::KamikazeSnowball(const ReaderMapping& reader, const std::string& sprite_name) :
   BadGuy(reader, sprite_name)
 {
+  parse_type(reader);
   SoundManager::current()->preload(SPLAT_SOUND);
   set_action (m_dir, /* loops = */ -1);
 }
@@ -99,7 +100,7 @@ KamikazeSnowball::collision_player(Player& player, const CollisionHit& hit)
 LeafShot::LeafShot(const ReaderMapping& reader) :
   KamikazeSnowball(reader, "images/creatures/leafshot/leafshot.sprite")
 {
-  parse_type(reader);
+
 }
 
 void


### PR DESCRIPTION
This avoids resetting the sprite in LeafShot's constructor again which leads to a wrongly sized hitbox after launch.

Fixes #3463