### PR TITLE
Add back the 1D OKLab color picker

### DIFF
--- a/src/gui/item_colorchannel.hpp
+++ b/src/gui/item_colorchannel.hpp
@@ -63,3 +63,34 @@ private:
   ItemColorChannelRGBA(const ItemColorChannelRGBA&) = delete;
   ItemColorChannelRGBA& operator=(const ItemColorChannelRGBA&) = delete;
 };
+
+
+class ItemColorChannelOKLab final : public MenuItem
+{
+public:
+  enum class ChannelType { CHANNEL_L, CHANNEL_C, CHANNEL_H };
+
+public:
+  ItemColorChannelOKLab(Color* col, int channel, Menu* menu);
+  virtual void draw(DrawingContext&, const Vector& pos, int menu_width,
+    bool active) override;
+  /** Returns the minimum width of the menu item. */
+  virtual int get_width() const override { return 64; }
+  virtual void process_action(const MenuAction& action) override;
+  virtual void event(const SDL_Event& ev) override;
+  virtual bool changes_width() const override { return true; }
+
+private:
+  void set_color(ColorOKLCh& col_oklch_clipped, ColorOKLCh& col_oklch_store);
+
+private:
+  Color* m_color;
+  ColorOKLCh m_col_prev;
+  ChannelType m_channel;
+  Menu* m_menu;
+  bool m_mousedown;
+
+private:
+  ItemColorChannelOKLab(const ItemColorChannelOKLab&) = delete;
+  ItemColorChannelOKLab& operator=(const ItemColorChannelOKLab&) = delete;
+};

