### PR TITLE
worldmap_sector: call init script after loading music

### DIFF
--- a/src/worldmap/worldmap_sector.cpp
+++ b/src/worldmap/worldmap_sector.cpp
@@ -146,9 +146,6 @@ WorldMapSector::setup()
     // doesn't exist or erroneous; do nothing
   }
 
-  if (!m_init_script.empty())
-    m_squirrel_environment->run_script(m_init_script, "WorldMapSector::init");
-
   // Check if Tux is on an auto-playing level.
   // No need to play music in that case.
   LevelTile* level = at_object<LevelTile>();
@@ -157,6 +154,9 @@ WorldMapSector::setup()
 
   auto& music_object = get_singleton_by_type<MusicObject>();
   music_object.play_music(MusicType::LEVEL_MUSIC);
+
+  if (!m_init_script.empty())
+    m_squirrel_environment->run_script(m_init_script, "WorldMapSector::init");
 }
 
 void


### PR DESCRIPTION
Fixes #3666 

This PR makes sure that the init script in a worldmap sector is called after the music is loaded. This allows the init script to play music without it getting immediately replaced by whatever's the default.