### PR TITLE
Fixes #3664 - Cutscenes with Best time completed

### DIFF
--- a/data/levels/world1/castle_cutscene.nut
+++ b/data/levels/world1/castle_cutscene.nut
@@ -1,6 +1,5 @@
 function initialize()
 {
-  wait(0);
   start_cutscene();
   
   TUX.set_action("big-run-right");

--- a/data/levels/world1/castle_cutscene.stl
+++ b/data/levels/world1/castle_cutscene.stl
@@ -8,7 +8,6 @@
   (icon-locked "")
   (statistics
     (enable-coins #f)
-    (enable-badguys #f)
     (enable-secrets #f)
   )
   (sector

--- a/data/levels/world1/worldmap.stwm
+++ b/data/levels/world1/worldmap.stwm
@@ -201,7 +201,7 @@
       (level "castle_cutscene.stl")
       (auto-play #t)
       (color 0.6 0.8 1)
-      (name "NOTE: put this in the castle level")
+      (sprite "/images/worldmap/common/invisible.png")
       (x 47)
       (y 92)
     )

--- a/data/levels/world2/ghosttree_cutscene.stl
+++ b/data/levels/world2/ghosttree_cutscene.stl
@@ -15,7 +15,9 @@
     (init-script "import(\"levels/world2/ghosttree_cutscene.nut\");
 
 Text.set_anchor_point(7);
-Text.set_pos(0, -250);")
+Text.set_pos(0, -250);
+
+trigger_state(\"start\");")
     (ambient-light
       (color 0.48 0.46 0.58)
     )


### PR DESCRIPTION
The cutscenes "Nobody Home" and "The Root Of The Problem" were incorrectly displaying level statistics.

To resolve this, I implemented the following changes:
- .stl files: Updated the (statistics) block to ensure HUD elements like time and badguys are disabled.
- castle_cutscene.nut: Removed an unnecessary 'wait(0)' before start_cutscene() to ensure the sequence triggers immediately and correctly.
- worldmap.stwm (World 1): Replaced a placeholder name string with an invisible sprite for the castle cutscene node, preventing debug text from appearing to the player.
- ghosttree_cutscene.stl: Added the missing 'trigger_state' to the init-script to properly initialize the cutscene logic.

Closes #3664