--- a/src/gui/item_colorchannel_oklab.cpp
+++ b/src/gui/item_colorchannel_oklab.cpp
@@ -1,0 +1,225 @@
+//  SuperTux
+//  Copyright (C) 2021
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gui/item_colorchannel.hpp"
+
+#include <vector>
+
+#include "math/util.hpp"
+#include "video/drawing_context.hpp"
+#include "video/video_system.hpp"
+#include "video/viewport.hpp"
+
+
+// This value affects the gamut clipping in the hue selection.
+// A bigger value means more preserving of chroma instead of lightness.
+constexpr float HUE_COLORFULNESS = 0.5f;
+
+ItemColorChannelOKLab::ItemColorChannelOKLab(Color* col, int channel,
+    Menu* menu) :
+  MenuItem(""),
+  m_color(col),
+  m_col_prev(0, 0, 0),
+  m_channel(ChannelType::CHANNEL_L),
+  m_menu(menu),
+  m_mousedown(false)
+{
+  if (channel == 1)
+    m_channel = ChannelType::CHANNEL_L;
+  else if (channel == 2)
+    m_channel = ChannelType::CHANNEL_C;
+  else
+    m_channel = ChannelType::CHANNEL_H;
+}
+
+void
+ItemColorChannelOKLab::draw(DrawingContext& context, const Vector& pos,
+  int menu_width, bool active)
+{
+  const float lw = static_cast<float>(menu_width - 32);
+  ColorOKLCh col_oklch(0, 0, 0);
+  if (active) {
+    col_oklch = m_col_prev;
+  } else {
+    col_oklch = ColorOKLCh(*m_color);
+  }
+
+  // Draw all possible colour values for the given component
+  float chroma_max_any_l = 1.0f;
+  if (m_channel == ChannelType::CHANNEL_C)
+    chroma_max_any_l = col_oklch.get_maximum_chroma_any_l();
+  constexpr int NUM_RECTS = 128;
+  std::vector<Color> colors(NUM_RECTS+1);
+  for (int i = 0; i < NUM_RECTS+1; ++i) {
+    ColorOKLCh col_oklch_current = col_oklch;
+    float x = static_cast<float>(i) / NUM_RECTS;
+    if (m_channel == ChannelType::CHANNEL_L) {
+      col_oklch_current.L = x;
+    } else if (m_channel == ChannelType::CHANNEL_C) {
+      col_oklch_current.C = x * chroma_max_any_l;
+      col_oklch_current.clip_lightness();
+    } else {
+      col_oklch_current.h = (2.0f * x - 1.0f) * math::PI;
+      col_oklch_current.clip_adaptive_L0_L_cusp(HUE_COLORFULNESS);
+    }
+    colors[i] = col_oklch_current.to_srgb();
+  }
+  for (int i = 0; i < NUM_RECTS; ++i) {
+    float x1 = 16 + static_cast<float>(i) * lw / NUM_RECTS;
+    float x2 = x1 + lw / NUM_RECTS;
+    context.color().draw_gradient(colors[i], colors[i+1], LAYER_GUI-1,
+      GradientDirection::HORIZONTAL,
+      Rectf(pos + Vector(x1, -10), pos + Vector(x2, 10)));
+  }
+
+  // Draw a marker for the current colour
+  float x_marker;
+  if (m_channel == ChannelType::CHANNEL_L) {
+    x_marker = col_oklch.L;
+  } else if (m_channel == ChannelType::CHANNEL_C) {
+    x_marker = chroma_max_any_l > 0.0f ? col_oklch.C / chroma_max_any_l : 0.0f;
+  } else {
+    x_marker = 0.5f * col_oklch.h / math::PI + 0.5f;
+  }
+  x_marker = pos.x + 16 + x_marker * lw;
+  context.color().draw_triangle(Vector(x_marker - 3, pos.y - 11),
+    Vector(x_marker + 3, pos.y - 11), Vector(x_marker, pos.y - 4),
+    Color::WHITE, LAYER_GUI-1);
+  context.color().draw_triangle(Vector(x_marker, pos.y + 4),
+    Vector(x_marker - 3, pos.y + 11), Vector(x_marker + 3, pos.y + 11),
+    Color::BLACK, LAYER_GUI-1);
+
+  if (m_channel == ChannelType::CHANNEL_C && chroma_max_any_l > 0.0f) {
+    // Draw a marker where the lightness clipping starts
+    x_marker = col_oklch.get_maximum_chroma() / chroma_max_any_l;
+    x_marker = pos.x + 16 + x_marker * lw;
+    context.color().draw_triangle(Vector(x_marker - 2, pos.y - 11),
+      Vector(x_marker + 2, pos.y - 11), Vector(x_marker, pos.y),
+      Color(0.73f, 0.73f, 0.73f), LAYER_GUI-1);
+  }
+}
+
+void
+ItemColorChannelOKLab::process_action(const MenuAction& action)
+{
+  if (action == MenuAction::SELECT) {
+    m_col_prev = ColorOKLCh(*m_color);
+    return;
+  }
+  float increment;
+  if (action == MenuAction::LEFT)
+    increment = -0.1f;
+  else if (action == MenuAction::RIGHT)
+    increment = 0.1f;
+  else
+    return;
+
+  ColorOKLCh col_oklch = m_col_prev;
+  ColorOKLCh col_oklch_clipped(0, 0, 0);
+  if (m_channel == ChannelType::CHANNEL_L) {
+    col_oklch.L = math::clamp(col_oklch.L + increment, 0.0f, 1.0f);
+    col_oklch_clipped = col_oklch;
+  } else if (m_channel == ChannelType::CHANNEL_C) {
+    float chroma_max = col_oklch.get_maximum_chroma_any_l();
+    increment *= chroma_max;
+    col_oklch.C = math::clamp(col_oklch.C + increment, 0.0f, chroma_max);
+    col_oklch_clipped = col_oklch;
+    col_oklch_clipped.clip_lightness();
+  } else {
+    increment *= 3.0f;
+    col_oklch.h = fmodf(col_oklch.h + increment + 3.0f * math::PI,
+      2.0f * math::PI) - math::PI;
+    col_oklch_clipped = col_oklch;
+    col_oklch_clipped.clip_adaptive_L0_L_cusp(HUE_COLORFULNESS);
+  }
+  set_color(col_oklch_clipped, col_oklch);
+}
+
+void
+ItemColorChannelOKLab::event(const SDL_Event& ev)
+{
+  // Determine the new colour with the mouse position if either the mouse
+  // is clicked once or clicked and held down
+  bool is_mouseclick = ev.type == SDL_MOUSEBUTTONDOWN
+    && ev.button.button == SDL_BUTTON_LEFT;
+  bool is_hold_mousemove = ev.type == SDL_MOUSEMOTION
+    && (ev.motion.state & SDL_BUTTON_LMASK);
+  if (is_mouseclick) {
+    m_mousedown = true;
+  } else if (!is_hold_mousemove || !m_mousedown) {
+    m_mousedown = false;
+    return;
+  }
+
+  Vector mouse_pos = VideoSystem::current()->get_viewport().to_logical(
+    ev.motion.x, ev.motion.y);
+
+  // Calculate the menu item positions as passed in the draw method
+  Vector menu_centre = m_menu->get_center_pos();
+  const float menu_width = m_menu->get_width();
+  const float menu_height = m_menu->get_height();
+  Vector pos(
+    menu_centre.x - menu_width / 2.0f,
+    menu_centre.y
+    + 24.0f * static_cast<float>(m_menu->get_active_item_id())
+    - menu_height / 2.0f + 12.0f
+  );
+
+  // Calculate the relative horizontal position
+  float x1 = pos.x + 16.0f;
+  float x2 = pos.x + menu_width - 16.0f;
+  float x = (mouse_pos.x - x1) / (x2 - x1);
+  if (m_channel != ChannelType::CHANNEL_H) {
+    x = math::clamp(x, 0.0f, 1.0f);
+  } else {
+    // The hue is periodic
+    x = fmodf(x + 3.0f, 1.0f);
+  }
+
+  // Ignore distant mouse presses
+  if (x < -0.5f || x > 1.5f || mouse_pos.y > pos.y + menu_height / 2.0f
+      || mouse_pos.y < pos.y - menu_height / 2.0f)
+    return;
+
+  ColorOKLCh col_oklch = m_col_prev;
+  ColorOKLCh col_oklch_clipped(0, 0, 0);
+  if (m_channel == ChannelType::CHANNEL_L) {
+    col_oklch.L = x;
+    col_oklch_clipped = col_oklch;
+  } else if (m_channel == ChannelType::CHANNEL_C) {
+    float chroma_max_any_l = col_oklch.get_maximum_chroma_any_l();
+    col_oklch.C = x * chroma_max_any_l;
+    col_oklch_clipped = col_oklch;
+    col_oklch_clipped.clip_lightness();
+  } else {
+    col_oklch.h = (2.0f * x - 1.0f) * math::PI;
+    col_oklch_clipped = col_oklch;
+    col_oklch_clipped.clip_adaptive_L0_L_cusp(HUE_COLORFULNESS);
+  }
+  set_color(col_oklch_clipped, col_oklch);
+}
+
+void
+ItemColorChannelOKLab::set_color(ColorOKLCh& col_oklch_clipped,
+  ColorOKLCh& col_oklch_store)
+{
+  // Save the current unclipped colour
+  m_col_prev = col_oklch_store;
+  // Convert the colour back to sRGB and clip if needed; preserve transparency
+  float alpha = m_color->alpha;
+  *m_color = col_oklch_clipped.to_srgb();
+  m_color->alpha = alpha;
+}

