### PR TITLE
Fix #3685: Prevent coin collection through solid weak blocks

### DIFF
--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -247,15 +247,11 @@ Coin::collision(MovingObject& other, const CollisionHit& )
   // Check if this coin is trapped inside an active WeakBlock
   Vector coin_center = m_col.m_bbox.get_middle();
   for (auto& weak_block : Sector::get().get_objects_by_type<WeakBlock>()) {
-    if (weak_block.is_solid_block()) {
-      const Rectf& block_bbox = weak_block.get_bbox();
-      if (coin_center.x >= block_bbox.get_left() && 
-          coin_center.x <= block_bbox.get_right() &&
-          coin_center.y >= block_bbox.get_top() && 
-          coin_center.y <= block_bbox.get_bottom()) {
-        return ABORT_MOVE;
-      }
-    }
+    if (weak_block.get_group() == COLGROUP_DISABLED)
+      continue;
+      
+    if (weak_block.get_bbox().contains(coin_center)) 
+      return ABORT_MOVE;
   }
   
   if (m_col.get_bbox().overlaps(player->get_bbox().grown(-0.1f)))

--- a/src/object/coin.cpp
+++ b/src/object/coin.cpp
@@ -22,6 +22,7 @@
 #include "object/bouncy_coin.hpp"
 #include "object/player.hpp"
 #include "object/tilemap.hpp"
+#include "object/weak_block.hpp"
 #include "supertux/flip_level_transformer.hpp"
 #include "supertux/level.hpp"
 #include "supertux/sector.hpp"
@@ -242,6 +243,21 @@ Coin::collision(MovingObject& other, const CollisionHit& )
   auto player = dynamic_cast<Player*>(&other);
   if (player == nullptr)
     return ABORT_MOVE;
+  
+  // Check if this coin is trapped inside an active WeakBlock
+  Vector coin_center = m_col.m_bbox.get_middle();
+  for (auto& weak_block : Sector::get().get_objects_by_type<WeakBlock>()) {
+    if (weak_block.is_solid_block()) {
+      const Rectf& block_bbox = weak_block.get_bbox();
+      if (coin_center.x >= block_bbox.get_left() && 
+          coin_center.x <= block_bbox.get_right() &&
+          coin_center.y >= block_bbox.get_top() && 
+          coin_center.y <= block_bbox.get_bottom()) {
+        return ABORT_MOVE;
+      }
+    }
+  }
+  
   if (m_col.get_bbox().overlaps(player->get_bbox().grown(-0.1f)))
     collect();
   return ABORT_MOVE;

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -46,6 +46,9 @@ public:
   virtual void on_flip(float height) override;
 
   void startBurning();
+  
+  /** Check if this block is still solid (not destroyed) and blocking objects */
+  inline bool is_solid_block() const { return state != STATE_DISINTEGRATING; }
 
 private:
   virtual HitResponse collision_bullet(Bullet& bullet, const CollisionHit& hit);

--- a/src/object/weak_block.hpp
+++ b/src/object/weak_block.hpp
@@ -46,9 +46,6 @@ public:
   virtual void on_flip(float height) override;
 
   void startBurning();
-  
-  /** Check if this block is still solid (not destroyed) and blocking objects */
-  inline bool is_solid_block() const { return state != STATE_DISINTEGRATING; }
 
 private:
   virtual HitResponse collision_bullet(Bullet& bullet, const CollisionHit& hit);


### PR DESCRIPTION
This PR fixes a bug where players could collect coins trapped inside a WeakBlock (like ice blocks) before the block was destroyed.

Added is_solid_block() method to WeakBlock to check its current state.

Modified Coin::collision to prevent collection if the coin's center is inside a solid WeakBlock.

Closes #3685