### PR TITLE
Saving worldmap position on unstable tiles

### DIFF
--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -48,6 +48,10 @@ Tux::Tux(WorldMap* worldmap) :
   m_direction(Direction::NONE),
   m_initial_tile_pos(),
   m_tile_pos(),
+  m_last_stable_tile_pos(),
+  m_last_level_tile_pos(),
+  m_last_stable_back_direction(Direction::NONE),
+  m_last_level_back_direction(Direction::NONE),
   m_offset(0),
   m_moving(false),
   m_ghost_mode(false)
@@ -304,6 +308,24 @@ Tux::try_continue_walking(float dt_sec)
       m_worldmap->set_passive_message({}, 0.0f);
     }
 
+    if (const auto level = worldmap_sector->at_object<LevelTile>(); level)
+    {
+      m_last_level_tile_pos = m_tile_pos;
+      m_last_level_back_direction = m_back_direction;
+      m_last_stable_tile_pos = m_tile_pos;
+      m_last_stable_back_direction = m_back_direction;
+    }
+    else if (!m_ghost_mode)
+    {
+      m_last_stable_tile_pos = m_tile_pos;
+      m_last_stable_back_direction = m_back_direction;
+    }
+    else
+    {
+      m_last_stable_tile_pos = m_last_level_tile_pos;
+      m_last_stable_back_direction = m_last_level_back_direction;
+    }
+
     stop();
     return;
   }
@@ -391,6 +413,20 @@ Tux::setup()
   // Set initial tile position, if provided
   if (m_initial_tile_pos != Vector())
     m_tile_pos = m_initial_tile_pos;
+
+  m_last_stable_tile_pos = m_tile_pos;
+  m_last_stable_back_direction = m_back_direction;
+
+  if (m_worldmap->get_sector().at_object<LevelTile>(m_tile_pos))
+  {
+    m_last_level_tile_pos = m_tile_pos;
+    m_last_level_back_direction = m_back_direction;
+  }
+  else
+  {
+    m_last_level_tile_pos = m_last_stable_tile_pos;
+    m_last_level_back_direction = m_last_stable_back_direction;
+  }
 
   // check if we already touch a SpriteChange object
   auto sprite_change = m_worldmap->get_sector().at_object<SpriteChange>(m_tile_pos);

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -304,20 +304,19 @@ Tux::try_continue_walking(float dt_sec)
       (teleporter) ||
       m_ghost_mode)
   {
-      if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message())
-      {
-        m_worldmap->set_passive_message("", 0.0f);
-      }
+    if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message())
+    {
+      m_worldmap->set_passive_message("", 0.0f);
+    }
 
-      if (worldmap_sector->at_object<LevelTile>() != nullptr)
-      {
-        m_last_level_tile_pos = m_tile_pos;
-        m_last_level_back_direction = m_back_direction;
-      }
+    if (worldmap_sector->at_object<LevelTile>() != nullptr)
+    {
+      m_last_level_tile_pos = m_tile_pos;
+      m_last_level_back_direction = m_back_direction;
+    }
 
-      m_last_stable_tile_pos = m_ghost_mode ? m_last_level_tile_pos : m_tile_pos;
-      m_last_stable_back_direction = m_ghost_mode ? m_last_level_back_direction : m_back_direction;
-  }
+    m_last_stable_tile_pos = m_ghost_mode ? m_last_level_tile_pos : m_tile_pos;
+    m_last_stable_back_direction = m_ghost_mode ? m_last_level_back_direction : m_back_direction;
 
     stop();
     return;

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -308,7 +308,8 @@ Tux::try_continue_walking(float dt_sec)
         m_worldmap->set_passive_message({}, 0.0f);
       }
 