--- a/src/gui/item_colorchannel_rgba.cpp
+++ b/src/gui/item_colorchannel_rgba.cpp
@@ -14,7 +14,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "gui/item_colorchannel_rgba.hpp"
+#include "gui/item_colorchannel.hpp"
 
 #include <sstream>
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -20,7 +20,7 @@
 #include "gui/item_action.hpp"
 #include "gui/item_back.hpp"
 #include "gui/item_color.hpp"
-#include "gui/item_colorchannel_rgba.hpp"
+#include "gui/item_colorchannel.hpp"
 #include "gui/item_colordisplay.hpp"
 #include "gui/item_color_picker_2d.hpp"
 #include "gui/item_controlfield.hpp"
@@ -275,6 +275,12 @@ Menu::add_color_channel_rgba(float* input, Color channel, int id, bool is_linear
 ItemColorPicker2D&
 Menu::add_color_picker_2d(Color& color) {
   return add_item<ItemColorPicker2D>(color);
+}
+
+ItemColorChannelOKLab&
+Menu::add_color_channel_oklab(Color* color, int channel)
+{
+  return add_item<ItemColorChannelOKLab>(color, channel, this);
 }
 
 ItemPaths&

--- a/src/gui/menu.hpp
+++ b/src/gui/menu.hpp
@@ -31,6 +31,7 @@ class ItemAction;
 class ItemBack;
 class ItemColor;
 class ItemColorChannelRGBA;
+class ItemColorChannelOKLab;
 class ItemColorPicker2D;
 class ItemColorDisplay;
 class ItemControlField;
@@ -104,6 +105,7 @@ public:
   ItemColorDisplay& add_color_display(Color* color, int id = -1);
   ItemColorChannelRGBA& add_color_channel_rgba(float* input, Color channel, int id = -1,
     bool is_linear = false);
+  ItemColorChannelOKLab& add_color_channel_oklab(Color* color, int channel);
   ItemColorPicker2D& add_color_picker_2d(Color& color);
   ItemPaths& add_path_settings(const std::string& text, PathObject& target, const std::string& path_ref);
   ItemStringArray& add_string_array(const std::string& text, std::vector<std::string>& items, int id = -1);

--- a/src/gui/menu_color.cpp
+++ b/src/gui/menu_color.cpp
@@ -29,6 +29,9 @@ ColorMenu::ColorMenu(Color* color) :
   add_label(_("Mix the colour"));
   add_hl();
 
+  add_color_channel_oklab(m_color, 1);
+  add_color_channel_oklab(m_color, 2);
+  add_color_channel_oklab(m_color, 3);
   add_color_picker_2d(*m_color);
   add_color_channel_rgba(&(m_color->red), Color::RED);
   add_color_channel_rgba(&(m_color->green), Color::GREEN);

--- a/src/util/colorspace_oklab.cpp
+++ b/src/util/colorspace_oklab.cpp
@@ -40,7 +40,15 @@ namespace {
 
 struct ColorRGB {
   float r, g, b;
+  bool is_valid() const;
 };
+
+bool
+ColorRGB::is_valid() const
+{
+  return r >= 0.0f && r <= 1.0f && g >= 0.0f && g <= 1.0f
+    && b >= 0.0f && b <= 1.0f;
+}
 
 struct ColorOKLab {
   float L, a, b;
@@ -55,6 +63,24 @@ ColorRGB srgb_to_linear_srgb(const Color& c)
       return powf((channel + 0.055f) / (1.0f + 0.055f), 2.4f);
   };
   return {to_linear(c.red), to_linear(c.green), to_linear(c.blue)};
+}
+
+Color linear_srgb_to_srgb(const ColorRGB& c)
+{
+  auto make_nonlinear = [&](float channel) -> float {
+    if (channel <= 0.0031308f)
+      return 12.92f * channel;
+    else
+      return (1.0f + 0.055f) * powf(channel, 1.0f / 2.4f) - 0.055f;
+  };
+  float r = make_nonlinear(c.r);
+  float g = make_nonlinear(c.g);
+  float b = make_nonlinear(c.b);
+  // The clamping here is only for safety against numerical precision errors.
+  // r, g and b should already be in [0,1] (at least approximately)
+  // since they were clipped in the OKLab colourspace.
+  return Color(math::clamp(r, 0.0f, 1.0f), math::clamp(g, 0.0f, 1.0f),
+    math::clamp(b, 0.0f, 1.0f));
 }
 
 ColorOKLab linear_srgb_to_oklab(const ColorRGB& c)
@@ -74,9 +100,209 @@ ColorOKLab linear_srgb_to_oklab(const ColorRGB& c)
   };
 }
 
