### PR TITLE
Re-add world select backgrounds in worldmaps

### DIFF
--- a/data/levels/world1/worldmap.stwm
+++ b/data/levels/world1/worldmap.stwm
@@ -6,6 +6,7 @@
   (allow-item-pocket "on")
   (icon "/images/worlds/icon/icyisland.png")
   (icon-locked "/images/worlds/locked/icyisland.png")
+  (bkg "/images/worlds/background/icyisland.png")
   (sector
     (name "main")
     (init-script "import(\"levels/world1/worldmap.nut\");")

--- a/data/levels/world2/worldmap.stwm
+++ b/data/levels/world2/worldmap.stwm
@@ -6,6 +6,7 @@
   (allow-item-pocket "on")
   (icon "/images/worlds/icon/rootedforest.png")
   (icon-locked "/images/worlds/locked/rootedforest.png")
+  (bkg "/images/worlds/background/forest.png")
   (sector
     (name "main")
     (init-script "import(\"levels/world2/worldmap.nut\");")

--- a/data/levels/world3/worldmap.stwm
+++ b/data/levels/world3/worldmap.stwm
@@ -6,4 +6,5 @@
   (license "CC-BY-SA 4.0 International")
   (icon "/images/worlds/icon/tropicalparadise.png")
   (icon-locked "/images/worlds/locked/tropicalparadise.png")
+  (bkg "/images/worlds/background/***TODO***.png")
 )

--- a/data/levels/world4/worldmap.stwm
+++ b/data/levels/world4/worldmap.stwm
@@ -6,4 +6,5 @@
   (license "CC-BY-SA 4.0 International")
   (icon "/images/worlds/icon/mountainpeak.png")
   (icon-locked "/images/worlds/locked/mountainpeak.png")
+  (bkg "/images/worlds/background/***TODO***.png")
 )


### PR DESCRIPTION
The custom backgrounds were missing in the world selection interface in the main story (Icy island and rooted forest).

I also added a "Todo" placeholder in worlds 3 and 4 to help future contributors remember about this.

---

Can somebody check that loading and re-saving the worldmap preserves the background and the icons? I'm not familiar enough with the process to conduct a thorough enough check.