### PR TITLE
Fix WASM builds by removing `libraqm` dependency.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
     "fmt",
     "libogg",
     "libvorbis",
-    "libraqm",
     "freetype",
     "physfs",
     "glm",
@@ -18,7 +17,8 @@
         "sdl2",
         "sdl2-image",
         "curl",
-        "openal-soft"
+        "openal-soft",
+        "libraqm"
       ],
       "supports": "!emscripten"
     },


### PR DESCRIPTION
libraqm tests fail to build on WASM. Currently, upstream libraqm does not offer support for skipping the building of tests, so I'm gonna disable libraqm installation on WASM altogether.

See https://github.com/microsoft/vcpkg/issues/49390 and https://github.com/HOST-Oman/libraqm/issues/208

Are you guys okay with this solution until the upstream (vcpkg or libraqm) issue is fixed?