### PR TITLE
video: Switch DrawingRequest to a variant

### DIFF
--- a/src/video/compositor.cpp
+++ b/src/video/compositor.cpp
@@ -108,18 +108,19 @@ Compositor::render()
       if (texture)
       {
         DrawingTransform transform(m_video_system.get_viewport());
-        TextureRequest request(transform);
+        DrawingRequest request(transform);
+        auto&& req_var = std::get<TextureRequest>(request.request);
 
         request.blend = Blend::MOD;
 
-        request.srcrects.emplace_back(0.0f, 0.0f,
+        req_var.srcrects.emplace_back(0.0f, 0.0f,
                                       static_cast<float>(texture->get_image_width()),
                                       static_cast<float>(texture->get_image_height()));
-        request.dstrects.emplace_back(Vector(0.0f, 0.0f), lightmap.get_logical_size());
-        request.angles.emplace_back(0.0f);
+        req_var.dstrects.emplace_back(Vector(0.0f, 0.0f), lightmap.get_logical_size());
+        req_var.angles.emplace_back(0.0f);
 
-        request.texture = texture.get();
-        request.color = Color::WHITE;
+        req_var.texture = texture.get();
+        req_var.color = Color::WHITE;
 
         renderer.get_painter().draw_texture(request);
       }

--- a/src/video/drawing_request.hpp
+++ b/src/video/drawing_request.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <memory>
+#include <variant>
 
 #include "math/rectf.hpp"
 #include "math/sizef.hpp"
@@ -30,72 +31,18 @@
 
 class Surface;
 
-enum class RequestType
+struct TextureRequest
 {
-  TEXTURE, GRADIENT, FILLRECT, INVERSEELLIPSE, GETPIXEL, LINE, TRIANGLE
-};
-
-struct DrawingRequest
-{
-  int layer;
-  Flip flip;
-  float alpha;
-  Blend blend;
-  const Rect viewport;
-
-  DrawingRequest() = delete;
-  DrawingRequest(const DrawingTransform& transform) :
-    layer(),
-    flip(transform.flip),
-    alpha(transform.alpha),
-    blend(),
-    viewport(transform.viewport)
-  {}
-  virtual ~DrawingRequest() {}
-
-  virtual RequestType get_type() const = 0;
-};
-
-struct TextureRequest : public DrawingRequest
-{
-  TextureRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    texture(),
-    displacement_texture(),
-    srcrects(),
-    dstrects(),
-    angles(),
-    color(1.0f, 1.0f, 1.0f)
-  {}
-
-  RequestType get_type() const override { return RequestType::TEXTURE; }
-
   const Texture* texture;
   const Texture* displacement_texture;
   std::vector<Rectf> srcrects;
   std::vector<Rectf> dstrects;
   std::vector<float> angles;
   Color color;
-
-private:
-  TextureRequest(const TextureRequest&) = delete;
-  TextureRequest& operator=(const TextureRequest&) = delete;
 };
 
-struct GradientRequest : public DrawingRequest
+struct GradientRequest
 {
-  GradientRequest(const DrawingTransform& transform)  :
-    DrawingRequest(transform),
-    pos(0.0f, 0.0f),
-    size(0.0f, 0.0f),
-    top(),
-    bottom(),
-    direction(),
-    region()
-  {}
-
-  RequestType get_type() const override { return RequestType::GRADIENT; }
-
   Vector pos;
   Vector size;
   Color top;
@@ -104,86 +51,66 @@ struct GradientRequest : public DrawingRequest
   Rectf region;
 };
 
-struct FillRectRequest : public DrawingRequest
+struct FillRectRequest
 {
-  FillRectRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    rect(),
-    color(),
-    radius(),
-    blur()
-  {}
-
-  RequestType get_type() const override { return RequestType::FILLRECT; }
-
   Rectf rect;
   Color color;
   float radius;
   int blur;
 };
 
-struct InverseEllipseRequest : public DrawingRequest
+struct InverseEllipseRequest
 {
-  InverseEllipseRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    pos(0.0f, 0.0f),
-    size(0.0f, 0.0f),
-    color()
-  {}
-
-  RequestType get_type() const override { return RequestType::INVERSEELLIPSE; }
-
   Vector pos;
   Vector size;
   Color color;
 };
 
-struct LineRequest : public DrawingRequest
+struct LineRequest
 {
-  LineRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    pos(0.0f, 0.0f),
-    dest_pos(0.0f, 0.0f),
-    color()
-  {}
-
-  RequestType get_type() const override { return RequestType::LINE; }
-
   Vector pos;
   Vector dest_pos;
   Color color;
 };
 
-struct TriangleRequest : public DrawingRequest
+struct TriangleRequest
 {
-  TriangleRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    pos1(0.0f, 0.0f),
-    pos2(0.0f, 0.0f),
-    pos3(0.0f, 0.0f),
-    color()
-  {}
-
-  RequestType get_type() const override { return RequestType::TRIANGLE; }
-
   Vector pos1, pos2, pos3;
   Color  color;
 };
 
-struct GetPixelRequest : public DrawingRequest
+struct GetPixelRequest
 {
-  GetPixelRequest(const DrawingTransform& transform) :
-    DrawingRequest(transform),
-    pos(0.0f, 0.0f),
-    color_ptr()
-  {}
-
-  RequestType get_type() const override { return RequestType::GETPIXEL; }
-
   Vector pos;
   std::shared_ptr<Color> color_ptr;
+};
 
-private:
-  GetPixelRequest(const GetPixelRequest&) = delete;
-  GetPixelRequest& operator=(const GetPixelRequest&) = delete;
+struct DrawingRequest
+{
+  using RequestVariant =
+    std::variant<TextureRequest,
+                 GradientRequest,
+                 FillRectRequest,
+                 InverseEllipseRequest,
+                 LineRequest,
+                 TriangleRequest,
+                 GetPixelRequest>;
+  int layer;
+  Flip flip;
+  float alpha;
+  Blend blend;
+  const Rect viewport;
+  RequestVariant request;
+
+  DrawingRequest() = delete;
+  DrawingRequest(const DrawingTransform& transform) :
+    layer(),
+    flip(transform.flip),
+    alpha(transform.alpha),
+    blend(),
+    viewport(transform.viewport),
+    request()
+  {}
+  ~DrawingRequest() {}
+
 };

--- a/src/video/gl/gl_painter.cpp
+++ b/src/video/gl/gl_painter.cpp
@@ -68,8 +68,9 @@ GLPainter::GLPainter(GLVideoSystem& video_system, GLRenderer& renderer) :
 }
 
 void
