### PR TITLE
Add a leave script to scripttriggers

### DIFF
--- a/src/trigger/scripttrigger.hpp
+++ b/src/trigger/scripttrigger.hpp
@@ -34,9 +34,10 @@ public:
   virtual void event(Player& player, EventType type) override;
 
 private:
-  EventType triggerevent;
-  std::string script;
-  bool must_activate;
-  bool oneshot;
-  int runcount;
+  EventType m_triggerevent;
+  std::string m_script;
+  std::string m_leave_script;
+  bool m_must_activate;
+  bool m_oneshot;
+  int m_runcount;
 };


### PR DESCRIPTION
This PR adds a "Leave script" to scripttriggers. This script is triggered upon losing contact with the trigger. It doesn't activate in "button" mode. I made it so that the scripttrigger's trigger counter in non-button mode only increases after leaving the trigger, meaning that in "oneshot" mode, the regular script and the leave script will each trigger once but not again after re-entering the scripttrigger area.

I also added the m_ prefix for member variables in the ScriptTrigger class.

Why? This:
<img width="1167" height="669" alt="image" src="https://github.com/user-attachments/assets/a5b877dd-c42a-4690-8a4f-f9e2a6720a13" />
 (it's from The Curse of Quiddlesworth, and this is a common theme across the add-on; this PR, if merged, would cut the amount of scripttriggers used in there by 60-70%)

**DO NOT MERGE** until after 0.7.0