### PR TITLE
Fix compiler warning in root_sapling.cpp

### DIFF
--- a/src/badguy/root_sapling.cpp
+++ b/src/badguy/root_sapling.cpp
@@ -177,7 +177,7 @@ RootSapling::get_tile_spawn_pos_offset(const Tile& tile)
       else
         return -32.f;
 
-    default: assert(false); break;
+    default: assert(false); return 0.f;
   }
 }
 


### PR DESCRIPTION
This one:
<img width="719" height="102" alt="scr" src="https://github.com/user-attachments/assets/df016eea-9c22-4e5f-977e-3b5f411dad3e" />

The function in question now returns 0.f when it would previously return nothing.