### PR TITLE
Add `cutscene` property for levels (title screen, credits, in-game cutscenes)

### DIFF
--- a/data/levels/misc/credits.stl
+++ b/data/levels/misc/credits.stl
@@ -7,6 +7,7 @@
   (suppress-pause-menu #t)
   (icon "")
   (icon-locked "")
+  (cutscene #t)
   (sector
     (name "main")
     (init-script "Tux.deactivate();

--- a/data/levels/misc/menu.stl
+++ b/data/levels/misc/menu.stl
@@ -7,6 +7,7 @@
   (allow-item-pocket "inherit")
   (icon "")
   (icon-locked "")
+  (cutscene #t)
   (statistics
     (enable-coins #t)
     (enable-badguys #f)

--- a/data/levels/misc/menu_retro.stl
+++ b/data/levels/misc/menu_retro.stl
@@ -7,6 +7,7 @@
   (allow-item-pocket "inherit")
   (icon "")
   (icon-locked "")
+  (cutscene #t)
   (statistics
     (enable-coins #t)
     (enable-badguys #f)

--- a/data/levels/world1/intro.stl
+++ b/data/levels/world1/intro.stl
@@ -6,6 +6,7 @@
   (allow-item-pocket "inherit")
   (icon "")
   (icon-locked "")
+  (cutscene #t)
   (statistics
     (enable-coins #t)
     (enable-secrets #t)

--- a/src/control/game_controller_manager.cpp
+++ b/src/control/game_controller_manager.cpp
@@ -24,7 +24,6 @@
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "supertux/game_session.hpp"
-#include "supertux/savegame.hpp"
 #include "util/log.hpp"
 
 GameControllerManager::GameControllerManager(InputManager* parent) :
@@ -208,9 +207,6 @@ GameControllerManager::on_controller_added(int joystick_index)
   if (!m_parent->can_add_user())
     return;
 
-  Savegame* savegame = (GameSession::current() && !Editor::is_active() ?
-    &GameSession::current()->get_savegame() : nullptr);
-
   if (!SDL_IsGameController(joystick_index))
   {
     log_warning << "joystick is not a game controller, ignoring: " << joystick_index << std::endl;
@@ -244,7 +240,7 @@ GameControllerManager::on_controller_added(int joystick_index)
 
         m_game_controllers[game_controller] = id;
 
-        if (GameSession::current() && (savegame && savegame->is_title_screen()) && id != 0)
+        if (GameSession::current() && id != 0)
         {
           GameSession::current()->on_player_added(id);
         }

--- a/src/control/joystick_manager.cpp
+++ b/src/control/joystick_manager.cpp
@@ -97,7 +97,7 @@ JoystickManager::on_joystick_added(int joystick_index)
 
       joysticks[joystick] = id;
 
-      if (GameSession::current() && !GameSession::current()->get_savegame().is_title_screen() && id != 0)
+      if (GameSession::current() && id != 0)
       {
         GameSession::current()->on_player_added(id);
       }

--- a/src/supertux/game_session.cpp
+++ b/src/supertux/game_session.cpp
@@ -96,8 +96,7 @@ GameSession::GameSession(Savegame* savegame, Statistics* statistics) :
   m_end_seq_started(false),
   m_pause_target_timer(false),
   m_current_cutscene_text(),
-  m_endsequence_timer(),
-  m_prevent_adding_players(false)
+  m_endsequence_timer()
 {
   set_start_point(DEFAULT_SECTOR_NAME, DEFAULT_SPAWNPOINT_NAME);
 
@@ -156,15 +155,9 @@ GameSession::reset_level()
 }
 
 void
-GameSession::prevent_adding_players()
-{
-  m_prevent_adding_players = true;
-}
-
-void
 GameSession::on_player_added(int id)
 {
-  if (m_prevent_adding_players)
+  if (!is_cutscene() || !m_currentsector)
     return;
 
   PlayerStatus* player_status;
@@ -190,11 +183,8 @@ GameSession::on_player_added(int id)
 bool
 GameSession::on_player_removed(int id)
 {
-  if (m_prevent_adding_players)
-    return false;
-
   // Sectors in worldmaps have no Player's of that class
-  if (!m_currentsector)
+  if (!is_cutscene() || !m_currentsector)
     return false;
 
   for (Player* player : m_currentsector->get_players())

--- a/src/supertux/game_session.hpp
+++ b/src/supertux/game_session.hpp
@@ -100,7 +100,6 @@ public:
                          const bool make_invincible = false);
   void reset_level();
 
-  void prevent_adding_players();
   void on_player_added(int id);
   bool on_player_removed(int id);
 
@@ -151,6 +150,8 @@ public:
   }
 
   void set_scheduler(SquirrelScheduler& new_scheduler);
+
+  inline bool is_cutscene() const { return m_level && !m_level->m_is_cutscene; }
 
 private:
   void check_end_conditions();
@@ -222,8 +223,6 @@ private:
   std::unique_ptr<GameObject> m_current_cutscene_text;
 
   Timer m_endsequence_timer;
-
-  bool m_prevent_adding_players;
 
 private:
   GameSession(const GameSession&) = delete;

--- a/src/supertux/level.cpp
+++ b/src/supertux/level.cpp
@@ -44,6 +44,7 @@ Level::Level(bool worldmap) :
   m_license(),
   m_filename(),
   m_note(),
+  m_is_cutscene(false),
   m_sectors(),
   m_stats(),
   m_target_time(),
@@ -82,11 +83,10 @@ Level::initialize()
     &GameSession::current()->get_savegame() : nullptr);
   PlayerStatus& player_status = savegame ? savegame->get_player_status() : s_dummy_player_status;
 
-  // Condition 1: If there is a savegame, it shouldn't be from the title screen. (Don't load HUD on title screen)
+  // Condition 1: Don't load HUD on a cutscene level
   // Condition 2: Pause menu shouldn't be suppressed.
   // Condition 3: The level shouldn't be loaded in the editor.
-  if ((!savegame || !savegame->is_title_screen()) &&
-      !m_suppress_pause_menu && !Editor::is_active())
+  if (!m_is_cutscene && !m_suppress_pause_menu && !Editor::is_active())
   {
     for (auto& sector : m_sectors)
       sector->add<PlayerStatusHUD>(player_status);
@@ -96,7 +96,7 @@ Level::initialize()
   Sector* sector = m_sectors.at(0).get();
   sector->add<Player>(player_status, "Tux", 0);
 
-  if (savegame && !savegame->is_title_screen())
+  if (!m_is_cutscene)
   {
     for (int id = 1; id < InputManager::current()->get_num_users() || id == 0; id++)
     {
@@ -198,6 +198,10 @@ Level::save(Writer& writer)
   }
   if(m_suppress_pause_menu) {
     writer.write("suppress-pause-menu", m_suppress_pause_menu);
+  }
+
+  if (m_is_cutscene) {
+    writer.write("cutscene", m_is_cutscene);
   }
 
   writer.write("allow-item-pocket", get_setting_name(static_cast<Level::Setting>(m_allow_item_pocket)));

--- a/src/supertux/level.hpp
+++ b/src/supertux/level.hpp
@@ -97,6 +97,7 @@ public:
   std::string m_license;
   std::string m_filename;
   std::string m_note;
+  bool m_is_cutscene;
 
   std::vector<std::unique_ptr<Sector> > m_sectors;
 

--- a/src/supertux/level_parser.cpp
+++ b/src/supertux/level_parser.cpp
@@ -172,6 +172,7 @@ LevelParser::load(const ReaderDocument& doc)
     level.get("target-time", m_level.m_target_time);
     level.get("suppress-pause-menu", m_level.m_suppress_pause_menu);
     level.get("note", m_level.m_note);
+    level.get("cutscene", m_level.m_is_cutscene);
     level.get("icon", m_level.m_icon);
     level.get("icon-locked", m_level.m_icon_locked);
     level.get("bkg", m_level.m_wmselect_bkg);

--- a/src/supertux/menu/editor_level_menu.cpp
+++ b/src/supertux/menu/editor_level_menu.cpp
@@ -35,6 +35,7 @@ EditorLevelMenu::EditorLevelMenu() :
   add_textfield(_("Contact"), &(level->m_contact));
   add_textfield(_("License"), &(level->m_license));
   add_textfield(_("Level Note"), &(level->m_note));
+  add_toggle(-1, _("Cinematic level"), &(level->m_is_cutscene));
   add_file(_("Tileset"), &(level->m_tileset), std::vector<std::string>(1, ".strf"), {}, true);
 
   std::vector<std::string> choices = {_("No"), _("Yes")};

--- a/src/supertux/menu/multiplayer_player_menu.cpp
+++ b/src/supertux/menu/multiplayer_player_menu.cpp
@@ -39,8 +39,7 @@ MultiplayerPlayerMenu::MultiplayerPlayerMenu(int player_id)
 
   add_toggle(-1, _("Play with the keyboard"), &InputManager::current()->m_uses_keyboard[player_id]);
 
-  if (player_id != 0 && GameSession::current()
-      && !GameSession::current()->get_savegame().is_title_screen())
+  if (player_id != 0 && GameSession::current() && !GameSession::current()->is_cutscene())
   {
     bool player_is_in_sector = false;
 
@@ -58,7 +57,7 @@ MultiplayerPlayerMenu::MultiplayerPlayerMenu(int player_id)
       add_entry(_("Remove Player"), [player_id] {
         // Re-check everything that concerns the sector, it might have changed
         // (e. g. when unplugging a controller with auto-management enabled)
-        if (!GameSession::current() || GameSession::current()->get_savegame().is_title_screen())
+        if (!GameSession::current() || GameSession::current()->is_cutscene())
         {
           log_warning << "Attempt to force player to despawn while not in session"
                       << std::endl;
@@ -76,7 +75,7 @@ MultiplayerPlayerMenu::MultiplayerPlayerMenu(int player_id)
       add_entry(_("Respawn Player"), [player_id] {
         // Re-check everything that concerns the sector, it might have changed
         // (e. g. when unplugging a controller with auto-management enabled)
-        if (!GameSession::current() || GameSession::current()->get_savegame().is_title_screen())
+        if (!GameSession::current() || GameSession::current()->is_cutscene())
         {
           log_warning << "Attempt to force player to respawn while not in session"
                       << std::endl;
@@ -102,7 +101,7 @@ MultiplayerPlayerMenu::MultiplayerPlayerMenu(int player_id)
       add_entry(_("Spawn Player"), [player_id] {
         // Re-check everything that concerns the sector, it might have changed
         // (e. g. when unplugging a controller with auto-management enabled)
-        if (!GameSession::current() || GameSession::current()->get_savegame().is_title_screen())
+        if (!GameSession::current() || GameSession::current()->is_cutscene())
         {
           log_warning << "Attempt to force player to spawn while not in session"
                       << std::endl;

--- a/src/supertux/title_screen.cpp
+++ b/src/supertux/title_screen.cpp
@@ -150,7 +150,6 @@ TitleScreen::refresh_level()
       if (new_session)
       {
         m_titlesession = std::move(new_session);
-        m_titlesession->prevent_adding_players();
         level_init = true;
       }
     }
@@ -159,7 +158,6 @@ TitleScreen::refresh_level()
   {
     m_titlesession = std::make_unique<GameSession>(DEFAULT_TITLE_LEVEL, m_savegame, nullptr);
     m_titlesession->restart_level(false, true);
-    m_titlesession->prevent_adding_players();
     level_init = true;
   }
 


### PR DESCRIPTION
Plugging/unplugging controllers while on the main menu would add and remove players automatically. I've added an option to prevent this from happening.

Edit:

Per discussion further below, the new solution involves making certain levels as cutscenes, which, among others, prevents the level from having more than one player.

It also updates the code that had hardcoded checks for the title screen to check for that property instead, which is now shared with the credits scene and the introduction of the main story, and will later be by other cutscene levels.