### PR TITLE
Add per-player joystick configuration system

### DIFF
--- a/src/control/input_manager.cpp
+++ b/src/control/input_manager.cpp
@@ -28,11 +28,12 @@
 static constexpr int MAX_PLAYERS = 4;
 
 InputManager::InputManager(KeyboardConfig& keyboard_config,
-                           JoystickConfig& joystick_config) :
+                           bool& use_game_controller,
+                           std::map<int, JoystickConfig>& joystick_configs) :
   m_controllers(),
-  m_use_game_controller(joystick_config.m_use_game_controller),
+  m_use_game_controller(use_game_controller),
   keyboard_manager(new KeyboardManager(this, keyboard_config)),
-  joystick_manager(new JoystickManager(this, joystick_config)),
+  joystick_manager(new JoystickManager(this, joystick_configs)),
   game_controller_manager(new GameControllerManager(this)),
   m_uses_keyboard()
 {
@@ -66,8 +67,6 @@ InputManager::use_game_controller(bool v)
 {
   m_use_game_controller = v;
 
-  // The 'rebinding' here is kind of a hack imo, but this is better than this
-  // option just not working at all...
   if (m_use_game_controller)
     game_controller_manager->rebind_controllers();
   else

--- a/src/control/input_manager.hpp
+++ b/src/control/input_manager.hpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #include "util/currenton.hpp"
+#include "control/joystick_config.hpp"
 
 class GameControllerManager;
 class JoystickManager;
@@ -43,7 +44,8 @@ private:
 
 public:
   InputManager(KeyboardConfig& keyboard_config,
-               JoystickConfig& joystick_config);
+               bool& use_game_controller,
+               std::map<int, JoystickConfig>& joystick_configs);
   ~InputManager() override;
 
   void process_event(const SDL_Event& event);

--- a/src/control/joystick_config.cpp
+++ b/src/control/joystick_config.cpp
@@ -26,25 +26,24 @@
 JoystickConfig::JoystickConfig() :
   m_dead_zone(8000),
   m_jump_with_up_joy(false),
-  m_use_game_controller(true),
   m_joy_button_map(),
   m_joy_axis_map(),
   m_joy_hat_map()
 {
   // Default joystick button configuration
-  bind_joybutton(0, 0, Control::JUMP);
-  bind_joybutton(0, 0, Control::MENU_SELECT);
-  bind_joybutton(0, 1, Control::ACTION);
-  bind_joybutton(0, 4, Control::PEEK_LEFT);
-  bind_joybutton(0, 5, Control::PEEK_RIGHT);
-  bind_joybutton(0, 6, Control::START);
-  bind_joybutton(0, 7, Control::ITEM);
+  bind_joybutton(0, Control::JUMP);
+  bind_joybutton(0, Control::MENU_SELECT);
+  bind_joybutton(1, Control::ACTION);
+  bind_joybutton(4, Control::PEEK_LEFT);
+  bind_joybutton(5, Control::PEEK_RIGHT);
+  bind_joybutton(6, Control::START);
+  bind_joybutton(7, Control::ITEM);
 
   // Default joystick axis configuration
-  bind_joyaxis(0, -1, Control::LEFT);
-  bind_joyaxis(0, 1, Control::RIGHT);
-  bind_joyaxis(0, -2, Control::UP);
-  bind_joyaxis(0, 2, Control::DOWN);
+  bind_joyaxis(-1, Control::LEFT);
+  bind_joyaxis(1, Control::RIGHT);
+  bind_joyaxis(-2, Control::UP);
+  bind_joyaxis(2, Control::DOWN);
 }
 
 int
@@ -52,7 +51,7 @@ JoystickConfig::reversemap_joyaxis(Control c) const
 {
   for (const auto& i : m_joy_axis_map) {
     if (i.second == c)
-      return i.first.second;
+      return i.first;
   }
 
   return 0;
@@ -63,7 +62,7 @@ JoystickConfig::reversemap_joybutton(Control c) const
 {
   for (const auto& i : m_joy_button_map) {
     if (i.second == c)
-      return i.first.second;
+      return i.first;
   }
 
   return -1;
@@ -74,7 +73,7 @@ JoystickConfig::reversemap_joyhat(Control c) const
 {
   for (const auto& i : m_joy_hat_map) {
     if (i.second == c)
-      return i.first.second;
+      return i.first;
   }
 
   return -1;
@@ -86,15 +85,15 @@ JoystickConfig::print_joystick_mappings() const
   std::cout << _("Joystick Mappings") << std::endl;
   std::cout << "-----------------" << std::endl;
   for (const auto& i : m_joy_axis_map) {
-    std::cout << "Axis: " << i.first.second << " -> " << i.second << std::endl;
+    std::cout << "Axis: " << i.first << " -> " << i.second << std::endl;
   }
 
   for (const auto& i : m_joy_button_map) {
-    std::cout << "Button: " << i.first.second << " -> " << i.second << std::endl;
+    std::cout << "Button: " << i.first << " -> " << i.second << std::endl;
   }
 
   for (const auto& i : m_joy_hat_map) {
-    std::cout << "Hat: " << i.first.second << " -> " << i.second << std::endl;
+    std::cout << "Hat: " << i.first << " -> " << i.second << std::endl;
   }
   std::cout << std::endl;
 }
@@ -126,7 +125,7 @@ JoystickConfig::unbind_joystick_control(Control control)
 }
 
 void
-JoystickConfig::bind_joyaxis(JoystickID joy_id, int axis, Control control)
+JoystickConfig::bind_joyaxis(int axis, Control control)
 {
   // axis isn't the SDL axis number, but axisnumber + 1 with sign
   // changed depending on if the positive or negative end is to be
@@ -136,25 +135,25 @@ JoystickConfig::bind_joyaxis(JoystickID joy_id, int axis, Control control)
   unbind_joystick_control(control);
 
   // add new mapping
-  m_joy_axis_map[std::make_pair(joy_id, axis)] = control;
+  m_joy_axis_map[axis] = control;
 }
 
 void
-JoystickConfig::bind_joyhat(JoystickID joy_id, int dir, Control c)
+JoystickConfig::bind_joyhat(int dir, Control c)
 {
   unbind_joystick_control(c);
 
   // add new mapping
-  m_joy_hat_map[std::make_pair(joy_id, dir)] = c;
+  m_joy_hat_map[dir] = c;
 }
 
 void
-JoystickConfig::bind_joybutton(JoystickID joy_id, int button, Control control)
+JoystickConfig::bind_joybutton(int button, Control control)
 {
   unbind_joystick_control(control);
 
   // add new mapping
-  m_joy_button_map[std::make_pair(joy_id, button)] = control;
+  m_joy_button_map[button] = control;
 }
 
 void
@@ -162,7 +161,6 @@ JoystickConfig::read(const ReaderMapping& joystick_mapping)
 {
   joystick_mapping.get("dead-zone", m_dead_zone);
   joystick_mapping.get("jump-with-up", m_jump_with_up_joy);
-  joystick_mapping.get("use-game-controller", m_use_game_controller);
 
   auto iter = joystick_mapping.get_iter();
   while (iter.next())
@@ -189,11 +187,11 @@ JoystickConfig::read(const ReaderMapping& joystick_mapping)
 
         if (map.get("button", button))
         {
-          bind_joybutton(0, button, control);
+          bind_joybutton(button, control);
         }
         else if (map.get("axis",   axis))
         {
-          bind_joyaxis(0, axis, control);
+          bind_joyaxis(axis, control);
         }
         else if (map.get("hat",   hat))
         {
@@ -205,7 +203,7 @@ JoystickConfig::read(const ReaderMapping& joystick_mapping)
           }
           else
           {
-            bind_joyhat(0, hat, control);
+            bind_joyhat(hat, control);
           }
         }
       }
@@ -218,25 +216,24 @@ JoystickConfig::write(Writer& writer)
 {
   writer.write("dead-zone", m_dead_zone);
   writer.write("jump-with-up", m_jump_with_up_joy);
-  writer.write("use-game-controller", m_use_game_controller);
 
   for (const auto& i : m_joy_button_map) {
     writer.start_list("map");
-    writer.write("button", i.first.second);
+    writer.write("button", i.first);
     writer.write("control", Control_to_string(i.second));
     writer.end_list("map");
   }
 
   for (const auto& i : m_joy_hat_map) {
     writer.start_list("map");
-    writer.write("hat", i.first.second);
+    writer.write("hat", i.first);
     writer.write("control", Control_to_string(i.second));
     writer.end_list("map");
   }
 
   for (const auto& i : m_joy_axis_map) {
     writer.start_list("map");
-    writer.write("axis", i.first.second);
+    writer.write("axis", i.first);
     writer.write("control", Control_to_string(i.second));
     writer.end_list("map");
   }

--- a/src/control/joystick_config.hpp
+++ b/src/control/joystick_config.hpp
@@ -31,9 +31,6 @@ class JoystickConfig final
   friend class JoystickMenu;
 
 public:
-  using JoystickID = SDL_JoystickID;
-
-public:
   JoystickConfig();
 
   void print_joystick_mappings() const;
@@ -44,9 +41,9 @@ public:
 
   void unbind_joystick_control(Control c);
 
-  void bind_joybutton(JoystickID joy_id, int button, Control c);
-  void bind_joyaxis(JoystickID joy_id, int axis, Control c);
-  void bind_joyhat(JoystickID joy_id, int dir, Control c);
+  void bind_joybutton(int button, Control c);
+  void bind_joyaxis(int axis, Control c);
+  void bind_joyhat(int dir, Control c);
 
   void read(const ReaderMapping& joystick_mapping);
   void write(Writer& writer);
@@ -54,13 +51,8 @@ public:
 private:
   int m_dead_zone;
   bool m_jump_with_up_joy;
-  bool m_use_game_controller;
 
-  std::map<std::pair<JoystickID, int>, Control> m_joy_button_map;
-  std::map<std::pair<JoystickID, int>, Control> m_joy_axis_map;
-  std::map<std::pair<JoystickID, int>, Control> m_joy_hat_map;
-
-private:
-  JoystickConfig(const JoystickConfig&) = delete;
-  JoystickConfig& operator=(const JoystickConfig&) = delete;
+  std::map<int, Control> m_joy_button_map;
+  std::map<int, Control> m_joy_axis_map;
+  std::map<int, Control> m_joy_hat_map;
 };

--- a/src/control/joystick_manager.cpp
+++ b/src/control/joystick_manager.cpp
@@ -29,15 +29,15 @@
 #include "util/log.hpp"
 
 JoystickManager::JoystickManager(InputManager* parent_,
-                                 JoystickConfig& joystick_config) :
+                                 std::map<int, JoystickConfig>& joystick_configs) :
   parent(parent_),
