### PR TITLE
Fix linting (Remove unused variable)

### DIFF
--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -636,7 +636,6 @@ Main::launch_game(const CommandLineArguments& args)
       // we have a normal path specified at commandline, not a physfs path.
       // So we simply mount that path here...
       std::string dir = FileSystem::dirname(start_level);
-      const std::string filename = FileSystem::basename(start_level);
       const std::string fileProtocol = "file://";
       const std::string::size_type position = dir.find(fileProtocol);
       if (position != std::string::npos) {


### PR DESCRIPTION
This is the easiest fix for that issue; I'm not sure if the variable was an accidental leftover or an intended reminder for somebody, but just in case it's the former, I took the initiative to fix it so that the CI gives green checks everywhere again :)