### PR TITLE
Allow opening level files in external text editor for viewing

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -634,6 +634,18 @@ Editor::open_level_directory()
 }
 
 void
+Editor::open_level_in_external_editor()
+{
+  auto temp_filename = get_readonly_levelname(m_levelfile);
+  m_level->save(FileSystem::join(get_level_directory(), temp_filename));
+  
+  auto path = FileSystem::join(PHYSFS_getWriteDir(), get_level_directory());
+  auto level_path = FileSystem::join(path, temp_filename);
+
+  FileSystem::open_editor(level_path);
+}
+
+void
 Editor::scroll(const Vector& velocity)
 {
   if (!m_levelloaded) return;

--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -70,6 +70,10 @@ private:
     return is_autosave_file(filename) ? filename : filename + "~";
   }
 
+  static std::string get_readonly_levelname(const std::string& filename) {
+    return filename + ".txt";
+  }
+
 public:
   static bool s_resaving_in_progress;
 
@@ -128,6 +132,7 @@ public:
   inline bool is_temp_level() const { return m_temp_level; }
 
   void open_level_directory();
+  void open_level_in_external_editor();
 
   inline bool is_testing_level() const { return m_leveltested; }
 

--- a/src/editor/toolbar_widget.cpp
+++ b/src/editor/toolbar_widget.cpp
@@ -48,7 +48,7 @@ EditorToolbarWidget::EditorToolbarWidget(Editor& editor) :
   m_widgets_width(0.f),
   m_widgets_width_offset(0.f)
 {
-    std::array<std::unique_ptr<EditorToolbarButtonWidget>, 8> general_widgets = {
+    std::array<std::unique_ptr<EditorToolbarButtonWidget>, 9> general_widgets = {
     // Undo button
     std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/undo.png",
         std::bind(&Editor::undo, Editor::current()),
@@ -88,6 +88,12 @@ EditorToolbarWidget::EditorToolbarWidget(Editor& editor) :
         Editor::current()->save_level();
       },
       _("Save level")),
+
+    std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/save.png",
+      [this] {
+        Editor::current()->open_level_in_external_editor();
+      },
+      _("Open level in external editor")),
 
     // Mode button
     std::make_unique<EditorToolbarButtonWidget>("images/engine/editor/toggle_tile_object_mode.png",


### PR DESCRIPTION
I often find myself wanting to look at the code of a level file. Unfortunately, our editor doesn't support that directly. 

Thus, I've added this feature by abusing our "edit scripts" feature. 

What still needs to be done

~~ - [ ] Add proper icon (currently uses save icon as a placeholder)~~
- [ ] Move to editor menu
- [ ] Maybe: Allow editing a level file in external editor and then refreshing the editor if the edited level file is valid, but I've talked to swagtoy on Discord and this seems to be difficult to accomplish.

Nonetheless, putting this up for discussion.