### PR TITLE
Fix #3689: Fix vertical mid-air jumps in walljump tiles

### DIFF
--- a/src/object/player.cpp
+++ b/src/object/player.cpp
@@ -1430,7 +1430,7 @@ Player::do_backflip() {
 
 void
 Player::do_jump(float yspeed) {
-  if (!m_can_walljump && !m_in_walljump_tile && !on_ground() && !m_coyote_timer.started())
+  if (!m_can_walljump && !on_ground() && !m_coyote_timer.started())
     return;
 
   // jump only if it would make Tux go faster upwards


### PR DESCRIPTION
When Tux is inside a walljump tile zone but not touching a wall,
he could jump mid-air. This happened because do_jump() checked
for walljump tiles separately, allowing jumps without wall contact.

Since m_can_walljump already validates both wall contact and tile
presence, the !m_in_walljump_tile check is redundant and was
removed to correctly block illegal mid-air jumps.

The code has been tested locally and verified to fix the reported
behavior without breaking the jumps and walljumps. 

Closes #3689