### PR TITLE
Fix two editor crashes (#3809, #3807)

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -619,6 +619,14 @@ Editor::test_level(const std::optional<std::pair<std::string, Vector>>& test_pos
     return;
   }
 
+  if (!m_level->get_sector("main"))
+  {
+    Dialog::show_message(_("This level has no \"main\" sector and cannot be tested.\n\n"
+                           "Rename one of the sectors to \"main\" in the Sector menu, then try again."));
+    m_leveltested = false;
+    return;
+  }
+
   Tile::draw_editor_images = false;
   Compositor::s_render_lighting = true;
 

--- a/src/editor/overlay_widget.cpp
+++ b/src/editor/overlay_widget.cpp
@@ -1069,7 +1069,8 @@ EditorOverlayWidget::on_mouse_button_up(const SDL_MouseButtonEvent& button)
         m_rectangle_preview->m_tiles.clear();
       }
 
-      m_editor.get_selected_tilemap()->check_state();
+      if (auto* tilemap = m_editor.get_selected_tilemap())
+        tilemap->check_state();
     }
     else
     {
@@ -1594,7 +1595,8 @@ EditorOverlayWidget::draw(DrawingContext& context)
   {
     // Deprecated tiles in active tilemaps should have indication, when hovered
     auto sel_tilemap = m_editor.get_selected_tilemap();
-    if (m_editor.get_tileset()->get(sel_tilemap->get_tile_id(m_hovered_tile)).is_deprecated())
+    if (sel_tilemap &&
+        m_editor.get_tileset()->get(sel_tilemap->get_tile_id(m_hovered_tile)).is_deprecated())
       context.color().draw_text(Resources::normal_font, "!",
                                 tp_to_sp(Vector(static_cast<int>(m_hovered_tile.x), static_cast<int>(m_hovered_tile.y))) + Vector(16, 8),
                                 ALIGN_CENTER, LAYER_GUI - 10, Color::RED);


### PR DESCRIPTION
Fixes two crashes in the level editor reported in #3809 and #3807.

## #3809 — null selected tilemap on early mouse release
The selected tilemap is null briefly between `EditorLayersWidget`'s creation and its first `update()` (which calls `refresh_layers()` to ensure one is selected). Releasing the left mouse button before the editor finished loading, or drawing the deprecated-tile indicator while no tilemap is selected, dereferenced null and crashed. Both accesses in `EditorOverlayWidget` now guard against a null tilemap.

## #3807 — testing a level without a "main" sector
`GameSession` resolves the spawn sector and expects a "main" sector to exist. Testing a level whose only sector was renamed (via the Sector menu) used to throw an uncaught exception and crash the editor. `Editor::test_level()` now shows a dialog and aborts instead.

Note: #3810 (division-by-zero in `replace()`) was already fixed upstream in 078b4239a, so it is not part of this PR.

Two focused commits, no new files, no behavioral change outside the guarded paths.