### PR TITLE
Add option to allow ignoring the hardcoded player limit

### DIFF
--- a/src/control/input_manager.cpp
+++ b/src/control/input_manager.cpp
@@ -21,6 +21,8 @@
 #include "control/joystick_config.hpp"
 #include "control/joystick_manager.hpp"
 #include "control/keyboard_manager.hpp"
+#include "supertux/gameconfig.hpp"
+#include "supertux/globals.hpp"
 #include "util/log.hpp"
 
 static constexpr int MAX_PLAYERS = 4;
@@ -56,7 +58,7 @@ InputManager::get_controller(int player_id)
 bool
 InputManager::can_add_user() const
 {
-  return get_num_users() < MAX_PLAYERS;
+  return get_num_users() < MAX_PLAYERS || g_config->multiplayer_no_limit;
 }
 
 void

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -142,6 +142,7 @@ Config::Config() :
   // and those with an older SDL; they won't have to check the setting each time.
   multiplayer_buzz_controllers(false),
 #endif
+  multiplayer_no_limit(false),
   touch_haptic_feedback(true),
   touch_just_directional(true),
   repository_url()
@@ -293,6 +294,7 @@ Config::load()
   config_mapping.get("multiplayer_auto_manage_players", multiplayer_auto_manage_players);
   config_mapping.get("multiplayer_multibind", multiplayer_multibind);
   config_mapping.get("multiplayer_buzz_controllers", multiplayer_buzz_controllers);
+  config_mapping.get("multiplayer_no_limit", multiplayer_no_limit);
   config_mapping.get("preferred_text_editor", preferred_text_editor);
 
   std::optional<ReaderMapping> config_video_mapping;
@@ -457,6 +459,7 @@ Config::save()
   writer.write("multiplayer_auto_manage_players", multiplayer_auto_manage_players);
   writer.write("multiplayer_multibind", multiplayer_multibind);
   writer.write("multiplayer_buzz_controllers", multiplayer_buzz_controllers);
+  writer.write("multiplayer_no_limit", multiplayer_no_limit);
   writer.write("preferred_text_editor", preferred_text_editor);
 
   writer.start_list("interface_colors");

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -179,6 +179,7 @@ public:
   bool multiplayer_auto_manage_players;
   bool multiplayer_multibind;
   bool multiplayer_buzz_controllers;
+  bool multiplayer_no_limit;
 
   std::string repository_url;
 

--- a/src/supertux/menu/multiplayer_menu.cpp
+++ b/src/supertux/menu/multiplayer_menu.cpp
@@ -33,6 +33,9 @@ MultiplayerMenu::MultiplayerMenu()
   add_toggle(-2, _("Allow Multibind"), &g_config->multiplayer_multibind)
     .set_help(_("Allow binding multiple joysticks to a single player"));
 
+  add_toggle(-3, _("Unlock player limit"), &g_config->multiplayer_no_limit)
+    .set_help(_("Allow having more than 4 players. Some interface elements may overflow out of the screen."));
+
   add_submenu(_("Manage Players"), MenuStorage::MULTIPLAYER_PLAYERS_MENU);
 
   add_hl();


### PR DESCRIPTION
Since the player limit isn't based on a technical limitation, but rather only on graphical convenience, I added an option to allow users to ignore the limit if they want to play with 5 or more players.

The limit is retained by default, as some HUD elements overflow off the screen (currently, only the item pocket) when too many players are added.

I wrote a note in the option's description about the HUD overflowing.