### PR TITLE
Link SimpleSquirrel lib statically for Emscripten builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ else()
 endif()
 
 ## Determine whether static linking for SimpleSquirrel should be defaulted to
-if(MSVC OR ANDROID)
+if(MSVC OR ANDROID OR EMSCRIPTEN)
   option(USE_STATIC_SIMPLESQUIRREL "Statically link the SimpleSquirrel library" ON)
 else()
   option(USE_STATIC_SIMPLESQUIRREL "Statically link the SimpleSquirrel library" OFF)


### PR DESCRIPTION
emscripten builds couldn't find a *.so file for simplesquirrel. So let's try linking it statically.