### PR TITLE
mr_tree, stumpy: consistent coin drops from glinting enemies

### DIFF
--- a/src/badguy/mrtree.cpp
+++ b/src/badguy/mrtree.cpp
@@ -107,18 +107,53 @@ MrTree::collision_squished(MovingObject& object)
     return true;
   }
 
-  // Replace with Stumpy.
+  // Give feedback.
+  SoundManager::current()->play("sounds/mr_tree.ogg", get_pos());
+  if (player)
+    player->bounce(*this);
+
+  // Calculate position of Stumpy
   Vector stumpy_pos = get_pos();
   stumpy_pos.x += 8;
   stumpy_pos.y += 28;
-  auto& stumpy = Sector::get().add<Stumpy>(stumpy_pos, m_dir);
+
+  int leaves_spawned = 0;
+
+  // Mr.Trees that are frozen don't spawn any Vicious Ivys.
+  if (!m_frozen)
+  {
+    // Spawn ViciousIvy.
+    Vector leaf1_pos(stumpy_pos.x - VICIOUSIVY_WIDTH - 1, stumpy_pos.y - VICIOUSIVY_Y_OFFSET);
+    Rectf leaf1_bbox(leaf1_pos.x, leaf1_pos.y, leaf1_pos.x + VICIOUSIVY_WIDTH, leaf1_pos.y + VICIOUSIVY_HEIGHT);
+    if (Sector::get().is_free_of_movingstatics(leaf1_bbox, this))
+    {
+      auto& leaf1 = Sector::get().add<ViciousIvy>(leaf1_bbox.p1(), Direction::LEFT);
+      if (m_is_glinting)
+        leaf1.m_is_glinting = true;
+
+      ++leaves_spawned;
+    }
+
+    // Spawn ViciousIvy.
+    Vector leaf2_pos(stumpy_pos.x + m_sprite->get_current_hitbox_width() + 1, stumpy_pos.y - VICIOUSIVY_Y_OFFSET);
+    Rectf leaf2_bbox(leaf2_pos.x, leaf2_pos.y,
+             VICIOUSIVY_WIDTH, leaf2_pos.y + VICIOUSIVY_HEIGHT);
+    if (Sector::get().is_free_of_movingstatics(leaf2_bbox, this))
+    {
+      auto& leaf2 = Sector::get().add<ViciousIvy>(leaf2_bbox.p1(), Direction::RIGHT);
+      if (m_is_glinting)
+        leaf2.m_is_glinting = true;
+
+      ++leaves_spawned;
+    }
+  }
+
+  // Replace with Stumpy.
+  auto& stumpy = Sector::get().add<Stumpy>(stumpy_pos, m_dir, 3 - leaves_spawned);
   if (m_is_glinting)
     stumpy.m_is_glinting = true;
-  remove_me();
 
-  // Give feedback.
-  SoundManager::current()->play("sounds/mr_tree.ogg", get_pos());
-  if (player) player->bounce(*this);
+  remove_me();
 
   // Spawn some particles.
   // TODO: Provide convenience function in MovingSprite or MovingObject?
@@ -132,31 +167,12 @@ MrTree::collision_squished(MovingObject& object)
     Vector pspeed = Vector(vx, vy);
     Vector paccel = Vector(0, Sector::get().get_gravity()*10);
     Sector::get().add<SpriteParticle>("images/particles/leaf.sprite",
-                                           "default",
-                                           ppos, ANCHOR_MIDDLE,
-                                           pspeed, paccel,
-                                           LAYER_OBJECTS-1);
+                                      "default",
+                                      ppos, ANCHOR_MIDDLE,
+                                      pspeed, paccel,
+                                      LAYER_OBJECTS-1);
   }
 
