### PR TITLE
Guard null TitleScreen when toggling custom title screen levels (Closes #3802)

### DIFF
--- a/src/supertux/menu/options_menu.cpp
+++ b/src/supertux/menu/options_menu.cpp
@@ -861,7 +861,8 @@ OptionsMenu::menu_action(MenuItem& item)
       break;
 
     case MNID_CUSTOM_TITLE_LEVELS:
-      TitleScreen::current()->refresh_level();
+      if (TitleScreen::current())
+        TitleScreen::current()->refresh_level();
       break;
 
     case MNID_FANCY_GFX:


### PR DESCRIPTION
## Summary
OptionsMenu handled `MNID_CUSTOM_TITLE_LEVELS` by unconditionally calling `TitleScreen::current()->refresh_level()`.

`TitleScreen` is a `Currenton`, so while a level is being played (i.e. the title screen is *not* the active screen) `TitleScreen::current()` is `nullptr`. The unguarded call dereferenced null and, depending on state, mutated title-screen state that then leaked into the running level — matching the reported symptoms (enemies not spawning, end-goal softlock, effects not working).

Guard the call with a null-check, matching the existing pattern in `language_menu.cpp`.

## Reproduction (before fix)
1. Enter any level.
2. Open Options → Extras and toggle "Custom title screen levels".
3. The running level is treated as the menu level, causing the bugs described in #3802 (and a potential null deref).

## Verification
- Built clean on current `master` (Release, `-DWARNINGS=ON -DWERROR=ON`).
- `ctest` passes (MD5Test, AATriangleTest, CollisionTest — all green).
- Branch is up to date with `upstream/master` (merge-base == HEAD).

Closes #3802