### PR TITLE
Fix cursor not showing when opening the cheat and debug menus on the worldmap

### DIFF
--- a/src/worldmap/worldmap.cpp
+++ b/src/worldmap/worldmap.cpp
@@ -27,7 +27,6 @@
 #include "supertux/gameconfig.hpp"
 #include "editor/editor.hpp"
 #include "supertux/level.hpp"
-#include "supertux/menu/menu_storage.hpp"
 #include "supertux/player_status.hpp"
 #include "supertux/screen_manager.hpp"
 #include "supertux/tile_manager.hpp"
@@ -219,19 +218,19 @@ WorldMap::process_input(const Controller& controller)
 
   if (controller.pressed_any(Control::START, Control::ESCAPE))
   {
-    on_escape_press();
+    on_menu_button_press(MenuStorage::WORLDMAP_MENU);
   }
 
   if (controller.pressed(Control::CHEAT_MENU) &&
       g_config->developer_mode)
   {
-    MenuManager::instance().set_menu(MenuStorage::WORLDMAP_CHEAT_MENU);
+    on_menu_button_press(MenuStorage::WORLDMAP_CHEAT_MENU);
   }
 
   if (controller.pressed(Control::DEBUG_MENU) &&
       g_config->developer_mode)
   {
-    MenuManager::instance().set_menu(MenuStorage::DEBUG_MENU);
+    on_menu_button_press(MenuStorage::DEBUG_MENU);
   }
 }
 
@@ -246,12 +245,12 @@ WorldMap::get_status() const
 
 
 void
-WorldMap::on_escape_press()
+WorldMap::on_menu_button_press(MenuStorage::MenuId menu_type)
 {
   // Show or hide the menu
   if (!MenuManager::instance().is_active())
   {
-    MenuManager::instance().set_menu(MenuStorage::WORLDMAP_MENU);
+    MenuManager::instance().set_menu(menu_type);
     MouseCursor::current()->set_visible(true);
     m_sector->get_tux().set_direction(Direction::NONE); // stop tux movement when menu is called
   }

--- a/src/worldmap/worldmap.hpp
+++ b/src/worldmap/worldmap.hpp
@@ -22,6 +22,7 @@
 #include "util/currenton.hpp"
 
 #include "control/controller.hpp"
+#include "supertux/menu/menu_storage.hpp"
 #include "supertux/savegame.hpp"
 #include "supertux/timer.hpp"
 #include "worldmap/worldmap_sector.hpp"
@@ -107,7 +108,7 @@ private:
 
   void process_input(const Controller& controller);
 
-  void on_escape_press();
+  void on_menu_button_press(MenuStorage::MenuId menu_type);
 
 private:
   WorldMapSector* m_sector; /* The currently active sector. */


### PR DESCRIPTION
Fixes an issue where the cursor is not shown when opening the cheat or debug menu on the worldmap.

I adapted the existing function to let it accept different menu types.