### PR TITLE
Support relative paths from the CLI

### DIFF
--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -637,7 +637,13 @@ Main::launch_game(const CommandLineArguments& args)
     for(auto start_level : args.filenames)
     {
       // PhysFS doesn't like relative paths
+#ifdef WIN32
+      std::wstring wpath = std::filesystem::weakly_canonical({ start_level });
+      std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+      start_level = converter.to_bytes(wpath);
+#else
       start_level = std::filesystem::weakly_canonical({ start_level });
+#endif
 
       // we have a normal path specified at commandline, not a physfs path.
       // So we simply mount that path here...


### PR DESCRIPTION
Providing an absolute path or a path relative to the data directory works, but relative paths to the CWD weren't appreciated by PhysFS if they contain `..`. Canonizing the paths helps.