### PR TITLE
Don't spawn a player immediately when a joystick is connected

### DIFF
--- a/src/control/game_controller_manager.hpp
+++ b/src/control/game_controller_manager.hpp
@@ -56,6 +56,9 @@ public:
   inline std::unordered_map<SDL_GameController*, int>& get_controller_mapping() { return m_game_controllers; }
 
 private:
+  void autobind_controller(SDL_GameController* game_controller);
+
+private:
   InputManager* m_parent;
   int m_deadzone;
   std::unordered_map<SDL_GameController*, int> m_game_controllers;

--- a/src/control/joystick_manager.hpp
+++ b/src/control/joystick_manager.hpp
@@ -64,6 +64,9 @@ public:
   inline std::unordered_map<SDL_Joystick*, int>& get_joystick_mapping() { return joysticks; }
 
 private:
+  void autobind_joystick(SDL_Joystick* joystick);
+
+private:
   InputManager* parent;
   JoystickConfig& m_joystick_config;
 


### PR DESCRIPTION
A connected joystick will no longer automatically spawn a player until the user presses A (Game controllers) or Jump (Joysticks).

The button is not reconfigurable in-game, but I can change it as needed.

## Design

If a controller is plugged in, no player is created until that user presses A. If a controller is disconnected, the player's character is removed from the game, but its information remains in memory, and when the controller is plugged back in, the player respawns immediately. This is to avoid too much frustration in case a game controller is unplugged by accident.

I tried to follow the code standards based on the surrounding code and my common sense, but I may have missed something. Do let me know if something needs to be modified code-wise.

---

To be discussed: How should we notify the user that a controller was plugged in and that they can press A to join immediately?