### PR TITLE
Give the Teleporter object a default sprite

### DIFF
--- a/src/worldmap/teleporter.cpp
+++ b/src/worldmap/teleporter.cpp
@@ -17,6 +17,7 @@
 
 #include "worldmap/teleporter.hpp"
 
+#include "sprite/sprite_manager.hpp"
 #include "util/reader_mapping.hpp"
 
 namespace worldmap {
@@ -30,7 +31,7 @@ Teleporter::Teleporter(const ReaderMapping& mapping) :
   m_message()
 {
   if (in_worldmap() && !has_found_sprite()) // In worldmap and no valid sprite is specified, remove it
-    m_sprite.reset();
+    m_sprite = SpriteManager::current()->create("images/worldmap/common/teleporterdot.sprite");
 
   mapping.get("worldmap", m_worldmap);
   mapping.get("sector", m_sector);


### PR DESCRIPTION
The MovingSprite class expects a non-null `m_sprite` at all times; the worldmap Teleporter would set it to null if its sprite was not found.

The behavior has been replaced by loading the default sprite instead.

The buggy behavior can be observed by attempting to run `./supertux2 --edit-level levels/world1/worldmap.stwm`. It will crash with a segfault somewhere within the MovingSprite class.

---

This may or may not be the desired fix; I did not find any visible difference in practice, and a missing teleporter sprite doesn't sound like something that should happen in practice, but if needed, I can replace the sprite with an invisible sprite or something else.

---

While fixing this, I added a bunch of assertions in the code to check for unexpected conditions (such as a MovingSprite having a null sprite). Assertions are practical because they allow catching bugs early, but aren't compiled in Release builds, and therefore won't affect the end users' experience. Would it be worth pushing the assertions I wrote in a separate PR?