### PR TITLE
Allow rebinding keys still mapped to CONSOLE (Closes #3801)

### DIFF
--- a/src/control/keyboard_manager.cpp
+++ b/src/control/keyboard_manager.cpp
@@ -37,7 +37,11 @@ KeyboardManager::process_key_event(const SDL_KeyboardEvent& event)
   auto key_mapping = m_keyboard_config.m_keymap.find(event.keysym.scancode);
 
   // if console key was pressed: toggle console
-  if (key_mapping != m_keyboard_config.m_keymap.end() &&
+  // Skip this while waiting for a key binding, otherwise a key that is still
+  // mapped to CONSOLE (e.g. the backtick key by default) can never be rebound
+  // because it gets intercepted here before reaching process_menu_key_event.
+  if (!m_wait_for_key &&
+      key_mapping != m_keyboard_config.m_keymap.end() &&
       key_mapping->second.control == Control::CONSOLE)
   {
     if (event.type == SDL_KEYDOWN)


### PR DESCRIPTION
## Summary

Fixes #3801: the backtick key (`SDL_SCANCODE_GRAVE`) cannot be assigned to any action in the keyboard setup menu.

## Root cause

In `KeyboardManager::process_key_event`, a key mapped to `Control::CONSOLE` is intercepted and toggles the console (keyboard_manager.cpp:40) **before** the menu's key-binding branch runs. The backtick key is mapped to `CONSOLE` by default (keyboard_config.cpp:62), so while it is still on `CONSOLE` it never reaches `process_menu_key_event` — where the "wait for key" rebinding happens. Result: the key can never be rebound (a key that is still mapped to CONSOLE can never be rebound, because it gets intercepted first).

## Fix

Skip the console-intercept while `m_wait_for_key` is set, so the pressed key passes through to the binding logic. The binding clears `m_wait_for_key` afterwards (keyboard_manager.cpp:173), so console toggling behaves exactly as before outside of key-binding mode.

## Test plan

- Open Options → Controls → Setup keyboard, pick an action, press the backtick key → it should now be assigned (previously nothing happened).
- With a different key bound to CONSOLE, open the console normally (outside key-binding) → still works.

## Note

One-file change, no new files. The build/SDL repro needs a running session; I could not run it headless here, so verification of the in-game behaviour is requested from the maintainers/CI.