### PR TITLE
Revert "Fix WASM builds by removing `libraqm` dependency."

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
     "fmt",
     "libogg",
     "libvorbis",
+    "libraqm",
     "freetype",
     "physfs",
     "sdl3",
@@ -17,8 +18,7 @@
       "description": "Add dependencies that aren't needed for WebAssembly",
       "dependencies": [
         "curl",
-        "openal-soft",
-        "libraqm"
+        "openal-soft"
       ],
       "supports": "!emscripten"
     },


### PR DESCRIPTION
libraqm compilation should be fixed by excluding tests from vcpkg installation. Let's see...

This reverts commit 9a0b35531d30ccc6f86cb2bd3048d9a8b2c18ed2.