### PR TITLE
Fix stacktrace display for Windows builds

### DIFF
--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -110,9 +110,6 @@ dewrangle(const std::string& symbol)
 std::string
 ErrorHandler::get_stacktrace()
 {
-  // Windows stacktraces are disabled for now until there's a way to get it
-  // to recognize symbol names (and therefore make it... work). Otherwise,
-  // users will report obfuscated stacktraces, thinking they are useful to developers.
 #ifdef WIN32
   // Adapted from SuperTuxKart, (C) 2013-2015 Lionel Fuentes, GPLv3
 
@@ -138,7 +135,6 @@ ErrorHandler::get_stacktrace()
     // Get the file path of the executable
     std::string path(MAX_PATH, 0);
     GetModuleFileName(NULL, &path[0], MAX_PATH);
-    SymSetOptions(SYMOPT_LOAD_LINES);
 
     // Finally initialize the symbol handler.
     BOOL bOk = SymInitializeW(hProcess, NULL, TRUE);
@@ -147,6 +143,7 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
+    SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;
   }
 

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -113,8 +113,8 @@ ErrorHandler::get_stacktrace()
   // Windows stacktraces are disabled for now until there's a way to get it
   // to recognize symbol names (and therefore make it... work). Otherwise,
   // users will report obfuscated stacktraces, thinking they are useful to developers.
-//#ifdef WIN32
-#if 0
+#ifdef WIN32
+// #if 0
   // Adapted from SuperTuxKart, (C) 2013-2015 Lionel Fuentes, GPLv3
 
   if (pcontext == NULL)

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -177,7 +177,6 @@ ErrorHandler::get_stacktrace()
     stackframe.AddrFrame.Offset = pcontext->Fp;
     const DWORD machine_type    = IMAGE_FILE_MACHINE_ARM64;
 #elif defined(_WIN64)
-  #error "This is just a way to see if _WIN64 is defined"
     stackframe.AddrPC.Offset    = pcontext->Rip;
     stackframe.AddrStack.Offset = pcontext->Rsp;
     stackframe.AddrFrame.Offset = pcontext->Rbp;
@@ -211,7 +210,7 @@ ErrorHandler::get_stacktrace()
       {
         DWORD last_error_code = GetLastError();
         callstack << "<no symbol available> (" << last_error_code << ")\n";
-Sy      continue;
+        continue;
       }
 
       IMAGEHLP_LINE64 line64;

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -132,10 +132,6 @@ ErrorHandler::get_stacktrace()
   // Initialize the symbol hander for the process
   if (first_time)
   {
-    // Get the file path of the executable
-    std::string path(MAX_PATH, 0);
-    GetModuleFileName(NULL, &path[0], MAX_PATH);
-
     // Finally initialize the symbol handler.
     BOOL bOk = SymInitializeW(hProcess, NULL, TRUE);
     if (!bOk)

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -152,7 +152,7 @@ ErrorHandler::get_stacktrace()
     }
 
     auto pdb_filename = "supertux2.pdb";
-    SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0x10000000, 0, NULL, 0);
+    SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0, 0, NULL, 0);
 
     SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -151,6 +151,9 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
+    auto pdb_filename = "supertux2.pdb";
+    SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0x10000000, 0, NULL, 0);
+
     SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;
   }

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -151,7 +151,7 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
-    std::string pdb_filename = "supertux2.pdb";
+    std::wstring pdb_filename = "supertux2.pdb";
     SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0, 0, NULL, 0);
 
     SymSetOptions(SYMOPT_LOAD_LINES);

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -177,6 +177,7 @@ ErrorHandler::get_stacktrace()
     stackframe.AddrFrame.Offset = pcontext->Fp;
     const DWORD machine_type    = IMAGE_FILE_MACHINE_ARM64;
 #elif defined(_WIN64)
+  #error "This is just a way to see if _WIN64 is defined"
     stackframe.AddrPC.Offset    = pcontext->Rip;
     stackframe.AddrStack.Offset = pcontext->Rsp;
     stackframe.AddrFrame.Offset = pcontext->Rbp;
@@ -210,7 +211,7 @@ ErrorHandler::get_stacktrace()
       {
         DWORD last_error_code = GetLastError();
         callstack << "<no symbol available> (" << last_error_code << ")\n";
-        continue;
+Sy      continue;
       }
 
       IMAGEHLP_LINE64 line64;

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -151,8 +151,7 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
-    std::wstring pdb_filename = "supertux2.pdb";
-    SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0, 0, NULL, 0);
+    SymLoadModuleExW(hProcess, NULL, L"supertux2.pdb", NULL, 0, 0, NULL, 0);
 
     SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -139,21 +139,15 @@ ErrorHandler::get_stacktrace()
     // Get the file path of the executable
     std::string path(MAX_PATH, 0);
     GetModuleFileName(NULL, &path[0], MAX_PATH);
