### PR TITLE
Fix leafshot getting killed instantly after being dispensed on macOS

### DIFF
--- a/src/badguy/kamikazesnowball.cpp
+++ b/src/badguy/kamikazesnowball.cpp
@@ -100,6 +100,7 @@ LeafShot::LeafShot(const ReaderMapping& reader) :
   KamikazeSnowball(reader, "images/creatures/leafshot/leafshot.sprite")
 {
   parse_type(reader);
+  set_action (m_dir, /* loops = */ -1);
 }
 
 void


### PR DESCRIPTION
Another attempt to fix #3463 as it has been reintroduced with acb76ca02e4dcf943a07cfde52ff4d92be83c8f8.