### PR TITLE
Fix #3634: Fix profile menu not greying out after deleting all profiles

### DIFF
--- a/src/supertux/menu/profile_menu.cpp
+++ b/src/supertux/menu/profile_menu.cpp
@@ -170,6 +170,7 @@ ProfileMenu::menu_action(MenuItem& item)
     Dialog::show_confirmation(message, [this]() {
       ProfileManager::current()->delete_profile(g_config->profile);
       g_config->profile = 1;
+      m_current_profile = nullptr;
       refresh();
     });
   }
@@ -181,6 +182,7 @@ ProfileMenu::menu_action(MenuItem& item)
         manager->delete_profile(profile->get_id());
 
       g_config->profile = 1;
+      m_current_profile = nullptr;
       refresh();
     });
   }


### PR DESCRIPTION
When all profiles are deleted, the "Rename", "Reset" and "Delete" options in the profile menu remained active instead of being greyed out. This was caused by m_current_profile not being reset to nullptr after deletion, leaving a dangling pointer that made the menu think a profile was still selected.

Fix by setting m_current_profile to nullptr before calling refresh() in both the "Delete" and "Delete all" callbacks.

Closes #3634