### PR TITLE
Add bogus SDL_VERSION_ATLEAST macro definition for cppcheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Lint code with Cppcheck
         run: |
           ./danmar-cppcheck-*/cppcheck \
-            --check-level=exhaustive \
+            --check-level=exhaustive --include=mk/cppcheck/include/SDL.h \
             --quiet --inline-suppr --language=c++ --error-exitcode=10 \
             -j"$(nproc)" --std=c++17 --enable=warning,style \
             --suppress=useStlAlgorithm -UEMSCRIPTEN src/

--- a/mk/cppcheck/include/SDL.h
+++ b/mk/cppcheck/include/SDL.h
@@ -1,0 +1,2 @@
+/* This definition is required for cppcheck to not bail out with a syntax error */
+#define SDL_VERSION_ATLEAST(X, Y, Z) true


### PR DESCRIPTION
This adds a bogus definition of the `SDL_VERSION_ATLEAST` macro for cppcheck to find so that the syntax error that we get when we run that is no more.