### PR TITLE
Fix #3650 Prevent thrown rocks from pushing heavy enemies such as Granitos

### DIFF
--- a/src/badguy/granito_giant.hpp
+++ b/src/badguy/granito_giant.hpp
@@ -38,6 +38,7 @@ public:
   virtual bool is_freezable() const override { return false; }
   virtual bool is_hurtable() const override { return false; }
   virtual bool is_snipable() const override { return false; }
+  virtual bool is_heavy() const override { return true; }
 
   GameObjectTypes get_types() const override;
   virtual std::string get_default_sprite_name() const override;

--- a/src/badguy/viciousivy.cpp
+++ b/src/badguy/viciousivy.cpp
@@ -106,7 +106,7 @@ ViciousIvy::active_update(float dt_sec)
     floatbox.set_bottom(get_bbox().get_bottom() + 8.f);
 
     const bool ignore_unisolid = on_top_of_water || m_physic.get_velocity_y() < 0.0f;
-    bool float_here = (Sector::get().is_free_of_statics(floatbox, nullptr, ignore_unisolid));
+    bool float_here = (Sector::get().is_free_of_movingstatics(floatbox, this, ignore_unisolid));
 
     if (in_water)
     {

--- a/src/object/rock.cpp
+++ b/src/object/rock.cpp
@@ -19,7 +19,6 @@
 #include "audio/sound_manager.hpp"
 #include "badguy/crusher.hpp"
 #include "badguy/badguy.hpp"
-#include "badguy/granito_big.hpp"
 #include "object/coin.hpp"
 #include "object/explosion.hpp"
 #include "object/lit_object.hpp"
@@ -225,6 +224,17 @@ Rock::collision(MovingObject& other, const CollisionHit& hit)
     return ABORT_MOVE;
   }
 
+
+  {
+    /**
+     * Heavy objects such as Granitos shouldn't be pushed!
+     */
+    const BadGuy* heavyGuy = dynamic_cast<BadGuy*>(&other);
+    if(heavyGuy && heavyGuy->is_heavy()){
+      return ABORT_MOVE;
+    }
+  }
+
   float sector_gravity = Sector::get().get_gravity();
 
   if ((hit.bottom && sector_gravity >= 0.f) || (hit.top && sector_gravity <= 0.f)) {
@@ -233,10 +243,7 @@ Rock::collision(MovingObject& other, const CollisionHit& hit)
       m_physic.set_velocity_y(sector_gravity >= 0.f ? -250.f : 250.f);
     }
 
-    const auto* granito = dynamic_cast<Granito*>(&other);
-    if (granito) {
-      return ABORT_MOVE;
-    }
+    
   }
 
   // Don't fall further if we are on a rock which is on the ground.


### PR DESCRIPTION
Fixes #3650

Heavy objects such as Granitos can no longer be pushed by thrown rocks or lanterns.
Giant Granito is now also treated as a heavy object.