### PR TITLE
Fix autotile mode not updating from menu

### DIFF
--- a/src/editor/editor.hpp
+++ b/src/editor/editor.hpp
@@ -202,6 +202,10 @@ public:
   void pack_addon();
   inline void on_exit(exit_cb_t exit_cb) { m_on_exit_cb = exit_cb; }
 
+  inline void update_autotile_mode() {
+    m_overlay_widget->update_autotile_mode();
+  }
+
 private:
   void set_sector(Sector* sector);
   void reload_level();

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1315,6 +1315,12 @@ EditorOverlayWidget::get_autotileset_key_range() const
 }
 
 void
+EditorOverlayWidget::update_autotile_mode()
+{
+  m_autotile_mode = g_config->editor_autotile_mode;
+}
+
+void
 EditorOverlayWidget::draw_tile_tip(DrawingContext& context)
 {
   if (m_editor.get_tileselect_input_type() == InputType::TILE)

--- a/src/editor/overlay_widget.hpp
+++ b/src/editor/overlay_widget.hpp
@@ -77,6 +77,8 @@ public:
 
   inline Vector get_sector_pos() const { return m_sector_pos; }
 
+  void update_autotile_mode();
+
 private:
   static bool action_pressed;
   static bool alt_pressed;

--- a/src/supertux/menu/editor_settings.cpp
+++ b/src/supertux/menu/editor_settings.cpp
@@ -16,6 +16,7 @@
 
 #include "supertux/menu/editor_settings.hpp"
 
+#include "editor/editor.hpp"
 #include "math/util.hpp"
 #include "gui/menu_item.hpp"
 #include "util/gettext.hpp"
@@ -47,7 +48,15 @@ EditorSettings::EditorSettings()
   add_toggle(-1, _("Render Animations"), &(g_config->editor_render_animations));
   add_toggle(-1, _("Invert Shift+Scroll"), &(g_config->editor_invert_shift_scroll));
   add_toggle(-1, _("Centered Zoom"), &(g_config->editor_zoom_centered));
-  add_toggle(-1, _("Autotile Mode"), &(g_config->editor_autotile_mode));
+  add_toggle(-1, _("Autotile Mode"), [] { return g_config->editor_autotile_mode; },
+    [] (bool v)
+    {
+      g_config->editor_autotile_mode = v;
+      if (Editor::current())
+      {
+        Editor::current()->update_autotile_mode();
+      }
+    });
   add_toggle(-1, _("Enable Autotile Help"), &(g_config->editor_autotile_help));
   add_toggle(-1, _("Enable Object Undo Tracking"), &(g_config->editor_undo_tracking));
 #if 0 // The option exists for those to mess with, but hidden because it's still a WIP


### PR DESCRIPTION
Going in the Editor settings menu, toggling the autotile mode and leaving the menu using only the mouse (not the escape key) would not update the status until Ctrl is pressed again.

I fixed this by making the overlay widget refresh immediately when the option changes using the callback implementation of the toggle option.

I'm not sure if this is the best fix possible, but it's a fix, so it can serve as a starting point should modifications be required.