### PR TITLE
Update data/AUTHORS to attribute "voc" music tracks to semajD.

### DIFF
--- a/data/AUTHORS
+++ b/data/AUTHORS
@@ -59,7 +59,7 @@ All files in data/music created by wansti and licensed under GPLv2+CC-by-sa, unl
 * greatgigantic.ogg - by Wansti based on a work by Chris Huelsbeck - We have his permission to release this under GPL.
 * shallow-green.ogg - Jason Lavallée, dual-licensed: GPL version 2 or later and CC-BY-SA
 * halloween_1.ogg - By Forty-Two - licensed under CC-BY-SA 4.0
-* ice_music.ogg - By ZhayTee
+* ice_music.ogg - By Joseph "ZhayTee" Toscano
 * intro.ogg
 * invincible.ogg
 * arctic_breeze.ogg - Jason Lavallée, dual-licensed: GPL version 2 or later and CC-BY-SA

--- a/data/AUTHORS
+++ b/data/AUTHORS
@@ -74,8 +74,8 @@ All files in data/music created by wansti and licensed under GPLv2+CC-by-sa, unl
 * treeboss.ogg
 * tropicalbreeze.ogg - by flan, licensed CC-BY-SA 4.0
 * wisphunt.ogg
-* worldmap_old.ogg - By ZhayTee
-* voc-***.ogg
+* worldmap_old.ogg - By Joseph "ZhayTee" Toscano
+* voc-***.ogg - By semajD, licensed under CC-BY-SA 3.0
 * night.ogg - By SnugglyBun, licensed under CC-BY-SA 4.0
 * worldmap_ice.ogg - By SnugglyBun, licensed under CC-BY-SA 4.0
 * sunset.ogg - By SnugglyBun, licensed under CC-BY-SA 4.0


### PR DESCRIPTION
This PR updates data/AUTHORS to include the correct attribution for the "voc-\*.ogg" music tracks.
The "voc-\*.ogg" music tracks were composed and arranged by semajD, not by Wansti.

These music tracks originate from a 2011 SuperTux addon, "The Valley of Chaos" ("voc" for short) also created by semajD.
https://www.mediafire.com/file/jsfl84p4ngkkg47/The_Valley_Of_Chaos.zip/file