### PR TITLE
Add favicon to WASM builds

### DIFF
--- a/mk/cmake/SuperTux/BuildInstall.cmake
+++ b/mk/cmake/SuperTux/BuildInstall.cmake
@@ -70,6 +70,11 @@ if(EMSCRIPTEN)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mk/emscripten/template.html.in ${CMAKE_CURRENT_BINARY_DIR}/template.html)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mk/emscripten/supertux2.png ${CMAKE_CURRENT_BINARY_DIR}/supertux2.png COPYONLY)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mk/emscripten/supertux2_bkg.png ${CMAKE_CURRENT_BINARY_DIR}/supertux2_bkg.png COPYONLY)
+  if(IS_SUPERTUX_RELEASE)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/images/engine/icons/supertux.ico ${CMAKE_CURRENT_BINARY_DIR}/supertux2.ico COPYONLY)
+  else()
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/images/engine/icons/supertux-nightly.ico ${CMAKE_CURRENT_BINARY_DIR}/supertux2.ico COPYONLY)
+  endif()
 endif()
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.md

--- a/mk/emscripten/template.html.in
+++ b/mk/emscripten/template.html.in
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta name="description" content="Play the official online version of SuperTux, directly in your browser. No installation required.">
+  <link rel="icon" href="supertux2.ico?v=@SUPERTUX_VERSION_STRING@" />
   <title>Play SuperTux online</title>
   <style>
     body {


### PR DESCRIPTION
This will display the game's icon in the title bar and in search engines.

It reuses the icons at `/data/images/engine/icons/supertux*.ico`. It picks the nightly icon for nightly builds, and the standard icon for releases.