+ColorRGB oklab_to_linear_srgb(const ColorOKLab& c)
+{
+  float l_ = c.L + 0.3963377774f * c.a + 0.2158037573f * c.b;
+  float m_ = c.L - 0.1055613458f * c.a - 0.0638541728f * c.b;
+  float s_ = c.L - 0.0894841775f * c.a - 1.2914855480f * c.b;
+
+  float l = l_*l_*l_;
+  float m = m_*m_*m_;
+  float s = s_*s_*s_;
+
+  return {
+    +4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s,
+    -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s,
+    -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s,
+  };
+}
+
 ColorOKLCh lab_to_lch(const ColorOKLab& c)
 {
   return ColorOKLCh{c.L, sqrtf(c.a * c.a + c.b * c.b), atan2f(c.b, c.a)};
+}
+
+ColorOKLab lch_to_lab(const ColorOKLCh& c)
+{
+  return {c.L, c.C * cosf(c.h), c.C * sinf(c.h)};
+}
+
+// Finds the maximum saturation possible for a given hue that fits in sRGB
+// Saturation here is defined as S = C/L
+// a and b must be normalized so a^2 + b^2 == 1.
+float compute_max_saturation(float a, float b)
+{
+  // Max saturation will be when one of r, g or b goes below zero.
+  // Select different coefficients depending on which component goes below zero first.
+  float k0, k1, k2, k3, k4, wl, wm, ws;
+
+  if (-1.88170328f * a - 0.80936493f * b > 1)
+  {
+    // Red component.
+    k0 = +1.19086277f; k1 = +1.76576728f; k2 = +0.59662641f; k3 = +0.75515197f; k4 = +0.56771245f;
+    wl = +4.0767416621f; wm = -3.3077115913f; ws = +0.2309699292f;
+  }
+  else if (1.81444104f * a - 1.19445276f * b > 1)
+  {
+    // Green component.
+    k0 = +0.73956515f; k1 = -0.45954404f; k2 = +0.08285427f; k3 = +0.12541070f; k4 = +0.14503204f;
+    wl = -1.2681437731f; wm = +2.6097574011f; ws = -0.3413193965f;
+  }
+  else
+  {
+    // Blue component.
+    k0 = +1.35733652f; k1 = -0.00915799f; k2 = -1.15130210f; k3 = -0.50559606f; k4 = +0.00692167f;
+    wl = -0.0041960863f; wm = -0.7034186147f; ws = +1.7076147010f;
+  }
+
+  // Approximate max saturation using a polynomial:
+  float S = k0 + k1 * a + k2 * b + k3 * a * a + k4 * a * b;
+
+  // Do one step Halley's method to get closer
+  // this gives an error less than 10e6, except for some blue hues where the dS/dh is close to infinite
+  // this should be sufficient for most applications, otherwise do two/three steps.
+
+  float k_l = +0.3963377774f * a + 0.2158037573f * b;
+  float k_m = -0.1055613458f * a - 0.0638541728f * b;
+  float k_s = -0.0894841775f * a - 1.2914855480f * b;
+
+  {
+    float l_ = 1.f + S * k_l;
+    float m_ = 1.f + S * k_m;
+    float s_ = 1.f + S * k_s;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    float l_dS = 3.f * k_l * l_ * l_;
+    float m_dS = 3.f * k_m * m_ * m_;
+    float s_dS = 3.f * k_s * s_ * s_;
+
+    float l_dS2 = 6.f * k_l * k_l * l_;
+    float m_dS2 = 6.f * k_m * k_m * m_;
+    float s_dS2 = 6.f * k_s * k_s * s_;
+
+    float f  = wl * l     + wm * m     + ws * s;
+    float f1 = wl * l_dS  + wm * m_dS  + ws * s_dS;
+    float f2 = wl * l_dS2 + wm * m_dS2 + ws * s_dS2;
+
+    S = S - f * f1 / (f1*f1 - 0.5f * f * f2);
+  }
+
+  return S;
+}
+
+// Finds L_cusp and C_cusp for a given hue
+// a and b must be normalized so a^2 + b^2 == 1.
+struct OKLabCusp {
+  float L, C;
+};
+OKLabCusp find_cusp(float a, float b)
+{
+  // First, find the maximum saturation (saturation S = C/L).
+  float S_cusp = compute_max_saturation(a, b);
+
+  // Convert to linear sRGB to find the first point where at least one of r,g or b >= 1:
+  ColorOKLab c = {1, S_cusp * a, S_cusp * b};
+  ColorRGB rgb_at_max = oklab_to_linear_srgb(c);
+  float L_cusp = cbrtf(1.f / std::max(std::max(rgb_at_max.r, rgb_at_max.g),
+    rgb_at_max.b));
+  float C_cusp = L_cusp * S_cusp;
+
+  return {L_cusp , C_cusp};
+}
+
+// Finds intersection of the line defined by
+// L = L0 * (1 - t) + t * L1;
+// C = t * C1;
+// a and b must be normalized so a^2 + b^2 == 1.
+float find_gamut_intersection(float a, float b, float L1, float C1, float L0)
+{
+  // Find the cusp of the gamut triangle.
+  OKLabCusp cusp = find_cusp(a, b);
+
+  // Find the intersection for upper and lower half seprately.
+  float t;
+  if (((L1 - L0) * cusp.C - (cusp.L - L0) * C1) <= 0.f)
+  {
+    // Lower half.
+
+    t = cusp.C * L0 / (C1 * cusp.L + cusp.C * (L0 - L1));
+  }
+  else
+  {
+    // Upper half.
+
+    // First intersect with triangle.
+    t = cusp.C * (L0 - 1.f) / (C1 * (cusp.L - 1.f) + cusp.C * (L0 - L1));
+
+    // Then one step Halley's method.
+    {
+      float dL = L1 - L0;
+      float dC = C1;
+
+      float k_l = +0.3963377774f * a + 0.2158037573f * b;
+      float k_m = -0.1055613458f * a - 0.0638541728f * b;
+      float k_s = -0.0894841775f * a - 1.2914855480f * b;
+
+      float l_dt = dL + dC * k_l;
+      float m_dt = dL + dC * k_m;
+      float s_dt = dL + dC * k_s;
+
+
+      // If higher accuracy is required, 2 or 3 iterations of the following block can be used:
+      {
+        float L = L0 * (1.f - t) + t * L1;
+        float C = t * C1;
+
+        float l_ = L + C * k_l;
+        float m_ = L + C * k_m;
+        float s_ = L + C * k_s;
+
+        float l = l_ * l_ * l_;
+        float m = m_ * m_ * m_;
+        float s = s_ * s_ * s_;
+
+        float ldt = 3 * l_dt * l_ * l_;
+        float mdt = 3 * m_dt * m_ * m_;
+        float sdt = 3 * s_dt * s_ * s_;
+
+        float ldt2 = 6 * l_dt * l_dt * l_;
+        float mdt2 = 6 * m_dt * m_dt * m_;
+        float sdt2 = 6 * s_dt * s_dt * s_;
+
+        float r = 4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s - 1;
+        float r1 = 4.0767416621f * ldt - 3.3077115913f * mdt + 0.2309699292f * sdt;
+        float r2 = 4.0767416621f * ldt2 - 3.3077115913f * mdt2 + 0.2309699292f * sdt2;
+
+        float u_r = r1 / (r1 * r1 - 0.5f * r * r2);
+        float t_r = -r * u_r;
+
+        float g = -1.2681437731f * l + 2.6097574011f * m - 0.3413193965f * s - 1;
+        float g1 = -1.2681437731f * ldt + 2.6097574011f * mdt - 0.3413193965f * sdt;
+        float g2 = -1.2681437731f * ldt2 + 2.6097574011f * mdt2 - 0.3413193965f * sdt2;
+
+        float u_g = g1 / (g1 * g1 - 0.5f * g * g2);
+        float t_g = -g * u_g;
+
+        b = -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s - 1;
+        float b1 = -0.0041960863f * ldt - 0.7034186147f * mdt + 1.7076147010f * sdt;
+        float b2 = -0.0041960863f * ldt2 - 0.7034186147f * mdt2 + 1.7076147010f * sdt2;
+
+        float u_b = b1 / (b1 * b1 - 0.5f * b * b2);
+        float t_b = -b * u_b;
+
+        t_r = u_r >= 0.f ? t_r : FLT_MAX;
+        t_g = u_g >= 0.f ? t_g : FLT_MAX;
+        t_b = u_b >= 0.f ? t_b : FLT_MAX;
+
+        t += std::min(t_r, std::min(t_g, t_b));
+      }
+    }
+  }
+
+  return t;
 }
 
 } // namespace