-
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &path[0], (int) path.size(), NULL, 0);
-    std::wstring wpath(size_needed, 0);
-    MultiByteToWideChar(CP_UTF8, 0, &path[0], (int) path.size(), &wpath[0], size_needed);
+    SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_DEBUG);
 
     // Finally initialize the symbol handler.
-    BOOL bOk = SymInitializeW(hProcess, wpath.empty() ? NULL : wpath.c_str(), TRUE);
+    BOOL bOk = SymInitializeW(hProcess, NULL, TRUE);
     if (!bOk)
     {
       return "";
     }
 
-    SymLoadModuleExW(hProcess, NULL, L"supertux2.pdb", NULL, 0x10000000, 0x1000, NULL, 0);
-
-    SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;
   }
 

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -151,7 +151,7 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
-    auto pdb_filename = "supertux2.pdb";
+    std::string pdb_filename = "supertux2.pdb";
     SymLoadModuleExW(hProcess, NULL, pdb_filename.c_str(), NULL, 0, 0, NULL, 0);
 
     SymSetOptions(SYMOPT_LOAD_LINES);

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -114,7 +114,6 @@ ErrorHandler::get_stacktrace()
   // to recognize symbol names (and therefore make it... work). Otherwise,
   // users will report obfuscated stacktraces, thinking they are useful to developers.
 #ifdef WIN32
-// #if 0
   // Adapted from SuperTuxKart, (C) 2013-2015 Lionel Fuentes, GPLv3
 
   if (pcontext == NULL)
@@ -139,7 +138,7 @@ ErrorHandler::get_stacktrace()
     // Get the file path of the executable
     std::string path(MAX_PATH, 0);
     GetModuleFileName(NULL, &path[0], MAX_PATH);
-    SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_DEBUG);
+    SymSetOptions(SYMOPT_LOAD_LINES);
 
     // Finally initialize the symbol handler.
     BOOL bOk = SymInitializeW(hProcess, NULL, TRUE);

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -44,7 +44,7 @@
 #include <DbgHelp.h>
 #endif
 //#include <VersionHelpers.h>
-
+#include <errhandlingapi.h>
 #ifdef _MSC_VER
 #pragma comment(lib, "DbgHelp.lib")
 #endif
@@ -208,7 +208,8 @@ ErrorHandler::get_stacktrace()
       if (!SymFromAddr(hProcess, stackframe.AddrPC.Offset,
                         &sym_displacement, symbol))
       {
-        callstack << "<no symbol available>\n";
+        DWORD last_error_code = GetLastError();
+        callstack << "<no symbol available> (" << last_error_code << ")\n";
         continue;
       }
 

--- a/src/supertux/error_handler.cpp
+++ b/src/supertux/error_handler.cpp
@@ -151,7 +151,7 @@ ErrorHandler::get_stacktrace()
       return "";
     }
 
-    SymLoadModuleExW(hProcess, NULL, L"supertux2.pdb", NULL, 0, 0, NULL, 0);
+    SymLoadModuleExW(hProcess, NULL, L"supertux2.pdb", NULL, 0x10000000, 0x1000, NULL, 0);
 
     SymSetOptions(SYMOPT_LOAD_LINES);
     first_time = false;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -180,7 +180,6 @@ PhysfsSubsystem::PhysfsSubsystem(const char* argv0,
   m_datadir(),
   m_userdir()
 {
-  int a = 1 / 0;
   if (!PHYSFS_init(argv0))
   {
     std::stringstream msg;
@@ -790,6 +789,8 @@ Main::run(int argc, char** argv)
       std::cout << "Error: " << err.what() << std::endl;
       return EXIT_FAILURE;
     }
+
+    throw std::runtime_error("This will crash as hard as your diabetic mom after eating an entire cheesecake!");
 
 #ifdef __ANDROID__
     m_physfs_subsystem.reset(new PhysfsSubsystem(nullptr, args.datadir, SDL_AndroidGetExternalStoragePath()));

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -790,8 +790,6 @@ Main::run(int argc, char** argv)
       return EXIT_FAILURE;
     }
 
-    throw std::runtime_error("This will crash as hard as your diabetic mom after eating an entire cheesecake!");
-
 #ifdef __ANDROID__
     m_physfs_subsystem.reset(new PhysfsSubsystem(nullptr, args.datadir, SDL_AndroidGetExternalStoragePath()));
 #else

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -180,6 +180,7 @@ PhysfsSubsystem::PhysfsSubsystem(const char* argv0,
   m_datadir(),
   m_userdir()
 {
+  int a = 1 / 0;
   if (!PHYSFS_init(argv0))
   {
     std::stringstream msg;


### PR DESCRIPTION
I believe that the issue was ultimately that the search path for the PDB file was wrong. Since we ship the PDB file side-by-side with the executable, I don't believe we need to get the executable name at all, since it'll search for it in its place anyway.