### PR TITLE
music_object: reset star theme when star is picked up

### DIFF
--- a/data/music/misc/invincible.music
+++ b/data/music/misc/invincible.music
@@ -1,0 +1,6 @@
+(supertux-music
+  (file "invincible.ogg")
+  (title "Invincibility Theme")
+  (loop-begin 2)
+  (loop-at    14)
+)

--- a/src/object/music_object.cpp
+++ b/src/object/music_object.cpp
@@ -57,7 +57,8 @@ MusicObject::play_music(MusicType type)
       break;
 
     case HERRING_MUSIC:
-      SoundManager::current()->play_music("music/misc/invincible.ogg");
+      SoundManager::current()->stop_music();
+      SoundManager::current()->play_music("music/misc/invincible.music");
       break;
 
     case HERRING_WARNING_MUSIC:


### PR DESCRIPTION
When the player picks up a star, the star theme resets instead of continuing and looping.

This fixes awkward looping situations using the easiest method.

fixes #3690