### PR TITLE
Better description for keyboard vs controller in multiplayer

### DIFF
--- a/src/supertux/menu/multiplayer_player_menu.cpp
+++ b/src/supertux/menu/multiplayer_player_menu.cpp
@@ -23,6 +23,7 @@
 #include "control/input_manager.hpp"
 #include "control/joystick_manager.hpp"
 #include "gui/dialog.hpp"
+#include "gui/item_toggle.hpp"
 #include "object/player.hpp"
 #include "supertux/game_session.hpp"
 #include "supertux/gameconfig.hpp"
@@ -37,7 +38,8 @@ MultiplayerPlayerMenu::MultiplayerPlayerMenu(int player_id)
   add_label(fmt::format(_("Player {}"), player_id + 1));
   add_hl();
 
-  add_toggle(-1, _("Play with the keyboard"), &InputManager::current()->m_uses_keyboard[player_id]);
+  add_toggle(-1, _("Play with the keyboard"), &InputManager::current()->m_uses_keyboard[player_id])
+    .set_help(_("Don't automatically bind controllers to this player, and spawn it even if it has no controller."));
 
   if (player_id != 0 && GameSession::current()
       && !GameSession::current()->get_savegame().is_title_screen())

--- a/src/supertux/menu/multiplayer_players_menu.cpp
+++ b/src/supertux/menu/multiplayer_players_menu.cpp
@@ -45,7 +45,19 @@ MultiplayerPlayersMenu::MultiplayerPlayersMenu()
 
   if (InputManager::current()->can_add_user())
   {
-    add_entry(_("Add Player"), [] {
+    add_entry(_("Add Player (Keyboard)"), [] {
+      InputManager::current()->push_user();
+      InputManager::current()->m_uses_keyboard[InputManager::current()->get_num_users() - 1] = true;
+
+      if (GameSession::current() && GameSession::current()->get_savegame().get_player_status().m_num_players < InputManager::current()->get_num_users())
+      {
+        GameSession::current()->get_savegame().get_player_status().add_player();
+      }
+
+      MenuManager::instance().set_menu(std::make_unique<MultiplayerPlayersMenu>());
+    });
+
+    add_entry(_("Add Player (Controller)"), [] {
       InputManager::current()->push_user();
 
       if (GameSession::current() && GameSession::current()->get_savegame().get_player_status().m_num_players < InputManager::current()->get_num_users())


### PR DESCRIPTION
I've improved the keyboard vs controller in the multiplayer settings with two changes:
- The "Add player" option has been duplicated in "Add player (keyboard)" and "Add player (controller)" to make it more visible that someone can play primarily with the keyboard or with the controller.
- The "Play with the keyboard" option now has a description to explain what it does. Technically, any player can be played with either the keyboard or the controller bound to it (if any) at any time; this option only offer quality-of-life features.