### PR TITLE
Add a toggle for screen shake effects

### DIFF
--- a/src/object/camera.cpp
+++ b/src/object/camera.cpp
@@ -248,7 +248,7 @@ Camera::reset(const Vector& tuxpos)
 void
 Camera::shake(float duration, float x, float y)
 {
-  if (!g_config->screen_shake)
+  if (g_config->screen_shake_mode == Config::ScreenShakeMode::OFF)
     return;
 
   m_shaketimer.start(duration*100.f);
@@ -260,7 +260,7 @@ Camera::shake(float duration, float x, float y)
 void
 Camera::start_earthquake(float strength, float delay)
 {
-  if (!g_config->screen_shake) {
+  if (g_config->screen_shake_mode != Config::ScreenShakeMode::FULL) {
     return;
   }
   if (strength <= 0.f)
@@ -433,7 +433,7 @@ Camera::update_shake()
 void
 Camera::update_earthquake()
 {
-  if (m_earthquake && !g_config->screen_shake)
+  if (m_earthquake && g_config->screen_shake_mode != Config::ScreenShakeMode::FULL)
     stop_earthquake();
 
   if (!m_earthquake)

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -18,6 +18,7 @@
 
 #include <ctime>
 #include <config.h>
+#include <string>
 
 #include "editor/overlay_widget.hpp"
 #include "math/util.hpp"
@@ -65,7 +66,7 @@ Config::Config() :
   sound_volume(100),
   music_volume(50),
   flash_intensity(50),
-  screen_shake(true),
+  screen_shake_mode(ScreenShakeMode::FULL),
   max_viewport(false),
   fancy_gfx(true),
   precise_scrolling(true),
@@ -329,7 +330,19 @@ Config::load()
     config_video_mapping->get("aspect_width",  aspect_size.width);
     config_video_mapping->get("aspect_height", aspect_size.height);
     config_video_mapping->get("flash_intensity", flash_intensity);
-    config_video_mapping->get("screen_shake", screen_shake);
+    {
+      std::string screen_shake_mode_string;
+      config_video_mapping->get("screen_shake_mode", screen_shake_mode_string, "full");
+      if (screen_shake_mode_string == "off") {
+        screen_shake_mode = ScreenShakeMode::OFF;
+      } else if (screen_shake_mode_string == "reduced") {
+        screen_shake_mode = ScreenShakeMode::REDUCED;
+      } else if (screen_shake_mode_string == "full") {
+        screen_shake_mode = ScreenShakeMode::FULL;
+      } else {
+        throw std::runtime_error("invalid screen shake mode, valid values are 'off', 'reduced', and 'full'");
+      }
+    }
 
     config_video_mapping->get("magnification", magnification);
     config_video_mapping->get("fancy_gfx", fancy_gfx);
@@ -506,7 +519,21 @@ Config::save()
   writer.write("aspect_height", aspect_size.height);
 
   writer.write("flash_intensity", flash_intensity);
-  writer.write("screen_shake", screen_shake);
+  {
+    std::string screen_shake_mode_string;
+    switch (screen_shake_mode) {
+      case ScreenShakeMode::OFF:
+        screen_shake_mode_string = "off";
+        break;
+      case ScreenShakeMode::REDUCED:
+        screen_shake_mode_string = "reduced";
+        break;
+      case ScreenShakeMode::FULL:
+        screen_shake_mode_string = "full";
+        break;
+    }
+    writer.write("screen_shake_mode", screen_shake_mode_string);
+  }
 
 #ifdef __EMSCRIPTEN__
   // Forcibly set autofit to true

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -28,6 +28,11 @@
 class Config final
 {
 public:
+  enum class ScreenShakeMode {
+    OFF, REDUCED, FULL
+  };
+
+public:
   Config();
 
   void load();
@@ -79,7 +84,7 @@ public:
   int sound_volume;
   int music_volume;
   int flash_intensity;
-  bool screen_shake;
+  ScreenShakeMode screen_shake_mode;
   bool precise_scrolling;
   bool invert_wheel_x;
   bool invert_wheel_y;

--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -37,6 +37,7 @@
 #include "video/video_system.hpp"
 #include "video/viewport.hpp"
 
+#include <cassert>
 #include <sstream>
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -64,6 +65,7 @@ OptionsMenu::OptionsMenu(Type type, bool complete) :
   m_window_resolutions(),
   m_resolutions(),
   m_vsyncs(),
+  m_screen_shake_modes(),
   m_sound_volumes(),
   m_music_volumes(),
   m_flash_intensity_values(),
@@ -129,8 +131,7 @@ OptionsMenu::refresh()
 
       add_flash_intensity();
 
-      add_toggle(MNID_SCREEN_SHAKE, _("Screen Shake"), &g_config->screen_shake)
-        .set_help(_("Toggle the full screen shaking effects"));
+      add_screen_shake_mode();
 
 #if !defined(HIDE_NONMOBILE_OPTIONS) && !defined(__EMSCRIPTEN__)
       add_aspect_ratio();
@@ -501,6 +502,28 @@ OptionsMenu::add_vsync()
 }
 
 void
+OptionsMenu::add_screen_shake_mode() {
+  m_screen_shake_modes.list.push_back(_("off"));
+  m_screen_shake_modes.list.push_back(_("reduced"));
+  m_screen_shake_modes.list.push_back(_("full"));
+
+  switch (g_config->screen_shake_mode) {
+    case Config::ScreenShakeMode::OFF:
+      m_screen_shake_modes.next = 0;
+      break;
+    case Config::ScreenShakeMode::REDUCED:
+      m_screen_shake_modes.next = 1;
+      break;
+    case Config::ScreenShakeMode::FULL:
+      m_screen_shake_modes.next = 2;
+      break;
+  }
+
+  add_string_select(MNID_SCREEN_SHAKE_MODE, _("Screen shake"), &m_screen_shake_modes.next, m_screen_shake_modes.list)
+    .set_help(_("Adjust amount of screen shake effects"));
+}
+
+void
 OptionsMenu::add_sound_volume()
 {
   m_sound_volumes.list = { "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%" };
@@ -769,6 +792,27 @@ OptionsMenu::menu_action(MenuItem& item)
       }
       g_config->vsync = vsync;
       VideoSystem::current()->set_vsync(vsync);
+    }
+    break;
+
+    case MNID_SCREEN_SHAKE_MODE:
+    {
+      switch (m_screen_shake_modes.next)
+      {
+        case 0:
+          g_config->screen_shake_mode = Config::ScreenShakeMode::OFF;
+          break;
+        case 1:
+          g_config->screen_shake_mode = Config::ScreenShakeMode::REDUCED;
+          break;
+        case 2:
+          g_config->screen_shake_mode = Config::ScreenShakeMode::FULL;
+          break;
+        default:
+          assert(false);
+          break;
+      }
+
     }
     break;
 

--- a/src/supertux/menu/options_menu.hpp
+++ b/src/supertux/menu/options_menu.hpp
@@ -51,6 +51,7 @@ private:
   void add_window_resolutions();
   void add_resolutions();
   void add_vsync();
+  void add_screen_shake_mode();
   void add_sound_volume();
   void add_music_volume();
   void add_flash_intensity();
@@ -73,7 +74,7 @@ private:
     MNID_SOUND_VOLUME,
     MNID_MUSIC_VOLUME,
     MNID_FLASH_INTENSITY,
-    MNID_SCREEN_SHAKE,
+    MNID_SCREEN_SHAKE_MODE,
     MNID_RUMBLING,
     MNID_DEVELOPER_MODE,
     MNID_CHRISTMAS_MODE,
@@ -109,6 +110,7 @@ private:
   StringOption m_window_resolutions;
   StringOption m_resolutions;
   StringOption m_vsyncs;
+  StringOption m_screen_shake_modes;
   StringOption m_sound_volumes;
   StringOption m_music_volumes;
   StringOption m_flash_intensity_values;


### PR DESCRIPTION
Fixes #3609.

Marking as draft since I've realized it might be a good idea to make it tri-state instead:

* Full (default): both one-time shakes (e.g. from bombs) and "earthquakes" (persistent shaking) enabled
* Reduced: only one-time shakes enabled
* Off: both one-time shakes and "earthquakes" disabled

Should I go for that? If so, should I bother with an enumeration (like video subsystem selection) or would a simple `int` (like for vsync) do?