### PR TITLE
Fix crash when activating 'Show collision rects' in debug menu

### DIFF
--- a/src/object/draggable_region.cpp
+++ b/src/object/draggable_region.cpp
@@ -38,15 +38,15 @@ DraggableRegion::DraggableRegion(Color color, const ReaderMapping &reader) :
 void
 DraggableRegion::draw_draggable_box(DrawingContext& context)
 {
-  if (!Editor::is_active() && !g_debug.show_collision_rects)
-    return;
-
   Rectf& box = m_col.m_bbox;
-  if (Editor::current()->get_draggables_visible())
+  if (Editor::is_active() && Editor::current()->get_draggables_visible())
   {
     context.color().draw_filled_rect(box, m_color, 0.0f, LAYER_OBJECTS);
     return;
   }
+
+  if (!g_debug.show_collision_rects)
+    return;
 
   context.color().draw_line(
         { box.get_left(), box.get_top() },


### PR DESCRIPTION
When activating 'Show collision rects' from the debug menu while Editor is not active, the game crashed with a nullptr access. This is fixed by separating the check for Editor active and the show collision rects flag from the debug menu.