-      if (worldmap_sector->at_object<LevelTile>() != nullptr){
+      if (worldmap_sector->at_object<LevelTile>() != nullptr)
+      {
         m_last_level_tile_pos = m_tile_pos;
         m_last_level_back_direction = m_back_direction;
       }

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -304,27 +304,18 @@ Tux::try_continue_walking(float dt_sec)
       (teleporter) ||
       m_ghost_mode)
   {
-    if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message()) {
-      m_worldmap->set_passive_message({}, 0.0f);
-    }
+      if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message()) {
+        m_worldmap->set_passive_message({}, 0.0f);
+      }
 
-    if (const auto level = worldmap_sector->at_object<LevelTile>(); level)
-    {
-      m_last_level_tile_pos = m_tile_pos;
-      m_last_level_back_direction = m_back_direction;
-      m_last_stable_tile_pos = m_tile_pos;
-      m_last_stable_back_direction = m_back_direction;
-    }
-    else if (!m_ghost_mode)
-    {
-      m_last_stable_tile_pos = m_tile_pos;
-      m_last_stable_back_direction = m_back_direction;
-    }
-    else
-    {
-      m_last_stable_tile_pos = m_last_level_tile_pos;
-      m_last_stable_back_direction = m_last_level_back_direction;
-    }
+      if (worldmap_sector->at_object<LevelTile>() != nullptr){
+        m_last_level_tile_pos = m_tile_pos;
+        m_last_level_back_direction = m_back_direction;
+      }
+
+      m_last_stable_tile_pos = m_ghost_mode ? m_last_level_tile_pos : m_tile_pos;
+      m_last_stable_back_direction = m_ghost_mode ? m_last_level_back_direction : m_back_direction;
+  }
 
     stop();
     return;

--- a/src/worldmap/tux.cpp
+++ b/src/worldmap/tux.cpp
@@ -304,8 +304,9 @@ Tux::try_continue_walking(float dt_sec)
       (teleporter) ||
       m_ghost_mode)
   {
-      if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message()) {
-        m_worldmap->set_passive_message({}, 0.0f);
+      if (special_tile && !special_tile->get_map_message().empty() && !special_tile->is_passive_message())
+      {
+        m_worldmap->set_passive_message("", 0.0f);
       }
 
       if (worldmap_sector->at_object<LevelTile>() != nullptr)

--- a/src/worldmap/tux.hpp
+++ b/src/worldmap/tux.hpp
@@ -54,6 +54,18 @@ public:
   inline void set_initial_pos(const Vector& pos) { m_initial_tile_pos = pos / 32.f; }
   inline void set_tile_pos(const Vector& pos) { m_tile_pos = pos; }
 
+  inline Vector get_last_stable_tile_pos() const { return m_last_stable_tile_pos; }
+  inline void set_last_stable_tile_pos(const Vector& pos) { m_last_stable_tile_pos = pos; }
+
+  inline Vector get_last_level_tile_pos() const { return m_last_level_tile_pos; }
+  inline void set_last_level_tile_pos(const Vector& pos) { m_last_level_tile_pos = pos; }
+
+  inline Direction get_last_stable_back_direction() const { return m_last_stable_back_direction; }
+  inline void set_last_stable_back_direction(Direction dir) { m_last_stable_back_direction = dir; }
+
+  inline Direction get_last_level_back_direction() const { return m_last_level_back_direction; }
+  inline void set_last_level_back_direction(Direction dir) { m_last_level_back_direction = dir; }
+
   void process_special_tile(SpecialTile* special_tile);
 
 private:
@@ -78,6 +90,10 @@ private:
   Direction m_direction;
   Vector m_initial_tile_pos;
   Vector m_tile_pos;
+  Vector m_last_stable_tile_pos;
+  Vector m_last_level_tile_pos;
+  Direction m_last_stable_back_direction;
+  Direction m_last_level_back_direction;
   /** Length by which tux is away from its current tile, length is in
       input_direction direction */
   float m_offset;

--- a/src/worldmap/worldmap_state.cpp
+++ b/src/worldmap/worldmap_state.cpp
@@ -155,12 +155,14 @@ WorldMapState::load_tux(const ssq::Table& table)
     log_warning << "Player position not set, respawning." << std::endl;
     sector.move_to_spawnpoint(DEFAULT_SPAWNPOINT_NAME);
     m_position_was_reset = true;
+    return;
   }
 
   std::string back_str;
   tux.get("back", back_str);
   sector.m_tux->m_back_direction = string_to_direction(back_str);
   sector.m_tux->set_tile_pos(p);