@@ -95,6 +321,26 @@ ColorOKLCh::ColorOKLCh(const Color& c) :
     h = 0.0f;
 }
 
+Color
+ColorOKLCh::to_srgb() const
+{
+  ColorOKLCh c = *this;
+  ColorOKLab lab = lch_to_lab(c);
+  ColorRGB rgb = oklab_to_linear_srgb(lab);
+  if (!rgb.is_valid()) {
+    c.clip_chroma();
+    // Gamut clipping; reduce chroma when needed.
+    lab = lch_to_lab(c);
+    rgb = oklab_to_linear_srgb(lab);
+  }
+  if (!(rgb.r > -0.001f && rgb.r < 1.001f && rgb.g > -0.001f && rgb.g < 1.001f
+      && rgb.b > -0.001f && rgb.b < 1.001f)) {
+    log_warning << "Colour out of bounds (after clipping): (" << rgb.r <<
+      ", " << rgb.g << ", " << rgb.b << ")" << std::endl;
+  }
+  return linear_srgb_to_srgb(rgb);
+}
+
 float
 ColorOKLCh::get_modified_lightness() const
 {
@@ -105,4 +351,95 @@ ColorOKLCh::get_modified_lightness() const
   constexpr float k_3 = (1.f + k_1) / (1.f + k_2);
   return 0.5f * (k_3 * L - k_1 + sqrtf((k_3 * L - k_1) * (k_3 * L - k_1)
     + 4 * k_2 * k_3 * L));
+}
+
+float
+ColorOKLCh::get_maximum_chroma() const
+{
+  if (C <= 0.0f || L <= 0.0f || L >= 1.0f)
+    return 0.0f;
+  return find_gamut_intersection(cosf(h), sinf(h), L, 1.0f, L);
+}
+
+float
+ColorOKLCh::get_maximum_chroma_any_l() const
+{
+  OKLabCusp cusp = find_cusp(cosf(h), sinf(h));
+  return cusp.C;
+}
+
+void
+ColorOKLCh::clip_chroma()
+{
+  // Avoid numerical problems for certain hues of blue.
+  if (-1.67462f < h && h < -1.67460f)
+    h = -1.67462f;
+
+  L = math::clamp(L, 0.0f, 1.0f);
+  C = math::clamp(C, 0.0f, get_maximum_chroma());
+}
+
+void
+ColorOKLCh::clip_lightness()
+{
+  // Avoid numerical problems for certain hues of blue.
+  if (-1.67462f < h && h < -1.67460f)
+    h = -1.67462f;
+
+  L = math::clamp(L, 0.0f, 1.0f);
+  ColorOKLab lab = lch_to_lab(*this);
+  ColorRGB rgb = oklab_to_linear_srgb(lab);
+  if (rgb.is_valid())
+    return;
+
+  OKLabCusp cusp = find_cusp(lab.a / C, lab.b / C);
+  if (C >= cusp.C) {
+    // The cusp is the most colourful point for the given hue.
+    C = cusp.C;
+    L = cusp.L;
+    return;
+  }
+  // Select a point inside the triangle defined by (L,C) in {(0,0), (1,0), cusp}
+  // and then move it further if it's not in the sRGB gamut.
+  if (L > cusp.L) {
+    // Reduce L so that it's on the triangle.
+    L = std::min<float>(L, 1.0f + C * (cusp.L - 1.0f) / cusp.C);
+    // Reduce L so that it's in the sRGB gamut.
+    float L0 = -100.0f;
+    float t = find_gamut_intersection(lab.a / C, lab.b / C, L, C, L0);
+    L = (1.0f - t) * L0 + t * L;
+    C *= t;
+  } else {
+    // Here the triangle is accurate.
+    L = std::max<float>(L, C * cusp.L / cusp.C);
+  }
+}
+
+void
+ColorOKLCh::clip_adaptive_L0_L_cusp(float alpha)
+{
+  // Avoid numerical problems for certain hues of blue.
+  if (-1.67462f < h && h < -1.67460f)
+    h = -1.67462f;
+
+  ColorOKLab lab = lch_to_lab(*this);
+  ColorRGB rgb = oklab_to_linear_srgb(lab);
+  if (rgb.is_valid())
+    return;
+
+  float a_ = lab.a / C;
+  float b_ = lab.b / C;
+  OKLabCusp cusp = find_cusp(a_, b_);
+
+  float Ld = L - cusp.L;
+  float k = 2.f * (Ld > 0 ? 1.f - cusp.L : cusp.L);
+
+  float e1 = 0.5f * k + fabsf(Ld) + alpha * C / k;
+  float sgn = Ld < 0.0f ? -1.0f : 1.0f;
+  float L0 = cusp.L + 0.5f * (sgn * (e1 - sqrtf(
+    std::max<float>(e1 * e1 - 2.f * k * fabsf(Ld), 0.0f))));
+
+  float t = find_gamut_intersection(a_, b_, L, C, L0);
+  L = (1.0f - t) * L0 + t * L;
+  C *= t;
 }