-GLPainter::draw_texture(const TextureRequest& request)
+GLPainter::draw_texture(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<TextureRequest>(draw_req.request);
   assert_gl();
 
   const auto& texture = static_cast<const GLTexture&>(*request.texture);
@@ -79,7 +80,7 @@ GLPainter::draw_texture(const TextureRequest& request)
 
   m_vertices.reserve(request.srcrects.size() * 12);
   m_uvs.reserve(request.srcrects.size() * 12);
-  
+
   m_vertices.clear();
   m_uvs.clear();
 
@@ -95,10 +96,10 @@ GLPainter::draw_texture(const TextureRequest& request)
     float uv_right = request.srcrects[i].get_right() / static_cast<float>(texture.get_texture_width());
     float uv_bottom = request.srcrects[i].get_bottom() / static_cast<float>(texture.get_texture_height());
 
-    if (request.flip & HORIZONTAL_FLIP)
+    if (draw_req.flip & HORIZONTAL_FLIP)
       std::swap(uv_left, uv_right);
 
-    if (request.flip & VERTICAL_FLIP)
+    if (draw_req.flip & VERTICAL_FLIP)
       std::swap(uv_top, uv_bottom);
 
     if (request.angles[i] == 0.0f)
@@ -166,14 +167,14 @@ GLPainter::draw_texture(const TextureRequest& request)
 
   GLContext& context = m_video_system.get_context();
 
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_texture(texture, request.displacement_texture);
   context.set_texcoords(m_uvs.data(), sizeof(float) * m_uvs.size());
   context.set_positions(m_vertices.data(), sizeof(float) * m_vertices.size());
   context.set_color(Color(request.color.red,
                           request.color.green,
                           request.color.blue,
-                          request.color.alpha * request.alpha));
+                          request.color.alpha * draw_req.alpha));
 
   context.draw_arrays(GL_TRIANGLES, 0, static_cast<GLsizei>(request.srcrects.size() * 2 * 3));
 
