### PR TITLE
Add default method for adding a gameobject to the current sector for …

### DIFF
--- a/src/object/decal.cpp
+++ b/src/object/decal.cpp
@@ -21,7 +21,6 @@
 
 #include "squirrel/squirrel_object_initializer.hpp"
 #include "supertux/flip_level_transformer.hpp"
-#include "supertux/sector.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "util/reader.hpp"
 #include "util/reader_mapping.hpp"

--- a/src/object/decal.cpp
+++ b/src/object/decal.cpp
@@ -19,10 +19,23 @@
 #include <simplesquirrel/class.hpp>
 #include <simplesquirrel/vm.hpp>
 
+#include "squirrel/squirrel_object_initializer.hpp"
 #include "supertux/flip_level_transformer.hpp"
+#include "supertux/sector.hpp"
 #include "sprite/sprite_manager.hpp"
 #include "util/reader.hpp"
 #include "util/reader_mapping.hpp"
+
+Decal::Decal() :
+  MovingSprite(Vector(0, 0), "images/decal/explanations/billboard-bigtux.png", COLGROUP_DISABLED),
+  m_default_action("default"),
+  m_solid(),
+  m_fade_sprite(m_sprite.get()->clone()),
+  m_fade_timer(),
+  m_sprite_timer(),
+  m_visible(true)
+{
+}
 
 Decal::Decal(const ReaderMapping& reader) :
   MovingSprite(reader, "images/decal/explanations/billboard-bigtux.png", LAYER_OBJECTS, COLGROUP_DISABLED),
@@ -148,7 +161,8 @@ Decal::update(float)
 void
 Decal::register_class(ssq::VM& vm)
 {
-  ssq::Class cls = vm.addAbstractClass<Decal>("Decal", vm.findClass("MovingSprite"));
+  ssq::Class cls = vm.addClass("Decal", get_default_object_initializer<Decal>, {},
+  false /* Do not free pointer from Squirrel */, vm.findClass("MovingSprite"));
 
   cls.addFunc("fade_sprite", &Decal::fade_sprite);
   cls.addFunc("change_sprite", &MovingSprite::change_sprite); // Deprecated; for compatibility

--- a/src/object/decal.hpp
+++ b/src/object/decal.hpp
@@ -37,7 +37,8 @@ public:
   static void register_class(ssq::VM& vm);
 
 public:
-  Decal(const ReaderMapping& reader);
+  Decal();
+  Decal(const ReaderMapping &reader);
   ~Decal() override;
 
   virtual HitResponse collision(MovingObject& , const CollisionHit& ) override { return FORCE_MOVE; }

--- a/src/object/text_array_object.cpp
+++ b/src/object/text_array_object.cpp
@@ -20,6 +20,7 @@
 #include <simplesquirrel/vm.hpp>
 
 #include "control/input_manager.hpp"
+#include "squirrel/squirrel_object_initializer.hpp"
 #include "supertux/sector.hpp"
 
 TextArrayObject::TextArrayObject(const std::string& name) :
@@ -415,15 +416,9 @@ TextArrayObject::get_roundness() const
 void
 TextArrayObject::register_class(ssq::VM& vm)
 {
-  ssq::Class cls = vm.addClass("TextArrayObject", []()
-    {
-      if (!Sector::current())
-        throw std::runtime_error("Tried to create 'TextArrayObject' without an active sector.");
-
-      return &Sector::get().add<TextArrayObject>();
-    },
-    {},
-    false /* Do not free pointer from Squirrel */,
+  ssq::Class cls = vm.addClass("TextArrayObject",
+    get_default_object_initializer<TextArrayObject>, {}, 
+    false /* Do not free pointer from Squirrel */, 
     vm.findClass("GameObject"));
 
   cls.addFunc("clear", &TextArrayObject::clear);

--- a/src/squirrel/squirrel_object_initializer.hpp
+++ b/src/squirrel/squirrel_object_initializer.hpp
@@ -1,0 +1,38 @@
+//  SuperTux
+//  Copyright (C) 2026 Tobias Markus <tobbi.bugs@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "supertux/sector.hpp"
+
+namespace {
+
+  /**
+   * A function that creates a GameObject of type T and adds it to the current sector
+   */
+  template<class T>
+  T* get_default_object_initializer()
+  {
+    if (!Sector::current())
+    {
+      auto type_name = std::string(typeid(T).name());
+      auto msg = std::string("Tried to create " + type_name + " object without an active sector.");
+      throw std::runtime_error(msg);
+    }
+
+    return &Sector::get().add<T>();
+  }
+}


### PR DESCRIPTION
This PR allows initializing Decals using the following code:
```squirrel
a <- Decal();
```

I feel like this should be WIP, since other classes would require the same approach, thus I've made `get_default_object_initializer` a template method.