--- a/src/util/colorspace_oklab.hpp
+++ b/src/util/colorspace_oklab.hpp
@@ -28,8 +28,31 @@ struct ColorOKLCh final {
   // Convert an non-linear sRGB colour to OKLab's LCh
   ColorOKLCh(const Color& c);
 
+  // Convert to non-linear sRGB; clip_chroma is applied if required.
+  Color to_srgb() const;
+
   // Calculate a different lightness estimate which has less dark values
   float get_modified_lightness() const;
+
+  // Find the maximum chroma which is still representable in sRGB while the
+  // lightness and hue are preserved
+  float get_maximum_chroma() const;
+
+  // Find the maximum chroma which is still representable in sRGB while the
+  // hue is preserved
+  float get_maximum_chroma_any_l() const;
+
+  // Reduce the chroma so that the colour can be represented in sRGB.
+  // Also clamp the lightness if needed.
+  void clip_chroma();
+
+  // Change the lightness so that the colour can be represented in sRGB.
+  void clip_lightness();
+
+  // Changes both the lightness and chroma so that the colour can be represented
+  // in sRGB. The resulting colour should have less visual distance to the true
+  // colour than colour produced by clipping only chroma or lightness.
+  void clip_adaptive_L0_L_cusp(float alpha=0.05f);
 
   float L, C, h;
 };

