### PR TITLE
Fix worldmap not being tested properly when the editor was launched from the CLI

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -591,6 +591,13 @@ Editor::test_level(const std::optional<std::pair<std::string, Vector>>& test_pos
     return;
   }
 
+  if (m_level->is_worldmap() && !m_world)
+  {
+    Dialog::show_message(_("The worldmap cannot be tested when the editor was "
+                           "launched from the command line.\n\n"));
+    return;
+  }
+
   Tile::draw_editor_images = false;
   Compositor::s_render_lighting = true;
 


### PR DESCRIPTION
When launching SuperTux to open a worldmap in the editor, attempting to test the worldmap will make the game try to interpret the worldmap as a normal level.

Running `./supertux2 --edit-level levels/world1/worldmap.stwm` then pressing Ctrl+T (or Escape, then selecting the "Test level" option) will show the problematic behavior.

Since fixing the issue would require a certain amount of refactoring (allowing to play world maps without a world/savegame), and we are close to a release, I opted to prevent playtesting worldmaps in those conditions.