@@ -181,8 +182,9 @@ GLPainter::draw_texture(const TextureRequest& request)
 }
 
 void
-GLPainter::draw_gradient(const GradientRequest& request)
+GLPainter::draw_gradient(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<GradientRequest>(draw_req.request);
   assert_gl();
 
   const Color& top = request.top;
@@ -199,7 +201,7 @@ GLPainter::draw_gradient(const GradientRequest& request)
     region.get_left(), region.get_bottom()
   };
 
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_no_texture();
   context.set_positions(vertices, sizeof(vertices));
   context.set_texcoord(0.0f, 0.0f);
@@ -231,14 +233,15 @@ GLPainter::draw_gradient(const GradientRequest& request)
 }
 
 void
-GLPainter::draw_filled_rect(const FillRectRequest& request)
+GLPainter::draw_filled_rect(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<FillRectRequest>(draw_req.request);
   assert_gl();
 
   GLContext& context = m_video_system.get_context();
 
   context.set_blur(request.blur);
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_no_texture();
   context.set_texcoord(0.0f, 0.0f);
   context.set_color(request.color);
@@ -314,8 +317,9 @@ GLPainter::draw_filled_rect(const FillRectRequest& request)
 }
 
 void
-GLPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
+GLPainter::draw_inverse_ellipse(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<InverseEllipseRequest>(draw_req.request);
   assert_gl();
 
   const float& x = request.pos.x;
@@ -384,7 +388,7 @@ GLPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
 
   GLContext& context = m_video_system.get_context();
 
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_no_texture();
   context.set_positions(vertices, sizeof(vertices));
   context.set_texcoord(0.0f, 0.0f);
@@ -396,8 +400,9 @@ GLPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
 }
 
 void
-GLPainter::draw_line(const LineRequest& request)
+GLPainter::draw_line(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<LineRequest>(draw_req.request);
   assert_gl();
 
   Vector viewport_scale = m_video_system.get_viewport().get_scale();
@@ -427,7 +432,7 @@ GLPainter::draw_line(const LineRequest& request)
 
   GLContext& context = m_video_system.get_context();
 
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_no_texture();
   context.set_positions(vertices, sizeof(vertices));
   context.set_texcoord(0.0f, 0.0f);
@@ -439,8 +444,9 @@ GLPainter::draw_line(const LineRequest& request)
 }
 
 void