+  Direction back_dir = string_to_direction(back_str);
 
   int tile_data = sector.tile_data_at(p);
   if (!(tile_data & (Tile::WORLDMAP_NORTH | Tile::WORLDMAP_SOUTH | Tile::WORLDMAP_WEST | Tile::WORLDMAP_EAST)))
@@ -168,6 +170,18 @@ WorldMapState::load_tux(const ssq::Table& table)
     log_warning << "Player at illegal position " << p.x << ", " << p.y << " respawning." << std::endl;
     sector.move_to_spawnpoint(DEFAULT_SPAWNPOINT_NAME);
     m_position_was_reset = true;
+    return;
+  }
+
+  sector.m_tux->m_back_direction = back_dir;
+  sector.m_tux->set_tile_pos(p);
+  sector.m_tux->set_last_stable_tile_pos(p);
+  sector.m_tux->set_last_stable_back_direction(back_dir);
+
+  if (sector.at_object<LevelTile>(p))
+  {
+    sector.m_tux->set_last_level_tile_pos(p);
+    sector.m_tux->set_last_level_back_direction(back_dir);
   }
 }
 
@@ -296,10 +310,16 @@ WorldMapState::save_state(bool initial) const
     sector_table.set("music", music_object.get_music());
 
     /** Save Tux **/
+    const Vector save_pos = sector.m_tux->get_last_stable_tile_pos();
+    const Direction save_back = sector.m_tux->get_last_stable_back_direction();
+
     ssq::Table tux = sector_table.addTable("tux");
     tux.set("x", sector.m_tux->get_tile_pos().x);
     tux.set("y", sector.m_tux->get_tile_pos().y);
     tux.set("back", direction_to_string(sector.m_tux->m_back_direction));
+    tux.set("x", save_pos.x);
+    tux.set("y", save_pos.y);
+    tux.set("back", direction_to_string(save_back));
 
     /** Save levels **/
     ssq::Table levels = sector_table.addTable("levels");

--- a/src/worldmap/worldmap_state.cpp
+++ b/src/worldmap/worldmap_state.cpp
@@ -152,7 +152,6 @@ WorldMapState::load_tux(const ssq::Table& table)
   Vector p(0.0f, 0.0f);
   if (!tux.get("x", p.x) || !tux.get("y", p.y))
   {
-    log_warning << "Player position not set, respawning." << std::endl;
     sector.move_to_spawnpoint(DEFAULT_SPAWNPOINT_NAME);
     m_position_was_reset = true;
     return;
@@ -314,9 +313,6 @@ WorldMapState::save_state(bool initial) const
     const Direction save_back = sector.m_tux->get_last_stable_back_direction();
 
     ssq::Table tux = sector_table.addTable("tux");
-    tux.set("x", sector.m_tux->get_tile_pos().x);
-    tux.set("y", sector.m_tux->get_tile_pos().y);
-    tux.set("back", direction_to_string(sector.m_tux->m_back_direction));
     tux.set("x", save_pos.x);
     tux.set("y", save_pos.y);
     tux.set("back", direction_to_string(save_back));


### PR DESCRIPTION
When leaving to the main menu, the game saves Tux's current worldmap position even if he is mid-path or on a non-stable tile. Upon reloading, Tux is restored to that invalid position. Save Tux on the last valid "stable" tile (such as a stop or level tile) instead of the current one. Also store the corresponding back direction to keep movement consistent after loading. In ghost mode, avoid persisting invalid tiles by falling back to the last valid level tile. This ensures Tux always respawns on a valid, navigable position.


Closes #3728