-  if (!m_frozen) { // Mr.Trees that are frozen don't spawn any Vicious Ivys.
-    // Spawn ViciousIvy.
-    Vector leaf1_pos(stumpy_pos.x - VICIOUSIVY_WIDTH - 1, stumpy_pos.y - VICIOUSIVY_Y_OFFSET);
-    Rectf leaf1_bbox(leaf1_pos.x, leaf1_pos.y, leaf1_pos.x + VICIOUSIVY_WIDTH, leaf1_pos.y + VICIOUSIVY_HEIGHT);
-    if (Sector::get().is_free_of_movingstatics(leaf1_bbox, this)) {
-      auto& leaf1 = Sector::get().add<ViciousIvy>(leaf1_bbox.p1(), Direction::LEFT);
-      if (m_is_glinting)
-        leaf1.m_is_glinting = true;
-    }
-
-    // Spawn ViciousIvy.
-    Vector leaf2_pos(stumpy_pos.x + m_sprite->get_current_hitbox_width() + 1, stumpy_pos.y - VICIOUSIVY_Y_OFFSET);
-    Rectf leaf2_bbox(leaf2_pos.x, leaf2_pos.y, leaf2_pos.x + VICIOUSIVY_WIDTH, leaf2_pos.y + VICIOUSIVY_HEIGHT);
-    if (Sector::get().is_free_of_movingstatics(leaf2_bbox, this)) {
-      auto& leaf2 = Sector::get().add<ViciousIvy>(leaf2_bbox.p1(), Direction::RIGHT);
-      if (m_is_glinting)
-        leaf2.m_is_glinting = true;
-    }
-  }
   return true;
 }
 

--- a/src/badguy/stumpy.cpp
+++ b/src/badguy/stumpy.cpp
@@ -33,17 +33,19 @@ Stumpy::Stumpy(const ReaderMapping& reader) :
   WalkingBadguy(reader, "images/creatures/mr_tree/stumpy.sprite","left","right", LAYER_OBJECTS,
                 "images/objects/lightmap_light/lightmap_light-large.sprite"),
   mystate(STATE_NORMAL),
-  invincible_timer()
+  invincible_timer(),
+  m_glint_coins(1)
 {
   walk_speed = STUMPY_SPEED;
   set_ledge_behavior(LedgeBehavior::SMART);
   SoundManager::current()->preload("sounds/mr_treehit.ogg");
 }
 
-Stumpy::Stumpy(const Vector& pos, Direction d) :
+Stumpy::Stumpy(const Vector& pos, Direction d, int glint_coins) :
   WalkingBadguy(pos, d, "images/creatures/mr_tree/stumpy.sprite","left","right"),
   mystate(STATE_INVINCIBLE),
-  invincible_timer()
+  invincible_timer(),
+  m_glint_coins(glint_coins)
 {
   walk_speed = STUMPY_SPEED;
   set_ledge_behavior(LedgeBehavior::SMART);
@@ -130,7 +132,7 @@ Stumpy::collision_squished(MovingObject& object)
 int
 Stumpy::get_coins_worth() const
 {
-  return (m_is_glinting) ? 3 : 0;
+  return (m_is_glinting) ? m_glint_coins : 0;
 }
 
 void

--- a/src/badguy/stumpy.hpp
+++ b/src/badguy/stumpy.hpp
@@ -23,7 +23,7 @@ class Stumpy final : public WalkingBadguy
 {
 public:
   Stumpy(const ReaderMapping& reader);
-  Stumpy(const Vector& pos, Direction d);
+  Stumpy(const Vector& pos, Direction d, int glint_coins = 1);
 
   virtual void initialize() override;
   virtual void active_update(float dt_sec) override;
@@ -51,6 +51,7 @@ protected:
 private:
   MyState mystate;
   Timer   invincible_timer;
+  int     m_glint_coins;
 
 private:
   Stumpy(const Stumpy&) = delete;


### PR DESCRIPTION
Fixes #3698 

Glinting Stumpy (on its own) now drops one coin, as most other badguys
MrTree still drops three when insta-killed

However, when a MrTree is killed normally, it now makes sure that the number of coins dropped from the ivies and stumpy always adds up to three (previously, you'd get 3-5 coins).
The ivies drop one coin each.
The stumpy drops one coin if both ivies spawned, two coins if one ivy spawned and three coins if no ivy spawned.