-GLPainter::draw_triangle(const TriangleRequest& request)
+GLPainter::draw_triangle(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<TriangleRequest>(draw_req.request);
   assert_gl();
 
   const float vertices[] = {
@@ -451,7 +457,7 @@ GLPainter::draw_triangle(const TriangleRequest& request)
 
   GLContext& context = m_video_system.get_context();
 
-  context.blend_func(sfactor(request.blend), dfactor(request.blend));
+  context.blend_func(sfactor(draw_req.blend), dfactor(draw_req.blend));
   context.bind_no_texture();
   context.set_texcoord(0.0f, 0.0f);
   context.set_positions(vertices, sizeof(vertices));
@@ -474,8 +480,9 @@ GLPainter::clear(const Color& color)
 }
 
 void
-GLPainter::get_pixel(const GetPixelRequest& request) const
+GLPainter::get_pixel(const DrawingRequest& draw_req) const
 {
+  auto&& request = std::get<GetPixelRequest>(draw_req.request);
   assert_gl();
 
   const Rect& rect = m_renderer.get_rect();

--- a/src/video/gl/gl_painter.hpp
+++ b/src/video/gl/gl_painter.hpp
@@ -29,15 +29,15 @@ class GLPainter final : public Painter
 public:
   GLPainter(GLVideoSystem& video_system, GLRenderer& renderer);
 
-  virtual void draw_texture(const TextureRequest& request) override;
-  virtual void draw_gradient(const GradientRequest& request) override;
-  virtual void draw_filled_rect(const FillRectRequest& request) override;
-  virtual void draw_inverse_ellipse(const InverseEllipseRequest& request) override;
-  virtual void draw_line(const LineRequest& request) override;
-  virtual void draw_triangle(const TriangleRequest& request) override;
+  virtual void draw_texture(const DrawingRequest& request) override;
+  virtual void draw_gradient(const DrawingRequest& request) override;
+  virtual void draw_filled_rect(const DrawingRequest& request) override;
+  virtual void draw_inverse_ellipse(const DrawingRequest& request) override;
+  virtual void draw_line(const DrawingRequest& request) override;
+  virtual void draw_triangle(const DrawingRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
+  virtual void get_pixel(const DrawingRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;

--- a/src/video/null/null_painter.cpp
+++ b/src/video/null/null_painter.cpp
@@ -28,37 +28,37 @@ NullPainter::~NullPainter()
 }
 
 void
-NullPainter::draw_texture(const TextureRequest& request)
+NullPainter::draw_texture(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_texture()" << std::endl;
 }
 
 void
-NullPainter::draw_gradient(const GradientRequest& request)
+NullPainter::draw_gradient(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_gradient()" << std::endl;
 }
 
 void
-NullPainter::draw_filled_rect(const FillRectRequest& request)
+NullPainter::draw_filled_rect(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_filled_rect()" << std::endl;
 }
 
 void
-NullPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
+NullPainter::draw_inverse_ellipse(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_inverse_ellipse()" << std::endl;
 }
 
 void
-NullPainter::draw_line(const LineRequest& request)
+NullPainter::draw_line(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_line()" << std::endl;
 }
 
 void
-NullPainter::draw_triangle(const TriangleRequest& request)
+NullPainter::draw_triangle(const DrawingRequest& request)
 {
   log_info << "NullPainter::draw_triangle()" << std::endl;
 }
@@ -71,7 +71,7 @@ NullPainter::clear(const Color& color)
 }
 
 void
-NullPainter::get_pixel(const GetPixelRequest& request) const
+NullPainter::get_pixel(const DrawingRequest& request) const
 {
   log_info << "NullPainter::get_pixel()" << std::endl;
 }

--- a/src/video/null/null_painter.hpp
+++ b/src/video/null/null_painter.hpp
@@ -26,15 +26,15 @@ public:
   NullPainter();
   ~NullPainter() override;
 
-  virtual void draw_texture(const TextureRequest& request) override;
-  virtual void draw_gradient(const GradientRequest& request) override;
-  virtual void draw_filled_rect(const FillRectRequest& request) override;
-  virtual void draw_inverse_ellipse(const InverseEllipseRequest& request) override;
-  virtual void draw_line(const LineRequest& request) override;
-  virtual void draw_triangle(const TriangleRequest& request) override;
+  virtual void draw_texture(const DrawingRequest& request) override;
+  virtual void draw_gradient(const DrawingRequest& request) override;
+  virtual void draw_filled_rect(const DrawingRequest& request) override;
+  virtual void draw_inverse_ellipse(const DrawingRequest& request) override;
+  virtual void draw_line(const DrawingRequest& request) override;
+  virtual void draw_triangle(const DrawingRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
+  virtual void get_pixel(const DrawingRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;

--- a/src/video/painter.hpp
+++ b/src/video/painter.hpp
@@ -38,15 +38,15 @@ public:
   Painter() {}
   virtual ~Painter() {}
 
-  virtual void draw_texture(const TextureRequest& request) = 0;
-  virtual void draw_gradient(const GradientRequest& request) = 0;
-  virtual void draw_filled_rect(const FillRectRequest& request) = 0;
-  virtual void draw_inverse_ellipse(const InverseEllipseRequest& request) = 0;
-  virtual void draw_line(const LineRequest& request) = 0;
-  virtual void draw_triangle(const TriangleRequest& request) = 0;
+  virtual void draw_texture(const DrawingRequest& request) = 0;
+  virtual void draw_gradient(const DrawingRequest& request) = 0;
+  virtual void draw_filled_rect(const DrawingRequest& request) = 0;
+  virtual void draw_inverse_ellipse(const DrawingRequest& request) = 0;
+  virtual void draw_line(const DrawingRequest& request) = 0;
+  virtual void draw_triangle(const DrawingRequest& request) = 0;
 
   virtual void clear(const Color& color) = 0;
-  virtual void get_pixel(const GetPixelRequest& request) const = 0;
+  virtual void get_pixel(const DrawingRequest& request) const = 0;
 
   virtual void set_clip_rect(const Rect& rect) = 0;
   virtual void clear_clip_rect() = 0;

--- a/src/video/sdl/sdl_painter.cpp
+++ b/src/video/sdl/sdl_painter.cpp
@@ -210,8 +210,9 @@ SDLPainter::SDLPainter(SDLVideoSystem& video_system, Renderer& renderer, SDL_Ren
 {}
 
 void
-SDLPainter::draw_texture(const TextureRequest& request)
+SDLPainter::draw_texture(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<TextureRequest>(draw_req.request);
   const auto& texture = static_cast<const SDLTexture&>(*request.texture);
 
   assert(request.srcrects.size() == request.dstrects.size());
@@ -225,19 +226,19 @@ SDLPainter::draw_texture(const TextureRequest& request)
     Uint8 r = static_cast<Uint8>(request.color.red * 255);
     Uint8 g = static_cast<Uint8>(request.color.green * 255);
     Uint8 b = static_cast<Uint8>(request.color.blue * 255);
-    Uint8 a = static_cast<Uint8>(request.color.alpha * request.alpha * 255);
+    Uint8 a = static_cast<Uint8>(request.color.alpha * draw_req.alpha * 255);
 
     SDL_SetTextureColorMod(texture.get_texture(), r, g, b);
     SDL_SetTextureAlphaMod(texture.get_texture(), a);
-    SDL_SetTextureBlendMode(texture.get_texture(), blend2sdl(request.blend));
+    SDL_SetTextureBlendMode(texture.get_texture(), blend2sdl(draw_req.blend));
 
     SDL_RendererFlip flip = SDL_FLIP_NONE;
-    if ((request.flip & HORIZONTAL_FLIP) != 0)
+    if ((draw_req.flip & HORIZONTAL_FLIP) != 0)
     {
       flip = static_cast<SDL_RendererFlip>(flip | SDL_FLIP_HORIZONTAL);
     }
 
-    if ((request.flip & VERTICAL_FLIP) != 0)
+    if ((draw_req.flip & VERTICAL_FLIP) != 0)
     {
       flip = static_cast<SDL_RendererFlip>(flip | SDL_FLIP_VERTICAL);
     }
@@ -250,8 +251,9 @@ SDLPainter::draw_texture(const TextureRequest& request)
 }
 
 void
-SDLPainter::draw_gradient(const GradientRequest& request)
+SDLPainter::draw_gradient(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<GradientRequest>(draw_req.request);
   const Color& top = request.top;
   const Color& bottom = request.bottom;
   const GradientDirection& direction = request.direction;
@@ -343,15 +345,16 @@ SDLPainter::draw_gradient(const GradientRequest& request)
       a = static_cast<Uint8>(((1.0f - p) * top.alpha + p * bottom.alpha) * 255);
     }
 
-    SDL_SetRenderDrawBlendMode(m_sdl_renderer, blend2sdl(request.blend));
+    SDL_SetRenderDrawBlendMode(m_sdl_renderer, blend2sdl(draw_req.blend));
     SDL_SetRenderDrawColor(m_sdl_renderer, r, g, b, a);
     SDL_RenderFillRect(m_sdl_renderer, &rect);
   }
 }
 
 void
-SDLPainter::draw_filled_rect(const FillRectRequest& request)
+SDLPainter::draw_filled_rect(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<FillRectRequest>(draw_req.request);
   SDL_FRect rect = request.rect.to_sdl();
 
   Uint8 r = static_cast<Uint8>(request.color.red * 255);
@@ -419,8 +422,9 @@ SDLPainter::draw_filled_rect(const FillRectRequest& request)
 }
 
 void
-SDLPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
+SDLPainter::draw_inverse_ellipse(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<InverseEllipseRequest>(draw_req.request);
   float x = request.pos.x;
   float w = request.size.x;
   float h = request.size.y;
@@ -475,8 +479,9 @@ SDLPainter::draw_inverse_ellipse(const InverseEllipseRequest& request)
 }
 
 void
-SDLPainter::draw_line(const LineRequest& request)
+SDLPainter::draw_line(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<LineRequest>(draw_req.request);
   Uint8 r = static_cast<Uint8>(request.color.red * 255);
   Uint8 g = static_cast<Uint8>(request.color.green * 255);
   Uint8 b = static_cast<Uint8>(request.color.blue * 255);
@@ -536,8 +541,9 @@ draw_span_between_edges(SDL_Renderer* renderer, const Edge& e1, const Edge& e2)
 } // namespace
 
 void
-SDLPainter::draw_triangle(const TriangleRequest& request)
+SDLPainter::draw_triangle(const DrawingRequest& draw_req)
 {
+  auto&& request = std::get<TriangleRequest>(draw_req.request);
   Uint8 r = static_cast<Uint8>(request.color.red * 255);
   Uint8 g = static_cast<Uint8>(request.color.green * 255);
   Uint8 b = static_cast<Uint8>(request.color.blue * 255);
@@ -614,8 +620,9 @@ SDLPainter::clear_clip_rect()
 }
 
 void
-SDLPainter::get_pixel(const GetPixelRequest& request) const
+SDLPainter::get_pixel(const DrawingRequest& draw_req) const
 {
+  auto&& request = std::get<GetPixelRequest>(draw_req.request);
   const Rect& rect = m_renderer.get_rect();
   const Size& logical_size = m_renderer.get_logical_size();
 

--- a/src/video/sdl/sdl_painter.hpp
+++ b/src/video/sdl/sdl_painter.hpp
@@ -31,15 +31,15 @@ class SDLPainter final : public Painter
 public:
   SDLPainter(SDLVideoSystem& video_system, Renderer& renderer, SDL_Renderer* sdl_renderer);
 
-  virtual void draw_texture(const TextureRequest& request) override;
-  virtual void draw_gradient(const GradientRequest& request) override;
-  virtual void draw_filled_rect(const FillRectRequest& request) override;
-  virtual void draw_inverse_ellipse(const InverseEllipseRequest& request) override;
-  virtual void draw_line(const LineRequest& request) override;
-  virtual void draw_triangle(const TriangleRequest& request) override;
+  virtual void draw_texture(const DrawingRequest& request) override;
+  virtual void draw_gradient(const DrawingRequest& request) override;
+  virtual void draw_filled_rect(const DrawingRequest& request) override;
+  virtual void draw_inverse_ellipse(const DrawingRequest& request) override;
+  virtual void draw_line(const DrawingRequest& request) override;
+  virtual void draw_triangle(const DrawingRequest& request) override;
 
   virtual void clear(const Color& color) override;
-  virtual void get_pixel(const GetPixelRequest& request) const override;
+  virtual void get_pixel(const DrawingRequest& request) const override;
 
   virtual void set_clip_rect(const Rect& rect) override;
   virtual void clear_clip_rect() override;


### PR DESCRIPTION
This switches DrawingRequest to a variant.

This isn't a mindboggling change in terms of performance, but it better opens the doors for such things. We can probably look further into how obstack is used and stop using an std::vector<DrawingRequest*>. For now, let's get this out of the way.