### PR TITLE
Fix percentage counter overflow when downloading add-ons

### DIFF
--- a/src/supertux/menu/download_dialog.cpp
+++ b/src/supertux/menu/download_dialog.cpp
@@ -88,7 +88,7 @@ DownloadDialog::update_text()
   else
   {
     int dlnow = m_complete ? m_download_total : m_status->get_download_now();
-    int percent = 100.f * dlnow / dltotal;
+    int percent = (100.f * dlnow) / static_cast<float>(dltotal);
     out << dlnow / 1000 << "/"
         << dltotal / 1000 << " kB\n" << percent << "%";
   }


### PR DESCRIPTION
This fixes the percentage showing nonsense when reaching about 21 MB of downloaded data. This fix makes the entire calculation happen in floats. Alternatively, leaving the 100 as an int but putting the division into parentheses and turning that into floats also works. This looks cleaner, the other option would technically be more precise but there really is no need for atomic precision here.