--- a/tests/unit/util/colorspace_oklab.cpp
+++ b/tests/unit/util/colorspace_oklab.cpp
@@ -40,4 +40,67 @@ TEST(ColorOKLCh, ctor_Color)
   EXPECT_NEAR(color.h, -1.9393998f, 0.001f);
 }
 
+TEST(ColorOKLCh, to_srgb)
+{
+  Color col(.1f, 1.f, 0.f);
+  ColorOKLCh color(col);
+
+  col = color.to_srgb();
+
+  EXPECT_NEAR(col.red, .1f, 0.001f);
+  EXPECT_NEAR(col.green, 1.f, 0.001f);
+  EXPECT_NEAR(col.blue, 0.f, 0.001f);
+}
+
+TEST(ColorOKLCh, get_maximum_chroma)
+{
+  ColorOKLCh color(.6f, 1.f, .3f);
+
+  float chroma = color.get_maximum_chroma();
+
+  EXPECT_NEAR(chroma, .24032472f, 0.001f);
+}
+
+TEST(ColorOKLCh, get_maximum_chroma_any_l)
+{
+  ColorOKLCh color(0.f, .1f, .05f);
+
+  float chroma = color.get_maximum_chroma_any_l();
+
+  EXPECT_NEAR(chroma, .26009744f, 0.001f);
+}
+
+TEST(ColorOKLCh, clip_chroma)
+{
+  ColorOKLCh color(.45f, .67f, .12f);
+
+  color.clip_chroma();
+
+  EXPECT_NEAR(color.L, .45f, 0.001f);
+  EXPECT_NEAR(color.C, .1804768f, 0.001f);
+  EXPECT_NEAR(color.h, .12f, 0.001f);
+}
+
+TEST(ColorOKLCh, clip_lightness)
+{
+  ColorOKLCh color(.45f, .67f, .12f);
+
+  color.clip_lightness();
+
+  EXPECT_NEAR(color.L, .64147455f, 0.001f);
+  EXPECT_NEAR(color.C, .2572695f, 0.001f);
+  EXPECT_NEAR(color.h, .12f, 0.001f);
+}
+
+TEST(ColorOKLCh, clip_adaptive_L0_L_cusp)
+{
+  ColorOKLCh color(1.f, 1.f, 1.f);
+
+  color.clip_adaptive_L0_L_cusp(0.25f);
+
+  EXPECT_NEAR(color.L, .83574224f, 0.001f);
+  EXPECT_NEAR(color.C, .10836758f, 0.001f);
+  EXPECT_NEAR(color.h, 1.f, 0.001f);
+}
+
 /* EOF */


### PR DESCRIPTION
There are complaints that with the 2D colour picker only fully-saturated colours can be selected and requests to add back a saturation slider.

This reverts commit d7e670366c2dbeec5800ec514adeb6f5a2423704, i.e. it adds back the 1D sliders next to the 2D picker.