### PR TITLE
Fix #3569: Fix Tux not turning around in 1-block gaps

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -2238,6 +2238,8 @@ Player::draw(DrawingContext& context)
       const bool is_not_idle = std::all_of(IDLE_STAGES.begin(), IDLE_STAGES.end(),
         [this](const std::string& stage) { return m_sprite->get_action().find("-" + stage + "-") == std::string::npos; });
 
+      std::string base_idle_action = sa_prefix + "-" + IDLE_STAGES[0] + sa_postfix;
+
       if (is_not_idle || (m_should_fancy_idle && !m_fancy_idle_active) || m_reset_action)
       {
         m_idle_stage = 0;
@@ -2270,13 +2272,19 @@ Player::draw(DrawingContext& context)
           else
             set_action(sa_prefix + ("-" + IDLE_STAGES[m_idle_stage]) + sa_postfix, 1);
         }
+        else if(m_sprite->get_action() != base_idle_action)
+        {
+          m_idle_stage = 0;
+          set_action(base_idle_action);
+          m_sprite->set_animation_loops(-1);
+        }
       }
       else
       {
-        if (m_idle_stage != 0 || m_sprite->get_action() != sa_prefix + ("-" + IDLE_STAGES[0]) + sa_postfix)
+        if (m_idle_stage != 0 || m_sprite->get_action() != base_idle_action)
         {
           m_idle_stage = 0;
-          set_action(sa_prefix + ("-" + IDLE_STAGES[0]) + sa_postfix);
+          set_action(base_idle_action);
           m_sprite->set_animation_loops(-1);
         }
         m_fancy_idle_active = false;


### PR DESCRIPTION
This PR fixes issue #3569, where Tux ignores user directional input when placed in a 1-block gap while the fancy idle animation timer is active.

### Root Cause & Fix
When Tux's horizontal velocity becomes zero, the `draw()` function in `player.cpp` waits for the idle timer to finish before updating the sprite's direction. This patch adds a check during the idle wait state to force an action update if the direction changes, resetting the idle stage to zero.

### Testing
I validated this fix via manual runtime testing. 
- Compiled locally and ran the game.
- Verified Tux turns smoothly in 1-block gaps without getting stuck in the idle animation.

Closes #3569