-  m_joystick_config(joystick_config),
+  m_joystick_configs(joystick_configs),
   min_joybuttons(),
   max_joybuttons(),
   max_joyaxis(),
   max_joyhats(),
   hat_state(0),
-  wait_for_joystick(-1),
+  wait_for_joystick(std::nullopt),
   joysticks()
 {
 }
@@ -142,50 +142,54 @@ JoystickManager::process_hat_event(const SDL_JoyHatEvent& jhat)
 {
   Uint8 changed = hat_state ^ jhat.value;
 
-  if (wait_for_joystick >= 0)
+  if (wait_for_joystick.has_value())
   {
+    auto& cfg = m_joystick_configs[wait_for_joystick->player_id];
+
     if (changed & SDL_HAT_UP && jhat.value & SDL_HAT_UP)
-      m_joystick_config.bind_joyhat(jhat.which, SDL_HAT_UP, Control(wait_for_joystick));
+      cfg.bind_joyhat(SDL_HAT_UP, wait_for_joystick->control);
 
     if (changed & SDL_HAT_DOWN && jhat.value & SDL_HAT_DOWN)
-      m_joystick_config.bind_joyhat(jhat.which, SDL_HAT_DOWN, Control(wait_for_joystick));
+      cfg.bind_joyhat(SDL_HAT_DOWN, wait_for_joystick->control);
 
     if (changed & SDL_HAT_LEFT && jhat.value & SDL_HAT_LEFT)
-      m_joystick_config.bind_joyhat(jhat.which, SDL_HAT_LEFT, Control(wait_for_joystick));
+      cfg.bind_joyhat(SDL_HAT_LEFT, wait_for_joystick->control);
 
     if (changed & SDL_HAT_RIGHT && jhat.value & SDL_HAT_RIGHT)
-      m_joystick_config.bind_joyhat(jhat.which, SDL_HAT_RIGHT, Control(wait_for_joystick));
+      cfg.bind_joyhat(SDL_HAT_RIGHT, wait_for_joystick->control);
 
     MenuManager::instance().refresh();
-    wait_for_joystick = -1;
+    wait_for_joystick = std::nullopt;
   }
   else
   {
+    auto& cfg = get_config_for_joystick(jhat.which);
+
     if (changed & SDL_HAT_UP)
     {
-      auto it = m_joystick_config.m_joy_hat_map.find(std::make_pair(jhat.which, SDL_HAT_UP));
-      if (it != m_joystick_config.m_joy_hat_map.end())
+      auto it = cfg.m_joy_hat_map.find(SDL_HAT_UP);
+      if (it != cfg.m_joy_hat_map.end())
         set_joy_controls(jhat.which, it->second, (jhat.value & SDL_HAT_UP) != 0);
     }
 
     if (changed & SDL_HAT_DOWN)
     {
-      auto it = m_joystick_config.m_joy_hat_map.find(std::make_pair(jhat.which, SDL_HAT_DOWN));
-      if (it != m_joystick_config.m_joy_hat_map.end())
+      auto it = cfg.m_joy_hat_map.find(SDL_HAT_DOWN);
+      if (it != cfg.m_joy_hat_map.end())
         set_joy_controls(jhat.which, it->second, (jhat.value & SDL_HAT_DOWN) != 0);
     }
 
     if (changed & SDL_HAT_LEFT)
     {
-      auto it = m_joystick_config.m_joy_hat_map.find(std::make_pair(jhat.which, SDL_HAT_LEFT));
-      if (it != m_joystick_config.m_joy_hat_map.end())
+      auto it = cfg.m_joy_hat_map.find(SDL_HAT_LEFT);
+      if (it != cfg.m_joy_hat_map.end())
         set_joy_controls(jhat.which, it->second, (jhat.value & SDL_HAT_LEFT) != 0);
     }
 
     if (changed & SDL_HAT_RIGHT)
     {
-      auto it = m_joystick_config.m_joy_hat_map.find(std::make_pair(jhat.which, SDL_HAT_RIGHT));
-      if (it != m_joystick_config.m_joy_hat_map.end())
+      auto it = cfg.m_joy_hat_map.find(SDL_HAT_RIGHT);
+      if (it != cfg.m_joy_hat_map.end())
         set_joy_controls(jhat.which, it->second, (jhat.value & SDL_HAT_RIGHT) != 0);
     }
   }
@@ -199,40 +203,43 @@ JoystickManager::process_axis_event(const SDL_JoyAxisEvent& jaxis)
   if (g_config->ignore_joystick_axis)
     return;
 
-  if (wait_for_joystick >= 0)
+  if (wait_for_joystick.has_value())
   {
-    if (abs(jaxis.value) > m_joystick_config.m_dead_zone) {
+    auto& cfg = m_joystick_configs[wait_for_joystick->player_id];
+    if (abs(jaxis.value) > cfg.m_dead_zone) {
       if (jaxis.value < 0)
-        m_joystick_config.bind_joyaxis(jaxis.which, -(jaxis.axis + 1), Control(wait_for_joystick));
+        cfg.bind_joyaxis(-(jaxis.axis + 1), wait_for_joystick->control);
       else
-        m_joystick_config.bind_joyaxis(jaxis.which, jaxis.axis + 1, Control(wait_for_joystick));
+        cfg.bind_joyaxis(jaxis.axis + 1, wait_for_joystick->control);
 
       MenuManager::instance().refresh();
-      wait_for_joystick = -1;
+      wait_for_joystick = std::nullopt;
     }
   }
   else
   {
+    auto& cfg = get_config_for_joystick(jaxis.which);
+
     // Split the axis into left and right, so that both can be
     // mapped separately (needed for jump/down vs up/down)
     int axis = jaxis.axis + 1;
 
-    auto left = m_joystick_config.m_joy_axis_map.find(std::make_pair(jaxis.which, -axis));
-    auto right = m_joystick_config.m_joy_axis_map.find(std::make_pair(jaxis.which, axis));
+    auto left = cfg.m_joy_axis_map.find(-axis);
+    auto right = cfg.m_joy_axis_map.find(axis);
 
-    if (left == m_joystick_config.m_joy_axis_map.end()) {
+    if (left == cfg.m_joy_axis_map.end()) {
       // std::cout << "Unmapped joyaxis " << (int)jaxis.axis << " moved" << std::endl;
     } else {
-      if (jaxis.value < -m_joystick_config.m_dead_zone)
+      if (jaxis.value < -cfg.m_dead_zone)
         set_joy_controls(jaxis.which, left->second,  true);
       else
         set_joy_controls(jaxis.which, left->second, false);
     }
 
-    if (right == m_joystick_config.m_joy_axis_map.end()) {
+    if (right == cfg.m_joy_axis_map.end()) {
       // std::cout << "Unmapped joyaxis " << (int)jaxis.axis << " moved" << std::endl;
     } else {
-      if (jaxis.value > m_joystick_config.m_dead_zone)
+      if (jaxis.value > cfg.m_dead_zone)
         set_joy_controls(jaxis.which, right->second, true);
       else
         set_joy_controls(jaxis.which, right->second, false);
@@ -243,20 +250,21 @@ JoystickManager::process_axis_event(const SDL_JoyAxisEvent& jaxis)
 void
 JoystickManager::process_button_event(const SDL_JoyButtonEvent& jbutton)
 {
-  if (wait_for_joystick >= 0)
+  if (wait_for_joystick.has_value())
   {
     if (jbutton.state == SDL_PRESSED)
     {
-      m_joystick_config.bind_joybutton(jbutton.which, jbutton.button, static_cast<Control>(wait_for_joystick));
+      m_joystick_configs[wait_for_joystick->player_id].bind_joybutton(jbutton.button, wait_for_joystick->control);
       MenuManager::instance().refresh();
       parent->reset();
-      wait_for_joystick = -1;
+      wait_for_joystick = std::nullopt;
     }
   }
   else
   {
-    auto i = m_joystick_config.m_joy_button_map.find(std::make_pair(jbutton.which, jbutton.button));
-    if (i == m_joystick_config.m_joy_button_map.end()) {
+    auto& cfg = get_config_for_joystick(jbutton.which);
+    auto i = cfg.m_joy_button_map.find(jbutton.button);
+    if (i == cfg.m_joy_button_map.end()) {
       log_debug << "Unmapped joybutton " << static_cast<int>(jbutton.button) << " pressed" << std::endl;
     } else {
       set_joy_controls(jbutton.which, i->second, (jbutton.state == SDL_PRESSED));
@@ -265,9 +273,22 @@ JoystickManager::process_button_event(const SDL_JoyButtonEvent& jbutton)
 }
 
 void
-JoystickManager::bind_next_event_to(Control id)
+JoystickManager::bind_next_event_to(int player_id, Control id)
 {
-  wait_for_joystick = static_cast<int>(id);
+  wait_for_joystick = PlayerControl{player_id, id};
+}
+
+JoystickConfig&
+JoystickManager::get_config_for_joystick(SDL_JoystickID instance_id)
+{
+  SDL_Joystick* joystick = SDL_JoystickFromInstanceID(instance_id);
+  auto it = joysticks.find(joystick);
+  int player_id = (it != joysticks.end() && it->second >= 0) ? it->second : 0;
+
+  if (m_joystick_configs.find(player_id) == m_joystick_configs.end())
+    m_joystick_configs[player_id] = JoystickConfig();
+
+  return m_joystick_configs[player_id];
 }
 
 void
@@ -277,7 +298,7 @@ JoystickManager::set_joy_controls(SDL_JoystickID joystick, Control id, bool valu
   if (it == joysticks.end() || it->second < 0)
     return;
 
-  if (m_joystick_config.m_jump_with_up_joy &&
+  if (get_config_for_joystick(joystick).m_jump_with_up_joy &&
       id == Control::UP)
   {
     parent->get_controller(it->second).set_control(Control::JUMP, value);

--- a/src/control/joystick_manager.hpp
+++ b/src/control/joystick_manager.hpp
@@ -18,13 +18,14 @@
 #pragma once
 
 #include <SDL.h>
-#include <vector>
+#include <map>
+#include <optional>
 #include <unordered_map>
 
 #include "control/controller.hpp"
+#include "control/joystick_config.hpp"
 
 class InputManager;
-class JoystickConfig;
 
 
 /**
@@ -37,14 +38,22 @@ class JoystickManager final
   friend class KeyboardManager;
 
 public:
-  JoystickManager(InputManager* parent, JoystickConfig& joystick_config);
+  struct PlayerControl
+  {
+    int player_id;
+    Control control;
+  };
+
+public:
+  JoystickManager(InputManager* parent,
+                  std::map<int, JoystickConfig>& joystick_configs);
   ~JoystickManager();
 
   void process_hat_event(const SDL_JoyHatEvent& jhat);
   void process_axis_event(const SDL_JoyAxisEvent& jaxis);
   void process_button_event(const SDL_JoyButtonEvent& jbutton);
 
-  void bind_next_event_to(Control id);
+  void bind_next_event_to(int player_id, Control id);
 
   void set_joy_controls(SDL_JoystickID joystick, Control id, bool value);
 
@@ -65,8 +74,11 @@ public:
   inline std::unordered_map<SDL_Joystick*, int>& get_joystick_mapping() { return joysticks; }
 
 private:
+  JoystickConfig& get_config_for_joystick(SDL_JoystickID instance_id);
+
   InputManager* parent;
-  JoystickConfig& m_joystick_config;
+
+  std::map<int, JoystickConfig>& m_joystick_configs;
 
   /// the number of buttons all joysticks have
   int min_joybuttons;
@@ -79,7 +91,7 @@ private:
 
   Uint8 hat_state;
 
-  int wait_for_joystick;
+  std::optional<PlayerControl> wait_for_joystick;
 
   std::unordered_map<SDL_Joystick*, int> joysticks;
 

--- a/src/control/keyboard_manager.cpp
+++ b/src/control/keyboard_manager.cpp
@@ -174,13 +174,13 @@ KeyboardManager::process_menu_key_event(const SDL_KeyboardEvent& event)
     return;
   }
 
-  if (m_parent->joystick_manager->wait_for_joystick >= 0)
+  if (m_parent->joystick_manager->wait_for_joystick.has_value())
   {
     if (event.keysym.sym == SDLK_ESCAPE)
     {
       m_parent->reset();
       MenuManager::instance().refresh();
-      m_parent->joystick_manager->wait_for_joystick = -1;
+      m_parent->joystick_manager->wait_for_joystick = std::nullopt;
     }
     return;
   }

--- a/src/supertux/gameconfig.cpp
+++ b/src/supertux/gameconfig.cpp
@@ -77,7 +77,8 @@ Config::Config() :
   tux_spawn_pos(),
   locale(),
   keyboard_config(),
-  joystick_config(),
+  joystick_configs(),
+  use_game_controller(true),
   ignore_joystick_axis(false),
   mobile_controls(false),
   m_mobile_controls_scale(1.3f),
@@ -151,6 +152,7 @@ Config::Config() :
   touch_just_directional(true),
   repository_url()
 {
+  joystick_configs[0] = JoystickConfig();
 }
 
 void
@@ -381,9 +383,31 @@ Config::load()
     std::optional<ReaderMapping> joystick_mapping;
     if (config_control_mapping->get("joystick", joystick_mapping))
     {
-      joystick_config.read(*joystick_mapping);
+      joystick_configs[0].read(*joystick_mapping);
     }
 
+    std::optional<ReaderCollection> joystick_configs_collection;
+    if (config_control_mapping->get("joystick-configs", joystick_configs_collection))
+    {
+      for (auto const& node : joystick_configs_collection->get_objects())
+      {
+        if (node.get_name() == "joystick-config")
+        {
+          auto mapping = node.get_mapping();
+          int player_id = 0;
+          if (mapping.get("player", player_id))
+          {
+            joystick_configs[player_id].read(mapping);
+          }
+        }
+        else
+        {
+          log_warning << "Unknown token in config file: " << node.get_name() << std::endl;
+        }
+      }
+    }
+
+    config_control_mapping->get("use_game_controller", use_game_controller);
     config_control_mapping->get("ignore_joystick_axis", ignore_joystick_axis);
 
     config_control_mapping->get("touch_haptic_feedback", touch_haptic_feedback);
@@ -561,9 +585,17 @@ Config::save()
     keyboard_config.write(writer);
     writer.end_list("keymap");
 
-    writer.start_list("joystick");
-    joystick_config.write(writer);
-    writer.end_list("joystick");
+    writer.start_list("joystick-configs");
+    for (auto& [player_id, cfg] : joystick_configs)
+    {
+      writer.start_list("joystick-config");
+      writer.write("player", player_id);
+      cfg.write(writer);
+      writer.end_list("joystick-config");
+    }
+    writer.end_list("joystick-configs");
+
+    writer.write("use_game_controller", use_game_controller);
 
     writer.write("ignore_joystick_axis", ignore_joystick_axis);
     writer.write("touch_haptic_feedback", touch_haptic_feedback);

--- a/src/supertux/gameconfig.hpp
+++ b/src/supertux/gameconfig.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include <map>
 #include <optional>
+#include <string>
 
 #include "control/joystick_config.hpp"
 #include "control/keyboard_config.hpp"
@@ -110,7 +112,10 @@ public:
   std::string locale;
 
   KeyboardConfig keyboard_config;
-  JoystickConfig joystick_config;
+  std::map<int, JoystickConfig> joystick_configs;
+
+  bool use_game_controller;
+
   bool ignore_joystick_axis;
   bool touch_haptic_feedback;
   bool touch_just_directional;

--- a/src/supertux/main.cpp
+++ b/src/supertux/main.cpp
@@ -586,8 +586,7 @@ Main::launch_game(const CommandLineArguments& args)
 #endif
 
   s_timelog.log("controller");
-  m_input_manager.reset(new InputManager(g_config->keyboard_config, g_config->joystick_config));
-
+  m_input_manager.reset(new InputManager(g_config->keyboard_config, g_config->use_game_controller, g_config->joystick_configs));
   s_timelog.log("commandline");
 
 #ifndef __EMSCRIPTEN__

--- a/src/supertux/menu/joystick_menu.cpp
+++ b/src/supertux/menu/joystick_menu.cpp
@@ -17,57 +17,42 @@
 
 #include "supertux/menu/joystick_menu.hpp"
 
+#include <fmt/format.h>
 #include <sstream>
 
+#include "control/input_manager.hpp"
 #include "control/joystick_manager.hpp"
 #include "gui/item_controlfield.hpp"
 #include "gui/item_toggle.hpp"
+#include "gui/menu_manager.hpp"
 #include "supertux/gameconfig.hpp"
 #include "supertux/globals.hpp"
 #include "util/gettext.hpp"
 
-namespace {
-
-enum {
-  MNID_JUMP_WITH_UP = static_cast<int>(Control::CONTROLCOUNT),
-  MNID_SCAN_JOYSTICKS,
-  MNID_AUTO_JOYSTICK_CFG
-};
-
-} // namespace
-
-JoystickMenu::JoystickMenu(InputManager& input_manager) :
+JoystickMenu::JoystickMenu(InputManager& input_manager, int player_id) :
   m_input_manager(input_manager),
-  m_joysticks_available(false),
+  m_player_id(player_id),
   m_auto_joystick_cfg(!m_input_manager.use_game_controller())
 {
-  recreate_menu();
-}
-
-JoystickMenu::~JoystickMenu()
-{}
-
-void
-JoystickMenu::recreate_menu()
-{
-  clear();
   add_label(_("Setup Joystick"));
   add_hl();
 
-  add_toggle(MNID_AUTO_JOYSTICK_CFG, _("Manual Configuration"),
+  if (m_player_id == 0)
+  {
+    add_toggle(MNID_AUTO_JOYSTICK_CFG, _("Manual Configuration"),
              &m_auto_joystick_cfg)
-    .set_help(_("Use manual configuration instead of SDL2's automatic GameController support"));
+      .set_help(_("Use manual configuration instead of SDL2's automatic GameController support"));
+      add_hl();
+  }
 
   if (m_input_manager.use_game_controller())
   {
-    m_joysticks_available = false;
+    add_inactive(_("Enable Manual Configuration to setup joysticks"));
   }
   else
   {
     if (m_input_manager.joystick_manager->get_num_joysticks() > 0)
     {
-      m_joysticks_available = true;
-
       add_controlfield(static_cast<int>(Control::UP),          _("Up"));
       add_controlfield(static_cast<int>(Control::DOWN),        _("Down"));
       add_controlfield(static_cast<int>(Control::LEFT),        _("Left"));
@@ -80,28 +65,51 @@ JoystickMenu::recreate_menu()
       add_controlfield(static_cast<int>(Control::PEEK_RIGHT),  _("Peek Right"));
       add_controlfield(static_cast<int>(Control::PEEK_UP),     _("Peek Up"));
       add_controlfield(static_cast<int>(Control::PEEK_DOWN),   _("Peek Down"));
-      if (g_config->developer_mode) {
-        add_controlfield(static_cast<int>(Control::CONSOLE), _("Console"));
+
+      if (m_player_id == 0 && g_config->developer_mode) {
+        add_controlfield(static_cast<int>(Control::CONSOLE),    _("Console"));
         add_controlfield(static_cast<int>(Control::CHEAT_MENU), _("Cheat Menu"));
         add_controlfield(static_cast<int>(Control::DEBUG_MENU), _("Debug Menu"));
       }
-      add_toggle(MNID_JUMP_WITH_UP, _("Jump with Up"), &g_config->joystick_config.m_jump_with_up_joy);
+
+      add_toggle(MNID_JUMP_WITH_UP, _("Jump with Up"), &g_config->joystick_configs[m_player_id].m_jump_with_up_joy);
     }
     else
     {
-      m_joysticks_available = false;
-
       add_inactive(_("No Joysticks found"));
-      add_entry(MNID_SCAN_JOYSTICKS, _("Scan for Joysticks"));
     }
   }
 
-  add_toggle(-1, _("Globally Ignore Joystick Axis"), &g_config->ignore_joystick_axis);
+  if (m_player_id == 0)
+  {
+    if (m_input_manager.get_num_users() > 1)
+    {
+     add_hl();
+    }
 
+    for (int id = 1; id < m_input_manager.get_num_users(); id++)
+    {
+      add_entry(fmt::format(fmt::runtime(_("Player {}")), std::to_string(id + 1)),
+      [&input_manager, id] {
+        MenuManager::instance().push_menu(
+          std::make_unique<JoystickMenu>(input_manager, id));
+      });
+    }
+
+    add_hl();
+    add_toggle(-1, _("Globally Ignore Joystick Axis"), &g_config->ignore_joystick_axis);
+    add_hl();
+
+    add_entry(MNID_SCAN_JOYSTICKS, _("Scan for Joysticks"));
+  }
+  
   add_hl();
   add_back(_("Back"));
   refresh();
 }
+
+JoystickMenu::~JoystickMenu()
+{}
 
 std::string
 JoystickMenu::get_button_name(int button) const
@@ -125,33 +133,32 @@ JoystickMenu::menu_action(MenuItem& item)
   {
     ItemControlField& field = static_cast<ItemControlField&>(item);
     field.change_input(_("Press Button"));
-    m_input_manager.joystick_manager->bind_next_event_to(static_cast<Control>(item.get_id()));
+    m_input_manager.joystick_manager->bind_next_event_to(m_player_id, static_cast<Control>(item.get_id()));
   }
   else if (item.get_id() == MNID_AUTO_JOYSTICK_CFG)
   {
-    //m_input_manager.use_game_controller(!item.toggled);
     m_input_manager.use_game_controller(!m_auto_joystick_cfg);
     m_input_manager.reset();
-    recreate_menu();
+    MenuManager::instance().set_menu(std::make_unique<JoystickMenu>(m_input_manager, m_player_id));
   }
   else if (item.get_id() == MNID_SCAN_JOYSTICKS)
   {
     m_input_manager.reset();
-    recreate_menu();
+    MenuManager::instance().set_menu(std::make_unique<JoystickMenu>(m_input_manager, m_player_id));
   }
 }
 
 void
-JoystickMenu::refresh_menu_item(Control id)
+JoystickMenu::refresh_control(const Control& control)
 {
-  ItemControlField* itemcf = dynamic_cast<ItemControlField*>(&get_item_by_id(static_cast<int>(id)));
+  ItemControlField* itemcf = dynamic_cast<ItemControlField*>(&get_item_by_id(static_cast<int>(control)));
   if (!itemcf) {
     return;
   }
 
-  int button  = g_config->joystick_config.reversemap_joybutton(id);
-  int axis    = g_config->joystick_config.reversemap_joyaxis(id);
-  int hat_dir = g_config->joystick_config.reversemap_joyhat(id);
+  int button  = g_config->joystick_configs[m_player_id].reversemap_joybutton(control);
+  int axis    = g_config->joystick_configs[m_player_id].reversemap_joyaxis(control);
+  int hat_dir = g_config->joystick_configs[m_player_id].reversemap_joyhat(control);
 
   if (button != -1)
   {
@@ -219,26 +226,29 @@ JoystickMenu::refresh_menu_item(Control id)
 void
 JoystickMenu::refresh()
 {
-  if (m_joysticks_available)
+  if (m_input_manager.use_game_controller() ||
+      m_input_manager.joystick_manager->get_num_joysticks() == 0)
   {
-    refresh_menu_item(Control::UP);
-    refresh_menu_item(Control::DOWN);
-    refresh_menu_item(Control::LEFT);
-    refresh_menu_item(Control::RIGHT);
+    return;
+  }
 
-    refresh_menu_item(Control::JUMP);
-    refresh_menu_item(Control::ACTION);
-    refresh_menu_item(Control::ITEM);
-    refresh_menu_item(Control::START);
-    refresh_menu_item(Control::PEEK_LEFT);
-    refresh_menu_item(Control::PEEK_RIGHT);
-    refresh_menu_item(Control::PEEK_UP);
-    refresh_menu_item(Control::PEEK_DOWN);
+  const auto& controls = { Control::UP, Control::DOWN, Control::LEFT, Control::RIGHT,
+                           Control::JUMP, Control::ACTION, Control::ITEM,
+                           Control::START, Control::PEEK_LEFT, Control::PEEK_RIGHT,
+                           Control::PEEK_UP, Control::PEEK_DOWN };
 
-    if (g_config->developer_mode) {
-      refresh_menu_item(Control::CONSOLE);
-      refresh_menu_item(Control::CHEAT_MENU);
-      refresh_menu_item(Control::DEBUG_MENU);
+  const auto& developer_controls = { Control::CHEAT_MENU, Control::DEBUG_MENU, Control::CONSOLE };
+
+  for (const auto& control : controls)
+  {
+    refresh_control(control);
+  }
+
+  if (g_config->developer_mode && m_player_id == 0)
+  {
+    for (const auto& control : developer_controls)
+    {
+      refresh_control(control);
     }
   }
 }

--- a/src/supertux/menu/joystick_menu.hpp
+++ b/src/supertux/menu/joystick_menu.hpp
@@ -23,21 +23,26 @@
 class JoystickMenu final : public Menu
 {
 public:
-  JoystickMenu(InputManager& input_manager);
+  JoystickMenu(InputManager& input_manager, int player_id = 0);
   ~JoystickMenu() override;
 
   void refresh() override;
-  void refresh_menu_item(Control id);
-
-  std::string get_button_name(int button) const;
   void menu_action(MenuItem& item) override;
 
 private:
-  void recreate_menu();
+  void refresh_control(const Control& control);
+  std::string get_button_name(int button) const;
+
+private:
+  enum MenuIDs {
+    MNID_JUMP_WITH_UP = static_cast<int>(Control::CONTROLCOUNT),
+    MNID_SCAN_JOYSTICKS,
+    MNID_AUTO_JOYSTICK_CFG
+  };
 
 private:
   InputManager& m_input_manager;
-  bool m_joysticks_available;
+  int m_player_id;
   bool m_auto_joystick_cfg;
 
 private:


### PR DESCRIPTION
Replace single global joystick config with per-player independent configurations.

Each player now has their own JoystickConfig instance stored in a map<int, JoystickConfig> keyed by player ID. Bindings are stored as (player, button) pairs, consistent with KeyboardConfig's PlayerControl approach. The JoystickMenu mirrors KeyboardMenu, showing Player 2, 3 entries for additional players. Configurations are serialised to the existing config.cfg under a new joystick-configs section, with migration support for the old single-config format. 

The JoystickMenu changes also update refresh_menu_item to refresh_control, mirroring the pattern used in KeyboardMenu, which we considered pertinent as part of modernising the menu.

Closes #3572